### PR TITLE
lint(track_config): make `tags` check use `hasArrayOfStrings`

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -42,11 +42,8 @@ const tags = [
   "used_for/web_development",
 ].toHashSet()
 
-proc isValidTag(data: JsonNode, context: string, path: string): bool =
-  result = isString(data, context, path, allowed = tags)
-
 proc hasValidTags(data: JsonNode, path: string): bool =
-  result = hasArrayOf(data, "tags", path, isValidTag)
+  result = hasArrayOfStrings(data, "", "tags", path, allowed = tags)
 
 proc hasValidStatus(data: JsonNode, path: string): bool =
   if hasObject(data, "status", path):


### PR DESCRIPTION
PR #257 made this change possible.

This commit also improves the error message for an invalid tag.
