### PR TITLE
build: bump Nim from 1.4.2 to 1.4.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@d0c07f7ad4ed045c29cfcffbc1402643f8147184 # 1.3.2
         with:
-          nim-version: "1.4.2"
+          nim-version: "1.4.4"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@d0c07f7ad4ed045c29cfcffbc1402643f8147184 # 1.3.2
         with:
-          nim-version: "1.4.2"
+          nim-version: "1.4.4"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -7,7 +7,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 1.4.2"
+requires "nim >= 1.4.4"
 requires "parsetoml"
 requires "cligen"
 requires "uuids >= 0.1.11"


### PR DESCRIPTION
See the [release blog post](https://nim-lang.org/blog/2021/02/23/versions-144-and-1210-released.html).

---

To-do:
- [x] ~I'll fix the SSL issue with the Windows CI - the Windows build will currently fail. See this commit: https://github.com/nim-lang/Nim/commit/74d6a4d7f4fb9fb00632150f666e4de1cc5f7c63~