### PR TITLE
lint: check `blurb` for exercises

### DIFF
--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -17,6 +17,8 @@ proc checkFiles(data: JsonNode, context, path: string): bool =
 proc isValidConceptExerciseConfig(data: JsonNode, path: string): bool =
   if isObject(data, "", path):
     result = true
+    if not checkString(data, "blurb", path, maxLen = 350):
+      result = false
     if not hasArrayOfStrings(data, "", "authors", path):
       result = false
     if not hasArrayOfStrings(data, "", "contributors", path, isRequired = false):

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -17,6 +17,8 @@ proc checkFiles(data: JsonNode, context, path: string): bool =
 proc isValidPracticeExerciseConfig(data: JsonNode, path: string): bool =
   if isObject(data, "", path):
     result = true
+    if not checkString(data, "blurb", path, maxLen = 350):
+      result = false
     if not hasArrayOfStrings(data, "", "authors", path, isRequired = false):
       result = false
     if not hasArrayOfStrings(data, "", "contributors", path, isRequired = false):


### PR DESCRIPTION
This commit implements the below rules for the `.meta/config.json` file
of a Concept Exercise or a Practice Exercise.
- The `"blurb"` key is required
- The `"blurb"` value must be a non-empty, non-blank string with
  length <= 350

See:
- https://github.com/exercism/docs/pull/95/files
- https://github.com/exercism/docs/blob/f7d5ec6fda07/building/configlet/lint.md

---

This PR currently makes the below diff to the `configlet lint` output, per track.

#### ballerina
```diff
+Missing key: 'blurb':
+./exercises/practice/calculator-service/.meta/config.json
+
+Missing key: 'blurb':
+./exercises/practice/echo-service/.meta/config.json
+
+Missing key: 'blurb':
+./exercises/practice/greeting-service/.meta/config.json
+
+Missing key: 'blurb':
+./exercises/practice/hello-world-service/.meta/config.json
+
+Missing key: 'blurb':
+./exercises/practice/legacy-service-client/.meta/config.json
+
+Missing key: 'blurb':
+./exercises/practice/order-management/.meta/config.json
+
+Missing key: 'blurb':
+./exercises/practice/service-composition/.meta/config.json
+
+Missing key: 'blurb':
+./exercises/practice/service-invocation/.meta/config.json
+
```

#### bash
```diff
+Missing key: 'blurb':
+./exercises/practice/list-ops/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### erlang
```diff
+Missing key: 'blurb':
+./exercises/practice/bracket-push/.meta/config.json
+
```

#### go
```diff
+Missing key: 'blurb':
+./exercises/concept/chessboard/.meta/config.json
+
+Missing key: 'blurb':
+./exercises/concept/the-farm/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### objective-c
```diff
+Missing key: 'blurb':
+./exercises/practice/bracket-push/.meta/config.json
+
```

#### php
```diff
+Missing key: 'blurb':
+./exercises/practice/ordinal-number/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### purescript
```diff
+Missing key: 'blurb':
+./exercises/practice/bracket-push/.meta/config.json
+
```

#### r
```diff
+Missing key: 'blurb':
+./exercises/practice/fizz-buzz/.meta/config.json
+
```

#### solidity
```diff
+Missing key: 'blurb':
+./exercises/practice/token-transfer/.meta/config.json
+
```

#### swift
```diff
+Missing key: 'blurb':
+./exercises/practice/bracket-push/.meta/config.json
+
```
