### PR TITLE
lint: refactor to check value in `checkInteger`

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -80,13 +80,7 @@ proc hasValidOnlineEditor(data: JsonNode, path: string): bool =
     else:
       result = false
 
-    if checkInteger(d, "indent_size", path):
-      let num = d["indent_size"].getInt()
-      if num < 0:
-        let msg = "The value of `online_editor.indent_size` is `" & $num &
-                  "`, but it must be an integer >= 0"
-        result.setFalseAndPrint(msg, path)
-    else:
+    if not checkInteger(d, "indent_size", path, allowed = 0..8):
       result = false
 
 proc isValidKeyFeature(data: JsonNode, context: string, path: string): bool =
@@ -138,14 +132,7 @@ proc isValidTrackConfig(data: JsonNode, path: string): bool =
       result = false
     if not checkString(data, "blurb", path, maxLen = 400):
       result = false
-
-    if checkInteger(data, "version", path):
-      let version = data["version"].getInt()
-      if version != 3:
-        let msg = "The value of `version` is `" & $version &
-                  "`, but it must be the integer `3`"
-        result.setFalseAndPrint(msg, path)
-    else:
+    if not checkInteger(data, "version", path, allowed = 3..3):
       result = false
 
     if not hasValidStatus(data, path):

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -172,12 +172,22 @@ proc checkBoolean*(data: JsonNode; key, path: string; isRequired = true): bool =
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & q(key), path)
 
-proc checkInteger*(data: JsonNode; key, path: string; isRequired = true): bool =
+proc checkInteger*(data: JsonNode; key, path: string; isRequired = true;
+                   allowed: Slice): bool =
   result = true
   if data.hasKey(key):
     case data[key].kind
     of JInt:
-      return true
+      let num = data[key].getInt()
+      if num notin allowed:
+        let msgStart = "The value of `" & key & "` is `" & $num &
+                       "`, but it must be "
+        let msgEnd =
+          if allowed.len == 1:
+            "`" & $allowed.a & "`"
+          else:
+            "between " & $allowed.a & " and " & $allowed.b & " (inclusive)"
+        result.setFalseAndPrint(msgStart & msgEnd, path)
     of JNull:
       if isRequired:
         result.setFalseAndPrint("Value is `null`, but must be an integer: " &


### PR DESCRIPTION
This simplifies the code at the call site and reduces duplication.

---

The spec contains
> The "online_editor.indent_size" value must be a positive integer (>= 0)

But do we want to limit the `indent_size` to, say, `0..8`?

This PR doesn't affect the `configlet lint` output. But the new messages would look like
```
The value of `version` is `2`, but it must be `3`:
./config.json

The value of `indent_size` is `9`, but it must be between 0 and 8 (inclusive):
./config.json
```