### PR TITLE
lint: rename `checkX` validators to `hasX`

### DIFF
--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -2,7 +2,8 @@ import std/[json, os]
 import ".."/helpers
 import "."/validators
 
-proc checkFiles(data: JsonNode, context, path: string): bool =
+proc hasValidFiles(data: JsonNode, path: string): bool =
+  const context = "files"
   if hasObject(data, context, path):
     let checks = [
       hasArrayOfStrings(data, context, "solution", path),
@@ -14,12 +15,12 @@ proc checkFiles(data: JsonNode, context, path: string): bool =
 proc isValidConceptExerciseConfig(data: JsonNode, path: string): bool =
   if isObject(data, "", path):
     let checks = [
-      checkString(data, "blurb", path, maxLen = 350),
+      hasString(data, "blurb", path, maxLen = 350),
       hasArrayOfStrings(data, "", "authors", path),
       hasArrayOfStrings(data, "", "contributors", path, isRequired = false),
-      checkFiles(data, "files", path),
+      hasValidFiles(data, path),
       hasArrayOfStrings(data, "", "forked_from", path, isRequired = false),
-      checkString(data, "language_versions", path, isRequired = false),
+      hasString(data, "language_versions", path, isRequired = false),
     ]
     result = allTrue(checks)
 

--- a/src/lint/concepts.nim
+++ b/src/lint/concepts.nim
@@ -10,10 +10,10 @@ proc isValidLinkObject(data: JsonNode, context: string, path: string): bool =
   ## - if it has a `icon_url` key, the corresponding value is a URL-like string.
   if isObject(data, context, path):
     let checks = [
-      checkString(data, "url", path, checkIsUrlLike = true),
-      checkString(data, "description", path),
-      checkString(data, "icon_url", path, isRequired = false,
-                  checkIsUrlLike = true),
+      hasString(data, "url", path, checkIsUrlLike = true),
+      hasString(data, "description", path),
+      hasString(data, "icon_url", path, isRequired = false,
+                checkIsUrlLike = true),
     ]
     result = allTrue(checks)
   else:

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -2,7 +2,8 @@ import std/[json, os]
 import ".."/helpers
 import "."/validators
 
-proc checkFiles(data: JsonNode, context, path: string): bool =
+proc hasValidFiles(data: JsonNode, path: string): bool =
+  const context = "files"
   if hasObject(data, context, path):
     let checks = [
       hasArrayOfStrings(data, context, "solution", path),
@@ -15,11 +16,11 @@ proc isValidPracticeExerciseConfig(data: JsonNode, path: string): bool =
   if isObject(data, "", path):
     # TODO: Enable the `files` checks after the tracks have had some time to update.
     let checks = [
-      checkString(data, "blurb", path, maxLen = 350),
+      hasString(data, "blurb", path, maxLen = 350),
       hasArrayOfStrings(data, "", "authors", path, isRequired = false),
       hasArrayOfStrings(data, "", "contributors", path, isRequired = false),
-      if false: checkFiles(data, "files", path) else: true,
-      checkString(data, "language_versions", path, isRequired = false),
+      if false: hasValidFiles(data, path) else: true,
+      hasString(data, "language_versions", path, isRequired = false),
     ]
     result = allTrue(checks)
 

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -56,10 +56,10 @@ proc hasValidStatus(data: JsonNode, path: string): bool =
   if hasObject(data, "status", path):
     let d = data["status"]
     let checks = [
-      checkBoolean(d, "concept_exercises", path),
-      checkBoolean(d, "test_runner", path),
-      checkBoolean(d, "representer", path),
-      checkBoolean(d, "analyzer", path),
+      hasBoolean(d, "concept_exercises", path),
+      hasBoolean(d, "test_runner", path),
+      hasBoolean(d, "representer", path),
+      hasBoolean(d, "analyzer", path),
     ]
     result = allTrue(checks)
 
@@ -68,8 +68,8 @@ proc hasValidOnlineEditor(data: JsonNode, path: string): bool =
     let d = data["online_editor"]
     const indentStyles = ["space", "tab"].toHashSet()
     let checks = [
-      checkString(d, "indent_style", path, allowed = indentStyles),
-      checkInteger(d, "indent_size", path, allowed = 0..8),
+      hasString(d, "indent_style", path, allowed = indentStyles),
+      hasInteger(d, "indent_size", path, allowed = 0..8),
     ]
     result = allTrue(checks)
 
@@ -80,9 +80,9 @@ proc isValidKeyFeature(data: JsonNode, context: string, path: string): bool =
     ].toHashSet()
     # TODO: Enable the `icon` checks when we have a list of valid icons.
     let checks = [
-      if false: checkString(data, "icon", path, allowed = icons) else: true,
-      checkString(data, "title", path, maxLen = 25),
-      checkString(data, "content", path, maxLen = 100),
+      if false: hasString(data, "icon", path, allowed = icons) else: true,
+      hasString(data, "title", path, maxLen = 25),
+      hasString(data, "content", path, maxLen = 100),
     ]
     result = allTrue(checks)
 
@@ -93,11 +93,11 @@ proc hasValidKeyFeatures(data: JsonNode, path: string): bool =
 proc isValidTrackConfig(data: JsonNode, path: string): bool =
   if isObject(data, "", path):
     let checks = [
-      checkString(data, "language", path),
-      checkString(data, "slug", path),
-      checkBoolean(data, "active", path),
-      checkString(data, "blurb", path, maxLen = 400),
-      checkInteger(data, "version", path, allowed = 3..3),
+      hasString(data, "language", path),
+      hasString(data, "slug", path),
+      hasBoolean(data, "active", path),
+      hasString(data, "blurb", path, maxLen = 400),
+      hasInteger(data, "version", path, allowed = 3..3),
       hasValidStatus(data, path),
       hasValidOnlineEditor(data, path),
       hasValidKeyFeatures(data, path),

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -50,9 +50,9 @@ proc isUrlLike(s: string): bool =
 const
   emptySetOfStrings = initHashSet[string](0)
 
-proc checkString*(data: JsonNode; key, path: string; isRequired = true,
-                  allowed = emptySetOfStrings, checkIsUrlLike = false,
-                  maxLen = int.high): bool =
+proc hasString*(data: JsonNode; key, path: string; isRequired = true,
+                allowed = emptySetOfStrings, checkIsUrlLike = false,
+                maxLen = int.high): bool =
   result = true
   if data.hasKey(key):
     case data[key].kind
@@ -202,7 +202,7 @@ proc hasArrayOf*(data: JsonNode;
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & q(key), path)
 
-proc checkBoolean*(data: JsonNode; key, path: string; isRequired = true): bool =
+proc hasBoolean*(data: JsonNode; key, path: string; isRequired = true): bool =
   result = true
   if data.hasKey(key):
     case data[key].kind
@@ -217,8 +217,8 @@ proc checkBoolean*(data: JsonNode; key, path: string; isRequired = true): bool =
   elif isRequired:
     result.setFalseAndPrint("Missing key: " & q(key), path)
 
-proc checkInteger*(data: JsonNode; key, path: string; isRequired = true;
-                   allowed: Slice): bool =
+proc hasInteger*(data: JsonNode; key, path: string; isRequired = true;
+                 allowed: Slice): bool =
   result = true
   if data.hasKey(key):
     case data[key].kind


### PR DESCRIPTION
The `checkString`, `checkBoolean`, and `checkInteger` procs included
the `hasKey` check, so let's rename them to be consistent with
`hasArrayOf`.