### PR TITLE
console: write more things to stderr

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -173,9 +173,12 @@ proc showHelp(exitCode: range[0..255] = 0) =
   const helpText = genHelpText()
   let appName = extractFilename(getAppFilename())
   let usage = "Usage:\n" &
-              &"  {appName} [global-options] <command> [command-options]\n\n"
-  stdout.write usage
-  echo helpText
+              &"  {appName} [global-options] <command> [command-options]\n"
+  let f = if exitCode == 0: stdout else: stderr
+  f.writeLine usage
+  f.writeLine helpText
+  if f == stdout:
+    f.flushFile()
   quit(exitCode)
 
 proc showVersion =

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -271,13 +271,12 @@ proc main =
   const helpStart = &"Usage:\n  {binaryName} [global-options] <command> [command-options]"
 
   const cmd = "nimble --verbose build -d:release"
-  stdout.write(&"Running `{cmd}`... ")
-  stdout.flushFile()
+  stderr.write(&"Running `{cmd}`... ")
   let (buildOutput, buildExitCode) = execCmdEx(cmd, workingDir = repoRootDir)
   if buildExitCode == 0:
-    echo "success"
+    stderr.writeLine "success"
   else:
-    echo "failure"
+    stderr.writeLine "failure"
     raise newException(OSError, buildOutput)
 
   suite "help as an argument":


### PR DESCRIPTION
Rationale:
- When the user writes `--help`, the help message should go to stdout.
- When the user writes some incorrect options/arguments, the help
  message should go to stderr.