### PR TITLE
lint: extract required file checks to modules

### DIFF
--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -52,3 +52,17 @@ proc isEveryConceptExerciseConfigValid*(trackDir: string): bool =
             continue
         if not isValidConceptExerciseConfig(j, configPath):
           result = false
+
+proc conceptExerciseFilesExist*(trackDir: string): bool =
+  ## Returns true if every subdirectory in `trackDir/exercises/concept` has the
+  ## required files.
+  const
+    requiredConceptExerciseFiles = [
+      ".docs" / "hints.md",
+      ".docs" / "instructions.md",
+      ".docs" / "introduction.md",
+      ".meta" / "config.json",
+    ]
+
+  let conceptExercisesDir = trackDir / "exercises" / "concept"
+  result = subdirsContain(conceptExercisesDir, requiredConceptExerciseFiles)

--- a/src/lint/concepts.nim
+++ b/src/lint/concepts.nim
@@ -1,0 +1,15 @@
+import std/os
+import "."/validators
+
+proc conceptFilesExist*(trackDir: string): bool =
+  ## Returns true if every subdirectory in `trackDir/concepts` has the required
+  ## files.
+  const
+    requiredConceptFiles = [
+      "about.md",
+      "introduction.md",
+      "links.json",
+    ]
+
+  let conceptsDir = trackDir / "concepts"
+  result = subdirsContain(conceptsDir, requiredConceptFiles)

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -1,47 +1,5 @@
-import std/os
-import ".."/[cli, helpers]
-import "."/[concept_exercises, track_config]
-
-proc subdirsContain(dir: string, files: openArray[string]): bool =
-  ## Returns `true` if every file in `files` exists in every subdirectory of
-  ## `dir`.
-  ##
-  ## Returns `true` if `dir` does not exist or has no subdirectories.
-  result = true
-
-  if dirExists(dir):
-    for subdir in getSortedSubdirs(dir):
-      for file in files:
-        let path = subdir / file
-        if not fileExists(path):
-          result.setFalseAndPrint("Missing file", path)
-
-proc conceptExerciseFilesExist(trackDir: string): bool =
-  ## Returns true if every subdirectory in `trackDir/exercises/concept` has the
-  ## required files.
-  const
-    conceptExerciseFiles = [
-      ".docs" / "hints.md",
-      ".docs" / "instructions.md",
-      ".docs" / "introduction.md",
-      ".meta" / "config.json",
-    ]
-
-  let conceptDir = trackDir / "exercises" / "concept"
-  result = subdirsContain(conceptDir, conceptExerciseFiles)
-
-proc conceptFilesExist(trackDir: string): bool =
-  ## Returns true if every subdirectory in `trackDir/concepts` has the required
-  ## files.
-  const
-    conceptFiles = [
-      "about.md",
-      "introduction.md",
-      "links.json",
-    ]
-
-  let conceptsDir = trackDir / "concepts"
-  result = subdirsContain(conceptsDir, conceptFiles)
+import ".."/cli
+import "."/[concept_exercises, concepts, track_config]
 
 proc lint*(conf: Conf) =
   echo "The lint command is under development.\n" &

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -1,4 +1,4 @@
-import std/[json, strutils]
+import std/[json, os, strutils]
 import ".."/helpers
 
 func q(s: string): string =
@@ -97,3 +97,17 @@ proc checkInteger*(data: JsonNode; key, path: string; isRequired = true): bool =
       result.setFalseAndPrint("Not an integer: " & q(key) & ": " & $data[key], path)
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & q(key), path)
+
+proc subdirsContain*(dir: string, files: openArray[string]): bool =
+  ## Returns `true` if every file in `files` exists in every subdirectory of
+  ## `dir`.
+  ##
+  ## Returns `true` if `dir` does not exist or has no subdirectories.
+  result = true
+
+  if dirExists(dir):
+    for subdir in getSortedSubdirs(dir):
+      for file in files:
+        let path = subdir / file
+        if not fileExists(path):
+          result.setFalseAndPrint("Missing file", path)


### PR DESCRIPTION
The validation that checked if required files were present was done in
the `lint.nim` file. To better separate concerns, these file checks have
been moved to their own modules.

The validation helper proc to check for required files has been moved to
the validators module.

--- 

This commit is from https://github.com/exercism/configlet/pull/219 - let's merge this refactoring separately, just to lower the number of commits merged as "rebase and merge" from a single PR.