### PR TITLE
lint(validators): validate practice exercises

### DIFF
--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -1,5 +1,5 @@
 import ".."/cli
-import "."/[concept_exercises, concepts, track_config]
+import "."/[concept_exercises, concepts, practice_exercises, track_config]
 
 proc lint*(conf: Conf) =
   echo "The lint command is under development.\n" &
@@ -9,16 +9,18 @@ proc lint*(conf: Conf) =
   let trackDir = conf.trackDir
   let b1 = isTrackConfigValid(trackDir)
   let b2 = conceptExerciseFilesExist(trackDir)
-  let b3 = conceptFilesExist(trackDir)
-  let b4 = isEveryConceptExerciseConfigValid(trackDir)
+  let b3 = practiceExerciseFilesExist(trackDir)
+  let b4 = conceptFilesExist(trackDir)
+  let b5 = isEveryConceptExerciseConfigValid(trackDir)
 
-  if b1 and b2 and b3 and b4:
+  if b1 and b2 and b3 and b4 and b5:
     echo """
 Basic linting finished successfully:
 - config.json exists and is valid JSON
 - config.json has these valid fields: language, slug, active, blurb, version, tags
 - Every concept has the required .md files and links.json file
 - Every concept exercise has the required .md files and a .meta/config.json file
-- Every concept exercise .meta/config.json file is valid"""
+- Every concept exercise .meta/config.json file is valid
+- Every practice exercise has the required .md files and a .meta/config.json file"""
   else:
     quit(1)

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -12,8 +12,9 @@ proc lint*(conf: Conf) =
   let b3 = practiceExerciseFilesExist(trackDir)
   let b4 = conceptFilesExist(trackDir)
   let b5 = isEveryConceptExerciseConfigValid(trackDir)
+  let b6 = isEveryPracticeExerciseConfigValid(trackDir)
 
-  if b1 and b2 and b3 and b4 and b5:
+  if b1 and b2 and b3 and b4 and b5 and b6:
     echo """
 Basic linting finished successfully:
 - config.json exists and is valid JSON
@@ -21,6 +22,7 @@ Basic linting finished successfully:
 - Every concept has the required .md files and links.json file
 - Every concept exercise has the required .md files and a .meta/config.json file
 - Every concept exercise .meta/config.json file is valid
-- Every practice exercise has the required .md files and a .meta/config.json file"""
+- Every practice exercise has the required .md files and a .meta/config.json file
+- Every practice exercise .meta/config.json file is valid"""
   else:
     quit(1)

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -1,0 +1,14 @@
+import std/os
+import "."/validators
+
+proc practiceExerciseFilesExist*(trackDir: string): bool =
+  ## Returns true if every subdirectory in `trackDir/exercises/practice` has the
+  ## required files.
+  const
+    requiredPracticeExerciseFiles = [
+      ".docs" / "instructions.md",
+      ".meta" / "config.json",
+    ]
+
+  let practiceExercisesDir = trackDir / "exercises" / "practice"
+  result = subdirsContain(practiceExercisesDir, requiredPracticeExerciseFiles)

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -25,13 +25,17 @@ proc checkFiles(data: JsonNode, context, path: string): bool =
 proc isValidPracticeExerciseConfig(data: JsonNode, path: string): bool =
   if isObject(data, "root", path):
     result = true
-    if not checkArrayOf(data, "authors", path, isValidAuthorOrContributor):
-      result = false
+    # Temporarily disable the checking of authors as we'll be doing bulk PRs
+    # to pre-populate this field for all tracks
+    # if not checkArrayOf(data, "authors", path, isValidAuthorOrContributor):
+    #   result = false
     if not checkArrayOf(data, "contributors", path, isValidAuthorOrContributor,
                         isRequired = false):
       result = false
-    if not checkFiles(data, "files", path):
-      result = false
+    # Temporarily disable the checking of the files to give tracks the chance
+    # to update this manually
+    # if not checkFiles(data, "files", path):
+    #   result = false
     if not checkString(data, "language_versions", path, isRequired = false):
       result = false
 

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -1,5 +1,57 @@
-import std/os
+import std/[json, os]
+import ".."/helpers
 import "."/validators
+
+proc isValidAuthorOrContributor(data: JsonNode, context: string, path: string): bool =
+  if isObject(data, context, path):
+    result = true
+    if not checkString(data, "github_username", path):
+      result = false
+    if not checkString(data, "exercism_username", path, isRequired = false):
+      result = false
+
+proc checkFiles(data: JsonNode, context, path: string): bool =
+  result = true
+  if hasObject(data, context, path):
+    if not checkArrayOfStrings(data, context, "solution", path):
+      result = false
+    if not checkArrayOfStrings(data, context, "test", path):
+      result = false
+    if not checkArrayOfStrings(data, context, "example", path):
+      result = false
+  else:
+    result = false
+
+proc isValidPracticeExerciseConfig(data: JsonNode, path: string): bool =
+  if isObject(data, "root", path):
+    result = true
+    if not checkArrayOf(data, "authors", path, isValidAuthorOrContributor):
+      result = false
+    if not checkArrayOf(data, "contributors", path, isValidAuthorOrContributor,
+                        isRequired = false):
+      result = false
+    if not checkFiles(data, "files", path):
+      result = false
+    if not checkString(data, "language_versions", path, isRequired = false):
+      result = false
+
+proc isEveryPracticeExerciseConfigValid*(trackDir: string): bool =
+  let practiceExercisesDir = trackDir / "exercises" / "practice"
+  result = true
+  # Return true even if the directory does not exist - this allows a future
+  # track to have concept exercises and no practice exercises.
+  if dirExists(practiceExercisesDir):
+    for exerciseDir in getSortedSubdirs(practiceExercisesDir):
+      let configPath = exerciseDir / ".meta" / "config.json"
+      if fileExists(configPath):
+        let j =
+          try:
+            parseFile(configPath)
+          except:
+            result.setFalseAndPrint("JSON parsing error", getCurrentExceptionMsg())
+            continue
+        if not isValidPracticeExerciseConfig(j, configPath):
+          result = false
 
 proc practiceExerciseFilesExist*(trackDir: string): bool =
   ## Returns true if every subdirectory in `trackDir/exercises/practice` has the


### PR DESCRIPTION
This PR adds basic validation checks for practice exercises:

- Check if the required files are present
- Check if the .meta/config.json files are valid

The PR also applies a minor refactoring, where required file checking is moved to the corresponding module instead of the lint module.

The helper proc to check whether required files exist in a directory has been moved to the validators module to allow being called from the different modules.
