### PR TITLE
lint(track_config): check `status` and `online_editor`

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -52,6 +52,43 @@ proc isValidTag(data: JsonNode, context: string, path: string): bool =
   else:
     result.setFalseAndPrint("Tag is not a string: " & $data, path)
 
+proc hasValidStatus(data: JsonNode, path: string): bool =
+  if hasObject(data, "status", path):
+    result = true
+    let d = data["status"]
+
+    if not checkBoolean(d, "concept_exercises", path):
+      result = false
+    if not checkBoolean(d, "test_runner", path):
+      result = false
+    if not checkBoolean(d, "representer", path):
+      result = false
+    if not checkBoolean(d, "analyzer", path):
+      result = false
+
+proc hasValidOnlineEditor(data: JsonNode, path: string): bool =
+  if hasObject(data, "online_editor", path):
+    result = true
+    let d = data["online_editor"]
+
+    if checkString(d, "indent_style", path):
+      let s = d["indent_style"].getStr()
+      if s != "space" and s != "tab":
+        let msg = "The value of `online_editor.indent_style` is `" & s &
+                  "`, but it must be `space` or `tab`"
+        result.setFalseAndPrint(msg, path)
+    else:
+      result = false
+
+    if checkInteger(d, "indent_size", path):
+      let num = d["indent_size"].getInt()
+      if num < 0:
+        let msg = "The value of `online_editor.indent_size` is `" & $num &
+                  "`, but it must be an integer >= 0"
+        result.setFalseAndPrint(msg, path)
+    else:
+      result = false
+
 proc isValidTrackConfig(data: JsonNode, path: string): bool =
   if isObject(data, "", path):
     result = true
@@ -72,6 +109,11 @@ proc isValidTrackConfig(data: JsonNode, path: string): bool =
                   "`, but it must be the integer `3`"
         result.setFalseAndPrint(msg, path)
     else:
+      result = false
+
+    if not hasValidStatus(data, path):
+      result = false
+    if not hasValidOnlineEditor(data, path):
       result = false
 
     if not hasArrayOf(data, "tags", path, isValidTag):


### PR DESCRIPTION
From [the spec](https://github.com/exercism/docs/blob/main/building/configlet/lint.md):
> - The `"status.concept_exercises"` key is required
> - The `"status.concept_exercises"` value must be a boolean
> - The `"status.test_runner"` key is required
> - The `"status.test_runner"` value must be a boolean
> - The `"status.representer"` key is required
> - The `"status.representer"` value must be a boolean
> - The `"status.analyzer"` key is required
> - The `"status.analyzer"` value must be a boolean
> - The `"online_editor.indent_style"` key is required
> - The `"online_editor.indent_style"` value must be the string `space` or `tab`
> - The `"online_editor.indent_size"` key is required
> - The `"online_editor.indent_size"` value must be a positive integer (>= 0)


Diff due to this PR to the current tracks:

#### dart
Used `  "online_editor": null,` - see [here](https://github.com/exercism/dart/blob/b684207a7a38b77fdf07bc831be61a9ec752fc68/config.json#L13)

```diff
+Not an object: 'online_editor':
+./config.json
+
```

#### research_experiment_1
```diff
+Missing key: 'status':
+./config.json
+
+Missing key: 'online_editor':
+./config.json
+
```