### PR TITLE
build: add `--verbose` to `nimble build`

### DIFF
--- a/.github/bin/build
+++ b/.github/bin/build
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 nimble --accept install --depsOnly
-nimble build -d:release
+nimble --verbose build -d:release

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -12,7 +12,7 @@ proc main =
   let binaryPath = repoRootDir / binaryName
   const helpStart = &"Usage:\n  {binaryName} [global-options] <command> [command-options]"
 
-  const cmd = "nimble build -d:release"
+  const cmd = "nimble --verbose build -d:release"
   stdout.write(&"Running `{cmd}`... ")
   stdout.flushFile()
   let (buildOutput, buildExitCode) = execCmdEx(cmd, workingDir = repoRootDir)


### PR DESCRIPTION
It's useful for us to see the full `nimble build` output in the CI logs,
and if the build command fails in the binary tests.