### PR TITLE
build: bump `jiro4989/setup-nim-action` from 1.3.0 to 1.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
 
       - name: Install Nim
-        uses: jiro4989/setup-nim-action@de456899a933296efa9d86e050300c1d9cc7e446 # 1.3.0
+        uses: jiro4989/setup-nim-action@06254954e9ca216111b384b60904a587f1a7b22e # 1.3.1
         with:
           nim-version: "1.4.2"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
 
       - name: Install Nim
-        uses: jiro4989/setup-nim-action@de456899a933296efa9d86e050300c1d9cc7e446 # 1.3.0
+        uses: jiro4989/setup-nim-action@06254954e9ca216111b384b60904a587f1a7b22e # 1.3.1
         with:
           nim-version: "1.4.2"
 


### PR DESCRIPTION
Changes:
- https://github.com/jiro4989/setup-nim-action/commit/1882843075f0
- https://github.com/jiro4989/setup-nim-action/commit/5f74e312d0a0

A list of our current action usage:
```
$ git grep --break --heading 'uses:'
.github/workflows/build.yml
36:        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
39:        uses: jiro4989/setup-nim-action@06254954e9ca216111b384b60904a587f1a7b22e # 1.3.1

.github/workflows/shellcheck.yml
11:        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
14:        uses: ludeeus/action-shellcheck@d586102c117f97e63d7e3b56629d269efc9a7c60 # 1.0.0

.github/workflows/tests.yml
41:        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
44:        uses: jiro4989/setup-nim-action@06254954e9ca216111b384b60904a587f1a7b22e # 1.3.1
```