### PR TITLE
lint(track_config): check `blurb` length

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -99,7 +99,7 @@ proc isValidTrackConfig(data: JsonNode, path: string): bool =
       result = false
     if not checkBoolean(data, "active", path):
       result = false
-    if not checkString(data, "blurb", path):
+    if not checkString(data, "blurb", path, maxLen = 400):
       result = false
 
     if checkInteger(data, "version", path):


### PR DESCRIPTION
This commit causes the below diff to the `configlet lint` output.

#### haxe
```diff
+The value of `blurb` that starts with `Haxe is an open source hi...` is 423 characters, but must not exceed 400 characters:
+./config.json
+
```

---

To-do:
- [X] Merge #237 first then rebase this PR on `main`.