### PR TITLE
lint(validators): remove now-unused export

### DIFF
--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -1,6 +1,5 @@
 import std/[json, strutils]
 import ".."/helpers
-export strutils.strip
 
 proc q(s: string): string =
   "'" & s & "'"


### PR DESCRIPTION
We should have removed this line in 1bb5c115ca93 (#204).

This was our only `export` in the whole codebase. With this PR, running
```
$ git grep 'export'
```
produces no output.