### PR TITLE
build(config): make `nimble build` fast again

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,10 +1,11 @@
-switch("opt", "size")
-switch("passC", "-flto")
+if defined(release):
+  switch("opt", "size")
+  switch("passC", "-flto")
 
-if defined(linux) or defined(windows):
-  switch("passL", "-s")
-  switch("passL", "-static")
+  if defined(linux) or defined(windows):
+    switch("passL", "-s")
+    switch("passL", "-static")
 
-if defined(linux):
-  switch("gcc.exe", "musl-gcc")
-  switch("gcc.linkerexe", "musl-gcc")
+  if defined(linux):
+    switch("gcc.exe", "musl-gcc")
+    switch("gcc.linkerexe", "musl-gcc")


### PR DESCRIPTION
During development, a typical flow is to make a code change and then run
`nimble build`, which produces a debug build. However, our `config.nims`
file was enabling some optimizations for this debug build - in
particular, `--passC:-flto` adds a long wait to the linking step and
only makes sense when making a release build.

This commit makes a plain `nimble build` after no code change run in
something 1 second again, rather than something like 10 seconds (that's
actually longer than the time taken by the release build!).

Nothing is changed for the release build, which we still perform with
`nimble build -d:release`.