### PR TITLE
lint(practice_exercises): prefer `if false` to commenting out

### DIFF
--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -21,10 +21,10 @@ proc isValidPracticeExerciseConfig(data: JsonNode, path: string): bool =
       result = false
     if not hasArrayOfStrings(data, "", "contributors", path, isRequired = false):
       result = false
-    # Temporarily disable the checking of the files to give tracks the chance
-    # to update this manually
-    # if not checkFiles(data, "files", path):
-    #   result = false
+    # TODO: Enable the `files` checks after the tracks have had some time to update.
+    if false:
+      if not checkFiles(data, "files", path):
+        result = false
     if not checkString(data, "language_versions", path, isRequired = false):
       result = false
 


### PR DESCRIPTION
Let's prefer `if false` over commenting out (or using `when false`).
This ensures that the code still compiles.

This commit also adds a TODO so that we can grep in the codebase for the
disabled checks.

This change also resolves the following compilation hint:
> src/lint/practice_exercises.nim(5, 6) Hint: 'checkFiles' is declared but not used [XDeclaredButNotUsed]

---

With this PR:
```
$ git grep --ignore-case --break --heading 'TODO'
src/lint/practice_exercises.nim
24:    # TODO: Enable the `files` checks after the tracks have had some time to update.

src/lint/track_config.nim
96:    # TODO: Enable the `icon` checks when we have a list of valid icons.
99:        "todo",
```