### PR TITLE
lint(validators): refactor `len` conditions

### DIFF
--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -22,10 +22,11 @@ proc checkString*(data: JsonNode; key, path: string; isRequired = true): bool =
   if data.hasKey(key):
     if data[key].kind == JString:
       let s = data[key].getStr()
-      if s.len == 0:
+      if s.len > 0:
+        if s.strip().len == 0:
+          result.setFalseAndPrint("String is whitespace-only: " & q(key), path)
+      else:
         result.setFalseAndPrint("String is zero-length: " & q(key), path)
-      elif s.strip().len == 0:
-        result.setFalseAndPrint("String is whitespace-only: " & q(key), path)
     else:
       result.setFalseAndPrint("Not a string: " & q(key) & ": " & $data[key], path)
   elif isRequired:
@@ -40,25 +41,25 @@ func format(context, key: string): string =
 proc checkArrayOfStrings*(data: JsonNode; context, key, path: string;
                           isRequired = true): bool =
   result = true
-  var d = if context.len == 0: data else: data[context]
+  let d = if context.len > 0: data[context] else: data
   if d.hasKey(key):
     if d[key].kind == JArray:
-      if d[key].len == 0:
-        if isRequired:
-          result.setFalseAndPrint("Array is empty: " & format(context, key), path)
-      else:
+      if d[key].len > 0:
         for item in d[key]:
           if item.kind == JString:
             let s = item.getStr()
-            if s.len == 0:
+            if s.len > 0:
+              if s.strip().len == 0:
+                result.setFalseAndPrint("Array contains whitespace-only string: " &
+                                        format(context, key), path)
+            else:
               result.setFalseAndPrint("Array contains zero-length string: " &
-                                      format(context, key), path)
-            elif s.strip().len == 0:
-              result.setFalseAndPrint("Array contains whitespace-only string: " &
                                       format(context, key), path)
           else:
             result.setFalseAndPrint("Array contains non-string: " &
                                     format(context, key) & ": " & $item, path)
+      elif isRequired:
+        result.setFalseAndPrint("Array is empty: " & format(context, key), path)
     else:
       result.setFalseAndPrint("Not an array: " & format(context, key), path)
   elif isRequired:
@@ -70,13 +71,12 @@ proc checkArrayOf*(data: JsonNode; key, path: string;
   result = true
   if data.hasKey(key):
     if data[key].kind == JArray:
-      if data[key].len == 0:
-        if isRequired:
-          result.setFalseAndPrint("Array is empty: " & q(key), path)
-      else:
+      if data[key].len > 0:
         for item in data[key]:
           if not call(item, key, path):
             result = false
+      elif isRequired:
+        result.setFalseAndPrint("Array is empty: " & q(key), path)
     else:
       result.setFalseAndPrint("Not an array: " & q(key), path)
   elif isRequired:


### PR DESCRIPTION
In our validation procs, there are conditions like
```Nim
if data.hasKey(key):
  if data[key].kind == JString:
```
where the condition being `true` represents the "happy path".

To improve readability, let's try to do this consistently for every
condition apart from the innermost one; it's easier to see the "happy
path" when it minimises the number of `else`.

This commit refactors the `len` conditions accordingly, so that we
prefer `len > 0` and use `len == 0` only when there is no `else`.

This commit also changes a `var` to a `let` to better convey that we
don't mutate.