### PR TITLE
git: ignore temporary repos used in binary tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@
 configlet
 configlet.exe
 
-# Temporary prob-specs repo
+# Temporary repos
 .problem-specifications/
+.test_binary_problem_specifications/
+.test_binary_nim_track_repo/


### PR DESCRIPTION
The binary tests temporarily clone the prob-specs repo and the Nim track repo. While these directories should be removed after running the tests, adding them to the .gitignore list will prevent them from being committed accidentally.
