### PR TITLE
lint: update success message

### DIFF
--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -31,7 +31,8 @@ proc lint*(conf: Conf) =
     echo """
 Basic linting finished successfully:
 - config.json exists and is valid JSON
-- config.json has these valid fields: language, slug, active, blurb, version, tags
+- config.json has these valid fields:
+    language, slug, active, blurb, version, status, online_editor, key_features, tags
 - Every concept has the required .md files
 - Every concept has a valid links.json file
 - Every concept exercise has the required .md files


### PR DESCRIPTION
This commit adds `status`, `online_editor`, and `key_features` to the
success message.

These changes should have been included in:
- 3d19f6460d7f (#235)
- fb4712149d0a (#236)