### PR TITLE
lint: allow null for optional values (review)

### DIFF
--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -144,7 +144,7 @@ proc checkBoolean*(data: JsonNode; key, path: string; isRequired = true): bool =
   if data.hasKey(key):
     case data[key].kind
     of JBool:
-      return
+      return true
     of JNull:
       if isRequired:
         result.setFalseAndPrint("Value is `null`, but must be a bool: " &
@@ -159,7 +159,7 @@ proc checkInteger*(data: JsonNode; key, path: string; isRequired = true): bool =
   if data.hasKey(key):
     case data[key].kind
     of JInt:
-      return
+      return true
     of JNull:
       if isRequired:
         result.setFalseAndPrint("Value is `null`, but must be an integer: " &

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -23,14 +23,19 @@ proc hasObject*(data: JsonNode; key, path: string; isRequired = true): bool =
 proc checkString*(data: JsonNode; key, path: string; isRequired = true): bool =
   result = true
   if data.hasKey(key):
-    if data[key].kind == JString:
+    case data[key].kind
+    of JString:
       let s = data[key].getStr()
       if s.len > 0:
         if s.strip().len == 0:
           result.setFalseAndPrint("String is whitespace-only: " & q(key), path)
       else:
         result.setFalseAndPrint("String is zero-length: " & q(key), path)
-    elif data[key].kind != JNull or isRequired:
+    of JNull:
+      if isRequired:
+        result.setFalseAndPrint("Value is `null`, but must be a string: " &
+                                q(key), path)
+    else:
       result.setFalseAndPrint("Not a string: " & q(key) & ": " & $data[key], path)
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & q(key), path)
@@ -50,7 +55,8 @@ proc isArrayOfStrings*(data: JsonNode;
   ## - `data` is an empty `JArray` and `isRequired` is false.
   result = true
 
-  if data.kind == JArray:
+  case data.kind
+  of JArray:
     if data.len > 0:
       for item in data:
         if item.kind == JString:
@@ -67,7 +73,11 @@ proc isArrayOfStrings*(data: JsonNode;
                                   format(context, key) & ": " & $item, path)
     elif isRequired:
       result.setFalseAndPrint("Array is empty: " & format(context, key), path)
-  elif data.kind != JNull or isRequired:
+  of JNull:
+    if isRequired:
+      result.setFalseAndPrint("Value is `null`, but must be an array: " &
+                              format(context, key), path)
+  else:
     result.setFalseAndPrint("Not an array: " & format(context, key), path)
 
 proc hasArrayOfStrings*(data: JsonNode;
@@ -99,14 +109,19 @@ proc isArrayOf*(data: JsonNode;
   ## - `data` is an empty `JArray` and `isRequired` is false.
   result = true
 
-  if data.kind == JArray:
+  case data.kind
+  of JArray:
     if data.len > 0:
       for item in data:
         if not call(item, context, path):
           result = false
     elif isRequired:
       result.setFalseAndPrint("Array is empty: " & q(context), path)
-  elif data.kind != JNull or isRequired:
+  of JNull:
+    if isRequired:
+      result.setFalseAndPrint("Value is `null`, but must be an array: " &
+                              q(context), path)
+  else:
     result.setFalseAndPrint("Not an array: " & q(context), path)
 
 proc hasArrayOf*(data: JsonNode;
@@ -127,9 +142,14 @@ proc hasArrayOf*(data: JsonNode;
 proc checkBoolean*(data: JsonNode; key, path: string; isRequired = true): bool =
   result = true
   if data.hasKey(key):
-    if data[key].kind == JBool:
+    case data[key].kind
+    of JBool:
       return
-    elif data[key].kind != JNull or isRequired:
+    of JNull:
+      if isRequired:
+        result.setFalseAndPrint("Value is `null`, but must be a bool: " &
+                                q(key), path)
+    else:
       result.setFalseAndPrint("Not a bool: " & q(key) & ": " & $data[key], path)
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & q(key), path)
@@ -137,9 +157,14 @@ proc checkBoolean*(data: JsonNode; key, path: string; isRequired = true): bool =
 proc checkInteger*(data: JsonNode; key, path: string; isRequired = true): bool =
   result = true
   if data.hasKey(key):
-    if data[key].kind == JInt:
+    case data[key].kind
+    of JInt:
       return
-    elif data[key].kind != JNull or isRequired:
+    of JNull:
+      if isRequired:
+        result.setFalseAndPrint("Value is `null`, but must be an integer: " &
+                                q(key), path)
+    else:
       result.setFalseAndPrint("Not an integer: " & q(key) & ": " & $data[key], path)
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & q(key), path)


### PR DESCRIPTION
I think the case statement with
```Nim
of JNull
```
makes things more readable than
```Nim
elif data[key].kind != JNull or isRequired:
```

And maybe it's slightly better to have the ability to write targetted error messages for the `null` case. 

I've verified that this PR keeps the output of `configlet lint` the same as #199 on every track.