### PR TITLE
cli,helpers: don't always use color

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -185,8 +185,21 @@ proc showVersion =
   echo &"{configletVersion}"
   quit(0)
 
+proc shouldUseColor(f: File): bool =
+  ## Returns true if we should write to `f` with color.
+  existsEnv("CI") or
+    (isatty(f) and not existsEnv("NO_COLOR") and getEnv("TERM") != "dumb")
+
+let
+  colorStdout* = shouldUseColor(stdout)
+  colorStderr* = shouldUseColor(stderr)
+
 proc showError*(s: string) =
-  stderr.styledWrite(fgRed, "Error: ")
+  const errorPrefix = "Error: "
+  if colorStderr:
+    stderr.styledWrite(fgRed, errorPrefix)
+  else:
+    stderr.write(errorPrefix)
   stderr.write(s)
   stderr.write("\n\n")
   showHelp(exitCode = 1)

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -1,4 +1,5 @@
 import std/[algorithm, os, terminal]
+import "."/cli
 
 template withDir*(dir: string; body: untyped): untyped =
   ## Changes the current directory to `dir` temporarily.
@@ -21,6 +22,10 @@ proc setFalseAndPrint*(b: var bool; description: string; details: string) =
   ## Sets `b` to `false` and writes a message to stdout containing `description`
   ## and `details`.
   b = false
-  stdout.styledWriteLine(fgRed, description & ":")
+  let descriptionPrefix = description & ":"
+  if colorStdout:
+    stdout.styledWriteLine(fgRed, descriptionPrefix)
+  else:
+    stdout.writeLine(descriptionPrefix)
   stdout.writeLine(details)
   stdout.write "\n"


### PR DESCRIPTION
Benefits:
- A user who writes `configlet lint > output.txt` will no longer see
  color codes in that file.
- It becomes easier to write integration tests for `configlet lint`.

--- 

Currently when we have a PR that affects `configlet lint`, I check the diff that the PR makes to the output of `configlet lint` on every track. This PR helps to simplify that process a little.

From e.g. https://clig.dev/#output:
> Disable color if your program is not in a terminal or the user requested it. These things should disable colors:

> - `stdout` or `stderr` is not an interactive terminal (a TTY). It’s best to individually check—if you’re piping stdout to another program, it’s still useful to get colors on `stderr`.
> - The `NO_COLOR` environment variable is set.
> - The `TERM` environment variable has the value `dumb`.