### PR TITLE
build(config): add `--experimental:strictFuncs`

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,5 +1,6 @@
 switch("styleCheck", "hint")
 hint("Name", on)
+switch("experimental", "strictFuncs")
 
 if defined(release):
   switch("opt", "size")


### PR DESCRIPTION
This PR means that the Nim compiler will enforce that we don't have code like
```Nim
type
  Foo = ref object
    x: int

func mutate(foo: Foo) =
  foo.x = 2

let foo = Foo(x: 1)
mutate(foo)
echo foo.x
```

Without strictFuncs, the above code compiles without complaint (despite `mutate` being a `func`, and `foo` being declared with `let`), and outputs `2`. But compiling with `nim c --experimental:strictFuncs`, it produces an error:
```
/tmp/foo.nim(5, 6) Error: 'mutate' can have side effects
an object reachable from 'foo' is potentially mutated
/tmp/foo.nim(6, 6) the mutation is here
```

The code should instead be written as

```diff
 type
   Foo = ref object
     x: int

-func mutate(foo: Foo) =
+func mutate(foo: var Foo) =
   foo.x = 2

-let foo = Foo(x: 1)
+var foo = Foo(x: 1)
 mutate(foo)
 echo foo.x
```

See:
- https://nim-lang.github.io/Nim/manual_experimental.html#strict-funcs
- https://nim-lang.org/blog/2020/09/01/write-tracking.html

To-do:
- [X] Merge #164, #165 and #166 and rebase this PR on top.