### PR TITLE
tests: make `nimble test` faster

### DIFF
--- a/configlet.nimble
+++ b/configlet.nimble
@@ -11,3 +11,6 @@ requires "nim >= 1.4.2"
 requires "parsetoml"
 requires "cligen"
 requires "uuids >= 0.1.11"
+
+task test, "Runs the test suite":
+  exec "nim r ./tests/all_tests.nim"


### PR DESCRIPTION
By default, `nimble test` does this:
- find a Nim file beginning with `t` in the `tests` directory
- compile it
- run it
- repeat until all such files have been run.

But it's better to run the tests via `all_tests.nim`, which compiles
every test in one pass as an optimization. Individually compiling and
running each test file is slower because each dependency (most notably,
`system.nim`) must be compiled multiple times.

This optimization should become less important in the future - the
so-called "incremental compilation" is currently being worked on.

This commit overrides `nimble test` so that it runs the test suite the
faster way. We already ran `all_tests.nim` during CI.

Note that this commit doesn't make CI run `nimble test` for now - in CI
we currently pass `--styleCheck:error` instead of `--styleCheck:hint`.