### PR TITLE
lint(track_config): check `version` is `3`

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -55,6 +55,7 @@ proc isValidTag(data: JsonNode, context: string, path: string): bool =
 proc isValidTrackConfig(data: JsonNode, path: string): bool =
   if isObject(data, "", path):
     result = true
+
     if not checkString(data, "language", path):
       result = false
     if not checkString(data, "slug", path):
@@ -63,8 +64,16 @@ proc isValidTrackConfig(data: JsonNode, path: string): bool =
       result = false
     if not checkString(data, "blurb", path):
       result = false
-    if not checkInteger(data, "version", path):
+
+    if checkInteger(data, "version", path):
+      let version = data["version"].getInt()
+      if version != 3:
+        let msg = "The value of `version` is `" & $version &
+                  "`, but it must be the integer `3`"
+        result.setFalseAndPrint(msg, path)
+    else:
       result = false
+
     if not hasArrayOf(data, "tags", path, isValidTag):
       result = false
 


### PR DESCRIPTION
From [the spec](https://github.com/exercism/docs/blob/main/building/configlet/lint.md)

> - The `"version"` key is required
> - The `"version"` value must be the integer `3`

No diff to the `configlet lint` output for the tracks - every track currently uses `3`.

In general we'll have the question "should we add this code in `track_config.nim` or `validators.nim`?"

But let's work out how best to refactor it later. And there aren't many keys where we check that an integer is a certain number or in a certain range anyway.