### PR TITLE
tests(probspecs): fix for `accumulate` as new first exercise

### DIFF
--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -38,11 +38,34 @@ proc main =
         let exercise = probSpecsExercises[0]
 
         check:
-          exercise.slug == "acronym" # The first exercise with canonical data.
+          exercise.slug == "accumulate" # The first exercise with canonical data.
+          exercise.testCases.len >= 5 # Tests are never removed.
+
+      test "the first test case of first exercise is as expected":
+        let firstTestCase = probSpecsExercises[0].testCases[0].json
+        let firstTestCaseExpected = """{
+      "uuid": "64d97c14-36dd-44a8-9621-2cecebd6ed23",
+      "description": "accumulate empty",
+      "property": "accumulate",
+      "input": {
+        "list": [],
+        "accumulator": "(x) => x * x"
+      },
+      "expected": []
+    }""".parseJson()
+
+        check:
+          firstTestCase == firstTestCaseExpected
+
+      test "the second exercise is as expected":
+        let exercise = probSpecsExercises[1]
+
+        check:
+          exercise.slug == "acronym" # The second exercise with canonical data.
           exercise.testCases.len >= 9 # Tests are never removed.
 
-      test "the first test case is as expected":
-        let firstTestCase = probSpecsExercises[0].testCases[0].json
+      test "the first test case of second exercise is as expected":
+        let firstTestCase = probSpecsExercises[1].testCases[0].json
         let firstTestCaseExpected = """{
           "uuid": "1e22cceb-c5e4-4562-9afe-aef07ad1eaf4",
           "description": "basic",


### PR DESCRIPTION
- The first exercise of problem specs is now `accumulate`
- New problem spec has been added in https://github.com/exercism/problem-specifications/pull/1738 
- `nimble test` succeeds
- `nim c --styleCheck:error -r ./tests/all_tests.nim` succeeds

The error prior this fix was:
```
[Suite] findProbSpecsExercises: fresh clone
  [OK] can return the exercises
    configlet\tests\test_probspecs.nim(41, 24): Check failed: exercise.slug == "acronym"
    exercise.slug was accumulate
  [FAILED] the first exercise is as expected
```