### PR TITLE
ci: only run tests when source changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,13 @@
 name: tests
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    paths:
+      - "!**.md"
+  pull_request:
+    paths:
+      - "!**.md"
+  workflow_dispatch:
 
 jobs:
   all_tests:


### PR DESCRIPTION
To prevent the tests workflow from running unnecessarily (which is quite slow due to the slowness of the mac build), we'll only run it when either:

1. Source code changes: *.nim, *.nims, or *.nimble files
2. GitHub workflows change: .github/bin/* or .github/workflows/* files

I've verified this on my fork: https://github.com/ErikSchierboom/canonical-data-syncer/actions

Closes #141 