### PR TITLE
lint: add linting of concepts `links.json`

### DIFF
--- a/src/lint/concepts.nim
+++ b/src/lint/concepts.nim
@@ -3,15 +3,11 @@ import ".."/helpers
 import "."/validators
 
 proc isUrlLike(s: string): bool =
-  ## Returns true if `s` starts with `http://`, `https://` or `www`.
+  ## Returns true if `s` starts with `https://`, `http://` or `www`.
   # For now, this is deliberately simplistic. We probably don't need
   # sophisticated URL checking, and we don't want to use Nim's stdlib regular
   # expressions because that would add a dependency on PCRE.
-  if s.startsWith("http"):
-    if s.continuesWith("://", 4) or s.continuesWith("s://", 4):
-      result = true
-  elif s.startsWith("www"):
-    result = true
+  s.startsWith("https://") or s.startsWith("http://") or s.startsWith("www")
 
 proc isValidLinkObject(data: JsonNode, context: string, path: string): bool =
   ## Returns true if `data` is a `JObject` that satisfies all of the below:

--- a/src/lint/concepts.nim
+++ b/src/lint/concepts.nim
@@ -4,15 +4,15 @@ import "."/validators
 
 proc isUrlLike(s: string): bool =
   ## Returns true if `s` starts with `https://`, `http://` or `www`.
-  # For now, this is deliberately simplistic. We probably don't need
-  # sophisticated URL checking, and we don't want to use Nim's stdlib regular
-  # expressions because that would add a dependency on PCRE.
+  # We probably only need simplistic URL checking, and we want to avoid using
+  # Nim's stdlib regular expressions in order to avoid a dependency on PCRE.
   s.startsWith("https://") or s.startsWith("http://") or s.startsWith("www")
 
 proc isValidLinkObject(data: JsonNode, context: string, path: string): bool =
   ## Returns true if `data` is a `JObject` that satisfies all of the below:
   ## - has a `url` key, with a value that is a URL-like string.
-  ## - has a `description` key, with a value that is a non-empty, non-blank string.
+  ## - has a `description` key, with a value that is a non-empty, non-blank
+  ##   string.
   ## - if it has a `icon_url` key, the corresponding value is a URL-like string.
   if isObject(data, context, path):
     result = true
@@ -54,7 +54,8 @@ proc isEveryConceptLinksFileValid*(trackDir: string): bool =
             try:
               parseFile(linksPath) # Shows the filename in the exception message.
             except CatchableError:
-              result.setFalseAndPrint("JSON parsing error", getCurrentExceptionMsg())
+              result.setFalseAndPrint("JSON parsing error",
+                                      getCurrentExceptionMsg())
               continue
           if not isValidLinksFile(j, linksPath):
             result = false

--- a/src/lint/concepts.nim
+++ b/src/lint/concepts.nim
@@ -1,5 +1,80 @@
-import std/os
+import std/[json, os, strutils]
+import ".."/helpers
 import "."/validators
+
+proc isUrlLike(s: string): bool =
+  ## Returns true if `s` starts with `http://`, `https://` or `www`.
+  # For now, this is deliberately simplistic. We probably don't need
+  # sophisticated URL checking, and we don't want to use Nim's stdlib regular
+  # expressions because that would add a dependency on PCRE.
+  if s.startsWith("http"):
+    if s.continuesWith("://", 4) or s.continuesWith("s://", 4):
+      result = true
+  elif s.startsWith("www"):
+    result = true
+
+proc isValidLinkObject(data: JsonNode, context: string, path: string): bool =
+  ## Returns true if `data` is a `JObject` that satisfies all of the below:
+  ## - has a `url` key, with a value that is a URL-like string.
+  ## - has a `description` key, with a value that is a non-empty, non-blank string.
+  ## - if it has a `icon_url` key, the corresponding value is a URL-like string.
+  if isObject(data, context, path):
+    result = true
+
+    if checkString(data, "url", path):
+      let s = data["url"].getStr()
+      if not isUrlLike(s):
+        result.setFalseAndPrint("Not a valid URL: " & s, path)
+    else:
+      result = false
+
+    if not checkString(data, "description", path):
+      result = false
+
+    if data.hasKey("icon_url"):
+      if checkString(data, "icon_url", path, isRequired = false):
+        let s = data["icon_url"].getStr()
+        if not isUrlLike(s):
+          result.setFalseAndPrint("Not a valid URL: " & s, path)
+      else:
+        result = false
+  else:
+    result.setFalseAndPrint("At least one element of the top-level array is " &
+                            "not an object: " & $data[context], path)
+
+proc isValidLinksFile(data: JsonNode, path: string): bool =
+  result = isArrayOf(data, "", path, isValidLinkObject, isRequired = false)
+
+proc isNonBlank(path: string): bool =
+  ## Returns true if `path` points to a file that has at least one
+  ## non-whitespace character.
+  let contents = readFile(path)
+  for c in contents:
+    if c notin Whitespace:
+      return true
+
+proc isEveryConceptLinksFileValid*(trackDir: string): bool =
+  let conceptsDir = trackDir / "concepts"
+  result = true
+
+  if dirExists(conceptsDir):
+    for subdir in getSortedSubdirs(conceptsDir):
+      let linksPath = subdir / "links.json"
+      if fileExists(linksPath):
+        if isNonBlank(linksPath):
+          let j =
+            try:
+              parseFile(linksPath) # Shows the filename in the exception message.
+            except CatchableError:
+              result.setFalseAndPrint("JSON parsing error", getCurrentExceptionMsg())
+              continue
+          if not isValidLinksFile(j, linksPath):
+            result = false
+        else:
+          result.setFalseAndPrint("File is empty, but must contain at least " &
+                                  "the empty array, `[]`", linksPath)
+      else:
+        result.setFalseAndPrint("Missing file", linksPath)
 
 proc conceptFilesExist*(trackDir: string): bool =
   ## Returns true if every subdirectory in `trackDir/concepts` has the required

--- a/src/lint/concepts.nim
+++ b/src/lint/concepts.nim
@@ -41,14 +41,6 @@ proc isValidLinkObject(data: JsonNode, context: string, path: string): bool =
 proc isValidLinksFile(data: JsonNode, path: string): bool =
   result = isArrayOf(data, "", path, isValidLinkObject, isRequired = false)
 
-proc isNonBlank(path: string): bool =
-  ## Returns true if `path` points to a file that has at least one
-  ## non-whitespace character.
-  let contents = readFile(path)
-  for c in contents:
-    if c notin Whitespace:
-      return true
-
 proc isEveryConceptLinksFileValid*(trackDir: string): bool =
   let conceptsDir = trackDir / "concepts"
   result = true
@@ -57,7 +49,7 @@ proc isEveryConceptLinksFileValid*(trackDir: string): bool =
     for subdir in getSortedSubdirs(conceptsDir):
       let linksPath = subdir / "links.json"
       if fileExists(linksPath):
-        if isNonBlank(linksPath):
+        if not isEmptyOrWhitespace(readFile(linksPath)):
           let j =
             try:
               parseFile(linksPath) # Shows the filename in the exception message.

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -11,15 +11,17 @@ proc lint*(conf: Conf) =
   let b2 = conceptExerciseFilesExist(trackDir)
   let b3 = practiceExerciseFilesExist(trackDir)
   let b4 = conceptFilesExist(trackDir)
-  let b5 = isEveryConceptExerciseConfigValid(trackDir)
-  let b6 = isEveryPracticeExerciseConfigValid(trackDir)
+  let b5 = isEveryConceptLinksFileValid(trackDir)
+  let b6 = isEveryConceptExerciseConfigValid(trackDir)
+  let b7 = isEveryPracticeExerciseConfigValid(trackDir)
 
-  if b1 and b2 and b3 and b4 and b5 and b6:
+  if b1 and b2 and b3 and b4 and b5 and b6 and b7:
     echo """
 Basic linting finished successfully:
 - config.json exists and is valid JSON
 - config.json has these valid fields: language, slug, active, blurb, version, tags
 - Every concept has the required .md files and links.json file
+- Every concept links.json file is valid
 - Every concept exercise has the required .md files and a .meta/config.json file
 - Every concept exercise .meta/config.json file is valid
 - Every practice exercise has the required .md files and a .meta/config.json file


### PR DESCRIPTION
This PR implements [the `concept/<slug>/links.json` part of the spec](https://github.com/exercism/docs/blob/6ff54c5db80c21cb021d28d65b2528a72d9374de/building/configlet/lint.md#rule-conceptsluglinksjson-is-valid):

>- The file must be valid JSON
>- The JSON root must be an array
>- The `"[].url"` property is required
>- The `"[].url"` value must be an URL
>- The `"[].description"` property is required
>- The `"[].description"` value must be a non-empty, non-blank string
>- The `"[].icon_url"` property is optional
>- The `"[].icon_url"` value must be an URL

To-do:
- [x] Merge #169 and rebase this PR on top
- [X] Call `isEveryConceptLinksFileValid` from `lint.nim`
- [X] Improve the URL checking URL validity slightly. We make it stricter later.
- [X] Rebase on top of the new non-template code
- [x] Merge #218 and rebase this PR on top.
- [X] Improve error messages.
- [X] Check the diff that this PR causes to the `configlet lint` output on every track