### PR TITLE
refactor: replace validator templates with procs

### DIFF
--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -17,7 +17,7 @@ proc getSortedSubdirs*(dir: string): seq[string] =
       result.add path
   sort result
 
-proc setFalseAndPrint*(b: var bool, description: string, details: string) =
+proc setFalseAndPrint*(b: var bool; description: string; details: string) =
   ## Sets `b` to `false` and writes a message to stdout containing `description`
   ## and `details`.
   b = false

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -1,4 +1,4 @@
-import std/[algorithm, os]
+import std/[algorithm, os, terminal]
 
 template withDir*(dir: string; body: untyped): untyped =
   ## Changes the current directory to `dir` temporarily.
@@ -17,8 +17,7 @@ proc getSortedSubdirs*(dir: string): seq[string] =
       result.add path
   sort result
 
-template writeError*(description: string, details: string) =
+proc writeError*(description: string, details: string) =
   stdout.styledWriteLine(fgRed, description & ":")
   stdout.writeLine(details)
   stdout.write "\n"
-  result = false

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -17,7 +17,10 @@ proc getSortedSubdirs*(dir: string): seq[string] =
       result.add path
   sort result
 
-proc writeError*(description: string, details: string) =
+proc setFalseAndPrint*(b: var bool, description: string, details: string) =
+  ## Sets `b` to `false` and writes a message to stdout containing `description`
+  ## and `details`.
+  b = false
   stdout.styledWriteLine(fgRed, description & ":")
   stdout.writeLine(details)
   stdout.write "\n"

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -48,6 +48,7 @@ proc isEveryConceptExerciseConfigValid*(trackDir: string): bool =
             parseFile(configPath)
           except:
             writeError("JSON parsing error", getCurrentExceptionMsg())
+            result = false
             continue
         if not isValidConceptExerciseConfig(j, configPath):
           result = false

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -47,8 +47,7 @@ proc isEveryConceptExerciseConfigValid*(trackDir: string): bool =
           try:
             parseFile(configPath)
           except:
-            writeError("JSON parsing error", getCurrentExceptionMsg())
-            result = false
+            result.setFalseAndPrint("JSON parsing error", getCurrentExceptionMsg())
             continue
         if not isValidConceptExerciseConfig(j, configPath):
           result = false

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -1,29 +1,40 @@
-import std/[json, os, terminal]
+import std/[json, os]
 import ".."/helpers
 import "."/validators
 
 proc isValidAuthorOrContributor(data: JsonNode, context: string, path: string): bool =
   if isObject(data, context, path):
     result = true
-    checkString("github_username")
-    checkString("exercism_username", isRequired = false)
+    if not checkString(data, "github_username", path):
+      result = false
+    if not checkString(data, "exercism_username", path, isRequired = false):
+      result = false
 
-template checkFiles(data: JsonNode, context, path: string) =
+proc checkFiles(data: JsonNode, context, path: string): bool =
+  result = true
   if hasObject(data, context, path):
-    checkArrayOfStrings(context, "solution")
-    checkArrayOfStrings(context, "test")
-    checkArrayOfStrings(context, "exemplar")
+    if not checkArrayOfStrings(data, context, "solution", path):
+      result = false
+    if not checkArrayOfStrings(data, context, "test", path):
+      result = false
+    if not checkArrayOfStrings(data, context, "exemplar", path):
+      result = false
   else:
     result = false
 
 proc isValidConceptExerciseConfig(data: JsonNode, path: string): bool =
   if isObject(data, "root", path):
     result = true
-    checkArrayOf("authors", isValidAuthorOrContributor)
-    checkArrayOf("contributors", isValidAuthorOrContributor, isRequired = false)
-    checkFiles(data, "files", path)
-    checkArrayOfStrings("", "forked_from", isRequired = false)
-    checkString("language_versions", isRequired = false)
+    if not checkArrayOf(data, "authors", path, isValidAuthorOrContributor):
+      result = false
+    if not checkArrayOf(data, "contributors", path, isValidAuthorOrContributor, isRequired = false):
+      result = false
+    if not checkFiles(data, "files", path):
+      result = false
+    if not checkArrayOfStrings(data, "", "forked_from", path, isRequired = false):
+      result = false
+    if not checkString(data, "language_versions", path, isRequired = false):
+      result = false
 
 proc isEveryConceptExerciseConfigValid*(trackDir: string): bool =
   let conceptExercisesDir = trackDir / "exercises" / "concept"

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -27,7 +27,8 @@ proc isValidConceptExerciseConfig(data: JsonNode, path: string): bool =
     result = true
     if not checkArrayOf(data, "authors", path, isValidAuthorOrContributor):
       result = false
-    if not checkArrayOf(data, "contributors", path, isValidAuthorOrContributor, isRequired = false):
+    if not checkArrayOf(data, "contributors", path, isValidAuthorOrContributor,
+                        isRequired = false):
       result = false
     if not checkFiles(data, "files", path):
       result = false

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -1,4 +1,4 @@
-import std/[os, terminal]
+import std/os
 import ".."/[cli, helpers]
 import "."/[concept_exercises, track_config]
 

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -15,6 +15,7 @@ proc subdirsContain(dir: string, files: openArray[string]): bool =
         let path = subdir / file
         if not fileExists(path):
           writeError("Missing file", path)
+          result = false
 
 proc conceptExerciseFilesExist(trackDir: string): bool =
   ## Returns true if every subdirectory in `trackDir/exercises/concept` has the

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -14,8 +14,7 @@ proc subdirsContain(dir: string, files: openArray[string]): bool =
       for file in files:
         let path = subdir / file
         if not fileExists(path):
-          writeError("Missing file", path)
-          result = false
+          result.setFalseAndPrint("Missing file", path)
 
 proc conceptExerciseFilesExist(trackDir: string): bool =
   ## Returns true if every subdirectory in `trackDir/exercises/concept` has the

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -48,11 +48,9 @@ proc isValidTag(data: JsonNode, context: string, path: string): bool =
   if data.kind == JString:
     let s = data.getStr()
     if not tags.contains(s):
-      writeError("Not a valid tag: " & $data, path)
-      result = false
+      result.setFalseAndPrint("Not a valid tag: " & $data, path)
   else:
-    writeError("Tag is not a string: " & $data, path)
-    result = false
+    result.setFalseAndPrint("Tag is not a string: " & $data, path)
 
 proc isValidTrackConfig(data: JsonNode, path: string): bool =
   if isObject(data, "root", path):
@@ -78,10 +76,9 @@ proc isTrackConfigValid*(trackDir: string): bool =
       try:
         parseFile(configJsonPath)
       except:
-        writeError("JSON parsing error", getCurrentExceptionMsg())
+        result.setFalseAndPrint("JSON parsing error", getCurrentExceptionMsg())
         return false
     if not isValidTrackConfig(j, configJsonPath):
       result = false
   else:
-    writeError("Missing file", configJsonPath)
-    result = false
+    result.setFalseAndPrint("Missing file", configJsonPath)

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -8,19 +8,16 @@ proc q(s: string): string =
 proc isObject*(data: JsonNode; context, path: string): bool =
   result = true
   if data.kind != JObject:
-    writeError("Not an object: " & q(context), path)
-    result = false
+    result.setFalseAndPrint("Not an object: " & q(context), path)
 
 proc hasObject*(data: JsonNode; key, path: string,
                isRequired = true): bool =
   result = true
   if data.hasKey(key):
     if data[key].kind != JObject:
-      writeError("Not an object: " & q(key), path)
-      result = false
+      result.setFalseAndPrint("Not an object: " & q(key), path)
   elif isRequired:
-    writeError("Missing key: " & q(key), path)
-    result = false
+    result.setFalseAndPrint("Missing key: " & q(key), path)
 
 proc checkString*(data: JsonNode; key, path: string, isRequired = true): bool =
   result = true
@@ -28,17 +25,13 @@ proc checkString*(data: JsonNode; key, path: string, isRequired = true): bool =
     if data[key].kind == JString:
       let s = data[key].getStr()
       if s.len == 0:
-        writeError("String is zero-length: " & q(key), path)
-        result = false
+        result.setFalseAndPrint("String is zero-length: " & q(key), path)
       elif s.strip().len == 0:
-        writeError("String is whitespace-only: " & q(key), path)
-        result = false
+        result.setFalseAndPrint("String is whitespace-only: " & q(key), path)
     else:
-      writeError("Not a string: " & q(key) & ": " & $data[key], path)
-      result = false
+      result.setFalseAndPrint("Not a string: " & q(key) & ": " & $data[key], path)
   elif isRequired:
-    writeError("Missing key: " & q(key), path)
-    result = false
+    result.setFalseAndPrint("Missing key: " & q(key), path)
 
 proc format(context, key: string): string =
   if context.len > 0:
@@ -53,27 +46,24 @@ proc checkArrayOfStrings*(data: JsonNode, context, key, path: string; isRequired
     if d[key].kind == JArray:
       if d[key].len == 0:
         if isRequired:
-          writeError("Array is empty: " & format(context, key), path)
-          result = false
+          result.setFalseAndPrint("Array is empty: " & format(context, key), path)
       else:
         for item in d[key]:
           if item.kind == JString:
             let s = item.getStr()
             if s.len == 0:
-              writeError("Array contains zero-length string: " & format(context, key), path)
-              result = false
+              result.setFalseAndPrint("Array contains zero-length string: " &
+                                      format(context, key), path)
             elif s.strip().len == 0:
-              writeError("Array contains whitespace-only string: " & q(key), path)
-              result = false
+              result.setFalseAndPrint("Array contains whitespace-only string: " &
+                                      q(key), path)
           else:
-            writeError("Array contains non-string: " & format(context, key) & ": " & $item, path)
-            result = false
+            result.setFalseAndPrint("Array contains non-string: " &
+                                    format(context, key) & ": " & $item, path)
     else:
-      writeError("Not an array: " & format(context, key), path)
-      result = false
+      result.setFalseAndPrint("Not an array: " & format(context, key), path)
   elif isRequired:
-    writeError("Missing key: " & format(context, key), path)
-    result = false
+    result.setFalseAndPrint("Missing key: " & format(context, key), path)
 
 proc checkArrayOf*(data: JsonNode, key, path: string,
                    call: proc(d: JsonNode; key, path: string): bool,
@@ -83,35 +73,28 @@ proc checkArrayOf*(data: JsonNode, key, path: string,
     if data[key].kind == JArray:
       if data[key].len == 0:
         if isRequired:
-          writeError("Array is empty: " & q(key), path)
-          result = false
+          result.setFalseAndPrint("Array is empty: " & q(key), path)
       else:
         for item in data[key]:
           if not call(item, key, path):
             result = false
     else:
-      writeError("Not an array: " & q(key), path)
-      result = false
+      result.setFalseAndPrint("Not an array: " & q(key), path)
   elif isRequired:
-    writeError("Missing key: " & q(key), path)
-    result = false
+    result.setFalseAndPrint("Missing key: " & q(key), path)
 
 proc checkBoolean*(data: JsonNode; key, path: string, isRequired = true): bool =
   result = true
   if data.hasKey(key):
     if data[key].kind != JBool:
-      writeError("Not a bool: " & q(key) & ": " & $data[key], path)
-      result = false
+      result.setFalseAndPrint("Not a bool: " & q(key) & ": " & $data[key], path)
   elif isRequired:
-    writeError("Missing key: " & q(key), path)
-    result = false
+    result.setFalseAndPrint("Missing key: " & q(key), path)
 
 proc checkInteger*(data: JsonNode; key, path: string, isRequired = true): bool =
   result = true
   if data.hasKey(key):
     if data[key].kind != JInt:
-      writeError("Not an integer: " & q(key) & ": " & $data[key], path)
-      result = false
+      result.setFalseAndPrint("Not an integer: " & q(key) & ": " & $data[key], path)
   elif isRequired:
-    writeError("Missing key: " & q(key), path)
-    result = false
+    result.setFalseAndPrint("Missing key: " & q(key), path)

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -10,8 +10,7 @@ proc isObject*(data: JsonNode; context, path: string): bool =
   if data.kind != JObject:
     result.setFalseAndPrint("Not an object: " & q(context), path)
 
-proc hasObject*(data: JsonNode; key, path: string,
-               isRequired = true): bool =
+proc hasObject*(data: JsonNode; key, path: string; isRequired = true): bool =
   result = true
   if data.hasKey(key):
     if data[key].kind != JObject:
@@ -19,7 +18,7 @@ proc hasObject*(data: JsonNode; key, path: string,
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & q(key), path)
 
-proc checkString*(data: JsonNode; key, path: string, isRequired = true): bool =
+proc checkString*(data: JsonNode; key, path: string; isRequired = true): bool =
   result = true
   if data.hasKey(key):
     if data[key].kind == JString:
@@ -39,7 +38,8 @@ proc format(context, key: string): string =
   else:
     q(key)
 
-proc checkArrayOfStrings*(data: JsonNode, context, key, path: string; isRequired = true): bool =
+proc checkArrayOfStrings*(data: JsonNode; context, key, path: string;
+                          isRequired = true): bool =
   result = true
   var d = if context.len == 0: data else: data[context]
   if d.hasKey(key):
@@ -65,8 +65,8 @@ proc checkArrayOfStrings*(data: JsonNode, context, key, path: string; isRequired
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & format(context, key), path)
 
-proc checkArrayOf*(data: JsonNode, key, path: string,
-                   call: proc(d: JsonNode; key, path: string): bool,
+proc checkArrayOf*(data: JsonNode; key, path: string;
+                   call: proc(d: JsonNode; key, path: string): bool;
                    isRequired = true): bool =
   result = true
   if data.hasKey(key):
@@ -83,7 +83,7 @@ proc checkArrayOf*(data: JsonNode, key, path: string,
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & q(key), path)
 
-proc checkBoolean*(data: JsonNode; key, path: string, isRequired = true): bool =
+proc checkBoolean*(data: JsonNode; key, path: string; isRequired = true): bool =
   result = true
   if data.hasKey(key):
     if data[key].kind != JBool:
@@ -91,7 +91,7 @@ proc checkBoolean*(data: JsonNode; key, path: string, isRequired = true): bool =
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & q(key), path)
 
-proc checkInteger*(data: JsonNode; key, path: string, isRequired = true): bool =
+proc checkInteger*(data: JsonNode; key, path: string; isRequired = true): bool =
   result = true
   if data.hasKey(key):
     if data[key].kind != JInt:

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -1,4 +1,4 @@
-import std/[json, strutils, terminal]
+import std/[json, strutils]
 import ".."/helpers
 export strutils.strip
 
@@ -9,6 +9,7 @@ proc isObject*(data: JsonNode; context, path: string): bool =
   result = true
   if data.kind != JObject:
     writeError("Not an object: " & q(context), path)
+    result = false
 
 proc hasObject*(data: JsonNode; key, path: string,
                isRequired = true): bool =
@@ -16,21 +17,28 @@ proc hasObject*(data: JsonNode; key, path: string,
   if data.hasKey(key):
     if data[key].kind != JObject:
       writeError("Not an object: " & q(key), path)
+      result = false
   elif isRequired:
     writeError("Missing key: " & q(key), path)
+    result = false
 
-template checkString*(key: string, isRequired = true) =
+proc checkString*(data: JsonNode; key, path: string, isRequired = true): bool =
+  result = true
   if data.hasKey(key):
     if data[key].kind == JString:
       let s = data[key].getStr()
       if s.len == 0:
         writeError("String is zero-length: " & q(key), path)
+        result = false
       elif s.strip().len == 0:
         writeError("String is whitespace-only: " & q(key), path)
+        result = false
     else:
       writeError("Not a string: " & q(key) & ": " & $data[key], path)
+      result = false
   elif isRequired:
     writeError("Missing key: " & q(key), path)
+    result = false
 
 proc format(context, key: string): string =
   if context.len > 0:
@@ -38,55 +46,72 @@ proc format(context, key: string): string =
   else:
     q(key)
 
-template checkArrayOfStrings*(context, key: string; isRequired = true) =
+proc checkArrayOfStrings*(data: JsonNode, context, key, path: string; isRequired = true): bool =
+  result = true
   var d = if context.len == 0: data else: data[context]
   if d.hasKey(key):
     if d[key].kind == JArray:
       if d[key].len == 0:
         if isRequired:
           writeError("Array is empty: " & format(context, key), path)
+          result = false
       else:
         for item in d[key]:
           if item.kind == JString:
             let s = item.getStr()
             if s.len == 0:
               writeError("Array contains zero-length string: " & format(context, key), path)
+              result = false
             elif s.strip().len == 0:
               writeError("Array contains whitespace-only string: " & q(key), path)
+              result = false
           else:
             writeError("Array contains non-string: " & format(context, key) & ": " & $item, path)
+            result = false
     else:
       writeError("Not an array: " & format(context, key), path)
+      result = false
   elif isRequired:
     writeError("Missing key: " & format(context, key), path)
+    result = false
 
-template checkArrayOf*(key: string,
-                       call: proc(d: JsonNode; key, path: string): bool,
-                       isRequired = true) =
+proc checkArrayOf*(data: JsonNode, key, path: string,
+                   call: proc(d: JsonNode; key, path: string): bool,
+                   isRequired = true): bool =
+  result = true
   if data.hasKey(key):
     if data[key].kind == JArray:
       if data[key].len == 0:
         if isRequired:
           writeError("Array is empty: " & q(key), path)
+          result = false
       else:
         for item in data[key]:
           if not call(item, key, path):
             result = false
     else:
       writeError("Not an array: " & q(key), path)
+      result = false
   elif isRequired:
     writeError("Missing key: " & q(key), path)
+    result = false
 
-template checkBoolean*(key: string, isRequired = true) =
+proc checkBoolean*(data: JsonNode; key, path: string, isRequired = true): bool =
+  result = true
   if data.hasKey(key):
     if data[key].kind != JBool:
       writeError("Not a bool: " & q(key) & ": " & $data[key], path)
+      result = false
   elif isRequired:
     writeError("Missing key: " & q(key), path)
+    result = false
 
-template checkInteger*(key: string, isRequired = true) =
+proc checkInteger*(data: JsonNode; key, path: string, isRequired = true): bool =
+  result = true
   if data.hasKey(key):
     if data[key].kind != JInt:
       writeError("Not an integer: " & q(key) & ": " & $data[key], path)
+      result = false
   elif isRequired:
     writeError("Missing key: " & q(key), path)
+    result = false


### PR DESCRIPTION
While the template-based validator functions lead to some really nice looking code, working with them proved to be slightly harder. To keep the barrier to new contributors as low as possible, the templates have been converted to regular procs, which are easier to understand by people new to Nim.