### PR TITLE
lint(track_config): check `key_features`

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -89,6 +89,43 @@ proc hasValidOnlineEditor(data: JsonNode, path: string): bool =
     else:
       result = false
 
+proc isValidKeyFeature(data: JsonNode, context: string, path: string): bool =
+  if isObject(data, context, path):
+    result = true
+
+    # TODO: Enable the `icon` checks when we have a list of valid icons.
+    if false:
+      const icons = [
+        "todo",
+      ].toHashSet()
+
+      if checkString(data, "icon", path):
+        let s = data["icon"].getStr()
+
+        if s notin icons:
+          let msg = "The value of `key_features.icon` is `" & s &
+                    "` which is not one of the valid values"
+          result.setFalseAndPrint(msg, path)
+
+    if not checkString(data, "title", path, maxLen = 25):
+      result = false
+    if not checkString(data, "content", path, maxLen = 100):
+      result = false
+
+proc hasValidKeyFeatures(data: JsonNode, path: string): bool =
+  result = true
+  if data.hasKey("key_features"):
+    let d = data["key_features"]
+    if isArrayOf(d, "key_features", path, isValidKeyFeature,
+                 isRequired = false):
+      let arrayLen = d.len
+      if arrayLen != 0 and arrayLen != 6:
+        let msg = "The `key_features` array has length " & $arrayLen &
+                  ", but must have length 6"
+        result.setFalseAndPrint(msg, path)
+    else:
+      result = false
+
 proc isValidTrackConfig(data: JsonNode, path: string): bool =
   if isObject(data, "", path):
     result = true
@@ -114,6 +151,8 @@ proc isValidTrackConfig(data: JsonNode, path: string): bool =
     if not hasValidStatus(data, path):
       result = false
     if not hasValidOnlineEditor(data, path):
+      result = false
+    if not hasValidKeyFeatures(data, path):
       result = false
 
     if not hasArrayOf(data, "tags", path, isValidTag):


### PR DESCRIPTION
To-do: 
- [ ] Merge #237 and rebase this PR on `main`

---

This commit implements the below rules for a track's `config.json` file.
> - The `"key_features"` key is optional
> - The `"key_features"` value must be an array with length = 6
> - The `"key_features[].icon"` key is required
> - The `"key_features[].icon"` value must be a string that matches one of the pre-defined icon values (TODO: add link to list of icons)
> - The `"key_features[].title"` key is required
> - The `"key_features[].title"` value must be a non-empty, non-blank string with length <= 25
> - The `"key_features[].content"` key is required
> - The `"key_features[].content"` value must be a non-empty, non-blank string with length <= 100

See the spec:
- https://github.com/exercism/docs/blob/main/building/configlet/lint.md#rule-configjson-file-is-valid

---

Questions for @ErikSchierboom:
1. The string [here](https://github.com/exercism/common-lisp/blob/e5c6c295c60b908144d7a068de6a7ca9a24792e2/config.json#L971) has a rune length of 100, but a `len` of 102 (it contains `–`, which is 3 bytes). Should we be checking for length or rune length?
2. Should we hide the `icon` errors for now?

This PR produces the following diff to the output of `configlet lint`, per track:

#### common-lisp
```diff
+The value of `content` that starts with `The language is very stabl...` is 102 characters, but must not exceed 100 characters:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### julia
```diff
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
```

#### lua
```diff
+String is zero-length: 'icon':
+./config.json
+
+The value of `content` that starts with `Lua is primarily designed ...` is 167 characters, but must not exceed 100 characters:
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+The value of `content` that starts with `Lua is known to be one of ...` is 149 characters, but must not exceed 100 characters:
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+The value of `content` that starts with `Lua has a simple, yet powe...` is 112 characters, but must not exceed 100 characters:
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+The value of `content` that starts with `Lua offers a small, yet fl...` is 133 characters, but must not exceed 100 characters:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### php
```diff
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### python
```diff
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+String is zero-length: 'icon':
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### rust
```diff
+Missing key: 'icon':
+./config.json
+
+Missing key: 'icon':
+./config.json
+
+Missing key: 'icon':
+./config.json
+
+Missing key: 'icon':
+./config.json
+
+Missing key: 'icon':
+./config.json
+
+Missing key: 'icon':
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```
