### PR TITLE
lint: refactor `hasArrayOfStrings` context handling

### DIFF
--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -5,10 +5,11 @@ import "."/validators
 proc hasValidFiles(data: JsonNode, path: string): bool =
   const context = "files"
   if hasObject(data, context, path):
+    let d = data[context]
     let checks = [
-      hasArrayOfStrings(data, context, "solution", path),
-      hasArrayOfStrings(data, context, "test", path),
-      hasArrayOfStrings(data, context, "exemplar", path),
+      hasArrayOfStrings(d, context, "solution", path),
+      hasArrayOfStrings(d, context, "test", path),
+      hasArrayOfStrings(d, context, "exemplar", path),
     ]
     result = allTrue(checks)
 

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -5,10 +5,11 @@ import "."/validators
 proc hasValidFiles(data: JsonNode, path: string): bool =
   const context = "files"
   if hasObject(data, context, path):
+    let d = data[context]
     let checks = [
-      hasArrayOfStrings(data, context, "solution", path),
-      hasArrayOfStrings(data, context, "test", path),
-      hasArrayOfStrings(data, context, "example", path),
+      hasArrayOfStrings(d, context, "solution", path),
+      hasArrayOfStrings(d, context, "test", path),
+      hasArrayOfStrings(d, context, "example", path),
     ]
     result = allTrue(checks)
 

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -172,17 +172,12 @@ proc hasArrayOfStrings*(data: JsonNode;
                         isRequired = true;
                         allowed = emptySetOfStrings;
                         allowedArrayLen = 1..int.high): bool =
-  ## When `context` is the empty string, returns true in any of these cases:
+  ## Returns true in any of these cases:
   ## - `isArrayOfStrings` returns true for `data[key]`.
   ## - `data` lacks the key `key` and `isRequired` is false.
-  ##
-  ## When `context` is a non-empty string, returns true in any of these cases:
-  ## - `isArrayOfStrings` returns true for `data[context][key]`.
-  ## - `data[context]` lacks the key `key` and `isRequired` is false.
-  let d = if context.len > 0: data[context] else: data
-  if d.hasKey(key, path, isRequired, context):
-    result = isArrayOfStrings(d[key], context, key, path, isRequired, allowed,
-                              allowedArrayLen)
+  if data.hasKey(key, path, isRequired, context):
+    result = isArrayOfStrings(data[key], context, key, path, isRequired,
+                              allowed, allowedArrayLen)
   elif not isRequired:
     result = true
 


### PR DESCRIPTION
This is a step towards tidying up the context handling everywhere.

--- 

This PR keeps the output of `configlet lint` the same on every track.

We only used the non-empty string context in the `hasValidFiles` procs:

```
$ git grep --break --heading --ignore-case arrayOfStrings
```

```nim
src/lint/concept_exercises.nim
10:      hasArrayOfStrings(d, context, "solution", path),
11:      hasArrayOfStrings(d, context, "test", path),
12:      hasArrayOfStrings(d, context, "exemplar", path),
20:      hasArrayOfStrings(data, "", "authors", path),
21:      hasArrayOfStrings(data, "", "contributors", path, isRequired = false),
23:      hasArrayOfStrings(data, "", "forked_from", path, isRequired = false),

src/lint/practice_exercises.nim
10:      hasArrayOfStrings(d, context, "solution", path),
11:      hasArrayOfStrings(d, context, "test", path),
12:      hasArrayOfStrings(d, context, "example", path),
21:      hasArrayOfStrings(data, "", "authors", path, isRequired = false),
22:      hasArrayOfStrings(data, "", "contributors", path, isRequired = false),

src/lint/track_config.nim
46:  result = hasArrayOfStrings(data, "", "tags", path, allowed = tags)
79:      hasArrayOfStrings(data, "", "concepts", path),
80:      hasArrayOfStrings(data, "", "prerequisites", path),
93:      hasArrayOfStrings(data, "", "practices", path,
95:      hasArrayOfStrings(data, "", "prerequisites", path,
109:      hasArrayOfStrings(exercises, "", "foregone", path, isRequired = false),

src/lint/validators.nim
131:proc isArrayOfStrings*(data: JsonNode;
170:proc hasArrayOfStrings*(data: JsonNode;
176:  ## - `isArrayOfStrings` returns true for `data[key]`.
179:    result = isArrayOfStrings(data[key], context, key, path, isRequired,
```