### PR TITLE
lint: support top-level array

### DIFF
--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -23,12 +23,12 @@ proc checkFiles(data: JsonNode, context, path: string): bool =
     result = false
 
 proc isValidConceptExerciseConfig(data: JsonNode, path: string): bool =
-  if isObject(data, "root", path):
+  if isObject(data, "", path):
     result = true
-    if not checkArrayOf(data, "authors", path, isValidAuthorOrContributor):
+    if not hasArrayOf(data, "authors", path, isValidAuthorOrContributor):
       result = false
-    if not checkArrayOf(data, "contributors", path, isValidAuthorOrContributor,
-                        isRequired = false):
+    if not hasArrayOf(data, "contributors", path, isValidAuthorOrContributor,
+                      isRequired = false):
       result = false
     if not checkFiles(data, "files", path):
       result = false

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -13,11 +13,11 @@ proc isValidAuthorOrContributor(data: JsonNode, context: string, path: string): 
 proc checkFiles(data: JsonNode, context, path: string): bool =
   result = true
   if hasObject(data, context, path):
-    if not checkArrayOfStrings(data, context, "solution", path):
+    if not hasArrayOfStrings(data, context, "solution", path):
       result = false
-    if not checkArrayOfStrings(data, context, "test", path):
+    if not hasArrayOfStrings(data, context, "test", path):
       result = false
-    if not checkArrayOfStrings(data, context, "exemplar", path):
+    if not hasArrayOfStrings(data, context, "exemplar", path):
       result = false
   else:
     result = false
@@ -32,7 +32,7 @@ proc isValidConceptExerciseConfig(data: JsonNode, path: string): bool =
       result = false
     if not checkFiles(data, "files", path):
       result = false
-    if not checkArrayOfStrings(data, "", "forked_from", path, isRequired = false):
+    if not hasArrayOfStrings(data, "", "forked_from", path, isRequired = false):
       result = false
     if not checkString(data, "language_versions", path, isRequired = false):
       result = false

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -23,14 +23,14 @@ proc checkFiles(data: JsonNode, context, path: string): bool =
     result = false
 
 proc isValidPracticeExerciseConfig(data: JsonNode, path: string): bool =
-  if isObject(data, "root", path):
+  if isObject(data, "", path):
     result = true
     # Temporarily disable the checking of authors as we'll be doing bulk PRs
     # to pre-populate this field for all tracks
-    # if not checkArrayOf(data, "authors", path, isValidAuthorOrContributor):
+    # if not hasArrayOf(data, "authors", path, isValidAuthorOrContributor):
     #   result = false
-    if not checkArrayOf(data, "contributors", path, isValidAuthorOrContributor,
-                        isRequired = false):
+    if not hasArrayOf(data, "contributors", path, isValidAuthorOrContributor,
+                      isRequired = false):
       result = false
     # Temporarily disable the checking of the files to give tracks the chance
     # to update this manually

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -13,11 +13,11 @@ proc isValidAuthorOrContributor(data: JsonNode, context: string, path: string): 
 proc checkFiles(data: JsonNode, context, path: string): bool =
   result = true
   if hasObject(data, context, path):
-    if not checkArrayOfStrings(data, context, "solution", path):
+    if not hasArrayOfStrings(data, context, "solution", path):
       result = false
-    if not checkArrayOfStrings(data, context, "test", path):
+    if not hasArrayOfStrings(data, context, "test", path):
       result = false
-    if not checkArrayOfStrings(data, context, "example", path):
+    if not hasArrayOfStrings(data, context, "example", path):
       result = false
   else:
     result = false

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -53,7 +53,7 @@ proc isValidTag(data: JsonNode, context: string, path: string): bool =
     result.setFalseAndPrint("Tag is not a string: " & $data, path)
 
 proc isValidTrackConfig(data: JsonNode, path: string): bool =
-  if isObject(data, "root", path):
+  if isObject(data, "", path):
     result = true
     if not checkString(data, "language", path):
       result = false
@@ -65,7 +65,7 @@ proc isValidTrackConfig(data: JsonNode, path: string): bool =
       result = false
     if not checkInteger(data, "version", path):
       result = false
-    if not checkArrayOf(data, "tags", path, isValidTag):
+    if not hasArrayOf(data, "tags", path, isValidTag):
       result = false
 
 proc isTrackConfigValid*(trackDir: string): bool =


### PR DESCRIPTION
So far, none of the files we were linting were an array at the top level. But `links.json` is.

Some possible future refactorings:
- Use common logic for all the "missing key" conditions.
- Make the `arrayOfStrings` procs extend the `array` procs.
- Make the empty string unnecessary in `isObject(data, "", path)`.

This PR is still a bit WIP, and I'm not set on its approach yet. But it might soon be good enough for now.

I need to do the below before I merge this PR:
- [x] Fix the bug that makes `configlet lint` produce an error
- [x] Verify that this PR does not change the output of `configlet lint` 