### PR TITLE
refactor: prefer `func`

### DIFF
--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -1,7 +1,7 @@
 import std/[json, strutils]
 import ".."/helpers
 
-proc q(s: string): string =
+func q(s: string): string =
   "'" & s & "'"
 
 proc isObject*(data: JsonNode; context, path: string): bool =
@@ -31,7 +31,7 @@ proc checkString*(data: JsonNode; key, path: string; isRequired = true): bool =
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & q(key), path)
 
-proc format(context, key: string): string =
+func format(context, key: string): string =
   if context.len > 0:
     q(context & "." & key)
   else:

--- a/src/logger.nim
+++ b/src/logger.nim
@@ -1,7 +1,7 @@
 import std/[logging]
 import "."/[cli]
 
-proc levelThreshold(verbosity: Verbosity): Level =
+func levelThreshold(verbosity: Verbosity): Level =
   case verbosity
   of verQuiet: lvlNone
   of verNormal: lvlNotice

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -22,7 +22,7 @@ type
     tests*: ExerciseTests
     testCases*: seq[ExerciseTestCase]
 
-proc initExerciseTests*(included, excluded, missing: HashSet[string]): ExerciseTests =
+func initExerciseTests*(included, excluded, missing: HashSet[string]): ExerciseTests =
   result.included = included
   result.excluded = excluded
   result.missing = missing
@@ -64,7 +64,7 @@ proc findExercises*(conf: Conf): seq[Exercise] =
   for trackExercise in findTrackExercises(conf).sortedByIt(it.slug):
     result.add(initExercise(trackExercise, probSpecsExercises.getOrDefault(trackExercise.slug)))
 
-proc status*(exercise: Exercise): ExerciseStatus =
+func status*(exercise: Exercise): ExerciseStatus =
   if exercise.testCases.len == 0:
     exNoCanonicalData
   elif exercise.tests.missing.len > 0:
@@ -72,13 +72,13 @@ proc status*(exercise: Exercise): ExerciseStatus =
   else:
     exInSync
 
-proc hasCanonicalData*(exercise: Exercise): bool =
+func hasCanonicalData*(exercise: Exercise): bool =
   exercise.testCases.len > 0
 
-proc testsFile(exercise: Exercise, trackDir: string): string =
+func testsFile(exercise: Exercise, trackDir: string): string =
   trackDir / "exercises" / "practice" / exercise.slug / ".meta" / "tests.toml"
 
-proc toToml(exercise: Exercise): string =
+func toToml(exercise: Exercise): string =
   result.add("[canonical-tests]\n")
 
   for testCase in exercise.testCases:

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -33,17 +33,17 @@ proc clone(repo: ProbSpecsRepo) =
 proc remove(repo: ProbSpecsRepo) =
   removeDir(repo.dir)
 
-proc initProbSpecsRepoExercise(dir: string): ProbSpecsRepoExercise =
+func initProbSpecsRepoExercise(dir: string): ProbSpecsRepoExercise =
   result.dir = dir
 
-proc exercisesDir(repo: ProbSpecsRepo): string =
+func exercisesDir(repo: ProbSpecsRepo): string =
   repo.dir / "exercises"
 
 proc exercises(repo: ProbSpecsRepo): seq[ProbSpecsRepoExercise] =
   for exerciseDir in walkDirs(repo.exercisesDir / "*"):
     result.add(initProbSpecsRepoExercise(exerciseDir))
 
-proc canonicalDataFile(repoExercise: ProbSpecsRepoExercise): string =
+func canonicalDataFile(repoExercise: ProbSpecsRepoExercise): string =
   repoExercise.dir / "canonical-data.json"
 
 proc hasCanonicalDataFile(repoExercise: ProbSpecsRepoExercise): bool =
@@ -53,10 +53,10 @@ proc exercisesWithCanonicalData(repo: ProbSpecsRepo): seq[ProbSpecsRepoExercise]
   for repoExercise in repo.exercises().filter(hasCanonicalDataFile):
     result.add(repoExercise)
 
-proc slug(repoExercise: ProbSpecsRepoExercise): string =
+func slug(repoExercise: ProbSpecsRepoExercise): string =
   extractFilename(repoExercise.dir)
 
-proc initProbSpecsTestCase(node: JsonNode): ProbSpecsTestCase =
+func initProbSpecsTestCase(node: JsonNode): ProbSpecsTestCase =
   result.json = node
 
 proc uuid*(testCase: ProbSpecsTestCase): string =
@@ -65,7 +65,7 @@ proc uuid*(testCase: ProbSpecsTestCase): string =
 proc description*(testCase: ProbSpecsTestCase): string =
   testCase.json["description"].getStr()
 
-proc isReimplementation*(testCase: ProbSpecsTestCase): bool =
+func isReimplementation*(testCase: ProbSpecsTestCase): bool =
   testCase.json.hasKey("reimplements")
 
 proc reimplements*(testCase: ProbSpecsTestCase): string =

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -24,29 +24,29 @@ type
     tests*: TrackExerciseTests
     repoExercise: TrackRepoExercise
 
-proc configJsonFile(repo: TrackRepo): string =
+func configJsonFile(repo: TrackRepo): string =
   repo.dir / "config.json"
 
-proc exercisesDir(repo: TrackRepo): string =
+func exercisesDir(repo: TrackRepo): string =
   repo.dir / "exercises"
 
-proc practiceExerciseDir(repo: TrackRepo, exercise: ConfigJsonExercise): string =
+func practiceExerciseDir(repo: TrackRepo, exercise: ConfigJsonExercise): string =
   repo.exercisesDir / "practice" / exercise.slug
 
-proc slug(exercise: TrackRepoExercise): string =
+func slug(exercise: TrackRepoExercise): string =
   extractFilename(exercise.dir)
 
-proc testsFile(exercise: TrackRepoExercise): string =
+func testsFile(exercise: TrackRepoExercise): string =
   exercise.dir / ".meta" / "tests.toml"
 
-proc testsFile*(exercise: TrackExercise): string =
+func testsFile*(exercise: TrackExercise): string =
   exercise.repoExercise.testsFile
 
 proc parseConfigJson(filePath: string): ConfigJson =
   let json = json.parseFile(filePath)["exercises"]
   to(json, ConfigJson)
 
-proc newTrackRepoExercise(repo: TrackRepo,
+func newTrackRepoExercise(repo: TrackRepo,
     exercise: ConfigJsonExercise): TrackRepoExercise =
   result.dir = repo.practiceExerciseDir(exercise)
 


### PR DESCRIPTION
This PR changes `proc` to `func` where possible.

I made separate commits here, but I'd prefer to squash when merging.