### PR TITLE
build(config): add `--styleCheck:hint`

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,3 +1,6 @@
+switch("styleCheck", "hint")
+hint("Name", on)
+
 if defined(release):
   switch("opt", "size")
   switch("passC", "-flto")


### PR DESCRIPTION
This PR tries to address https://github.com/exercism/configlet/issues/16, but doesn't do so completely. The latest release of Nimble (0.12.0, in Oct 2020) adds `--hints:off` by default, and that's set after `--hint[Name]:on` can be passed.

From https://github.com/nim-lang/nimble/blob/master/changelog.markdown#0120:
> Calls to the Nim compiler now display --hints:off output by default. The --verbose flag will print the full Nim command as well as regular compiler output.

So when running `nimble build` we can only see the styleCheck output if `--verbose` was passed. However, this commit is also useful to turn on styleCheck by default for a user who runs `nim c foo.nim` in our project. 

`--styleCheck:error` would be possible too, but it's currently too
aggressive: it would currently produce an error if one of our Nimble
dependencies has a style problem.

To-do:
- [X] Merge #164 and #165, and rebase this PR on top.