### PR TITLE
lint(validators): add missing context

### DIFF
--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -55,7 +55,7 @@ proc checkArrayOfStrings*(data: JsonNode; context, key, path: string;
                                       format(context, key), path)
             elif s.strip().len == 0:
               result.setFalseAndPrint("Array contains whitespace-only string: " &
-                                      q(key), path)
+                                      format(context, key), path)
           else:
             result.setFalseAndPrint("Array contains non-string: " &
                                     format(context, key) & ": " & $item, path)


### PR DESCRIPTION
For a `.meta/config.json` containing a whitespace-only string:
```json
{
  "files": {
    "solution": [" "],
    "test": ["test_foo.nim"],
    "exemplar": [".meta/exemplar.nim"]
  }
}
```

Before this commit:
```
    Array contains whitespace-only string: 'solution'
```

With this commit:
```
    Array contains whitespace-only string: 'files.solution'
```