### PR TITLE
lint: make `path` a `distinct string`

### DIFF
--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -10,22 +10,32 @@ template withDir*(dir: string; body: untyped): untyped =
   finally:
     setCurrentDir(startDir)
 
-proc getSortedSubdirs*(dir: string): seq[string] =
+type
+  Path* {.requiresInit.} = distinct string
+
+# Borrow these two operators so that we can use `sort`.
+proc `==`(x, y: Path): bool {.borrow.}
+proc `<`(x, y: Path): bool {.borrow.}
+
+proc getSortedSubdirs*(dir: Path): seq[Path] =
   ## Returns a seq of the subdirectories of `dir`, in alphabetical order.
-  result = newSeqOfCap[string](100)
-  for kind, path in walkDir(dir):
+  result = newSeqOfCap[Path](100)
+  for kind, path in walkDir(dir.string):
     if kind == pcDir:
-      result.add path
+      result.add Path(path)
   sort result
 
-proc setFalseAndPrint*(b: var bool; description: string; details: string) =
+proc setFalseAndPrint*(b: var bool; description: string; path: Path) =
   ## Sets `b` to `false` and writes a message to stdout containing `description`
-  ## and `details`.
+  ## and `path`.
   b = false
   let descriptionPrefix = description & ":"
   if colorStdout:
     stdout.styledWriteLine(fgRed, descriptionPrefix)
   else:
     stdout.writeLine(descriptionPrefix)
-  stdout.writeLine(details)
+  stdout.writeLine(path.string)
   stdout.write "\n"
+
+proc `$`*(path: Path): string {.borrow.}
+proc `/`*(head: Path; tail: string): Path {.borrow.}

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -2,7 +2,7 @@ import std/[json, os]
 import ".."/helpers
 import "."/validators
 
-proc hasValidFiles(data: JsonNode, path: string): bool =
+proc hasValidFiles(data: JsonNode, path: Path): bool =
   const context = "files"
   if hasObject(data, context, path):
     let d = data[context]
@@ -13,7 +13,7 @@ proc hasValidFiles(data: JsonNode, path: string): bool =
     ]
     result = allTrue(checks)
 
-proc isValidConceptExerciseConfig(data: JsonNode, path: string): bool =
+proc isValidConceptExerciseConfig(data: JsonNode, path: Path): bool =
   if isObject(data, "", path):
     let checks = [
       hasString(data, "blurb", path, maxLen = 350),
@@ -25,7 +25,7 @@ proc isValidConceptExerciseConfig(data: JsonNode, path: string): bool =
     ]
     result = allTrue(checks)
 
-proc isEveryConceptExerciseConfigValid*(trackDir: string): bool =
+proc isEveryConceptExerciseConfigValid*(trackDir: Path): bool =
   let conceptExercisesDir = trackDir / "exercises" / "concept"
   result = true
   if dirExists(conceptExercisesDir):
@@ -36,7 +36,7 @@ proc isEveryConceptExerciseConfigValid*(trackDir: string): bool =
         if not isValidConceptExerciseConfig(j, configPath):
           result = false
 
-proc conceptExerciseDocsExist*(trackDir: string): bool =
+proc conceptExerciseDocsExist*(trackDir: Path): bool =
   ## Returns true if every subdirectory in `trackDir/exercises/concept` has the
   ## required Markdown files.
   const

--- a/src/lint/concepts.nim
+++ b/src/lint/concepts.nim
@@ -2,7 +2,7 @@ import std/[json, os]
 import ".."/helpers
 import "."/validators
 
-proc isValidLinkObject(data: JsonNode, context: string, path: string): bool =
+proc isValidLinkObject(data: JsonNode, context: string, path: Path): bool =
   ## Returns true if `data` is a `JObject` that satisfies all of the below:
   ## - has a `url` key, with a value that is a URL-like string.
   ## - has a `description` key, with a value that is a non-empty, non-blank
@@ -20,11 +20,11 @@ proc isValidLinkObject(data: JsonNode, context: string, path: string): bool =
     result.setFalseAndPrint("At least one element of the top-level array is " &
                             "not an object: " & $data[context], path)
 
-proc isValidLinksFile(data: JsonNode, path: string): bool =
+proc isValidLinksFile(data: JsonNode, path: Path): bool =
   result = isArrayOf(data, "", path, isValidLinkObject, isRequired = false,
                      allowedLength = 0..int.high)
 
-proc isEveryConceptLinksFileValid*(trackDir: string): bool =
+proc isEveryConceptLinksFileValid*(trackDir: Path): bool =
   let conceptsDir = trackDir / "concepts"
   result = true
 
@@ -36,7 +36,7 @@ proc isEveryConceptLinksFileValid*(trackDir: string): bool =
         if not isValidLinksFile(j, linksPath):
           result = false
 
-proc conceptDocsExist*(trackDir: string): bool =
+proc conceptDocsExist*(trackDir: Path): bool =
   ## Returns true if every subdirectory in `trackDir/concepts` has the required
   ## Markdown files.
   const

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -1,8 +1,8 @@
-import ".."/cli
+import ".."/[cli, helpers]
 import "."/[concept_exercises, concepts, practice_exercises, track_config,
             validators]
 
-proc allChecksPass(trackDir: string): bool =
+proc allChecksPass(trackDir: Path): bool =
   ## Returns true if all the linting checks pass for the track at `trackDir`.
   # We avoid some short-circuit evaluation here (e.g. due to `and`) because we
   # want to see errors from later checks even if earlier ones return `false`.
@@ -22,7 +22,7 @@ proc lint*(conf: Conf) =
        "Please re-run this command regularly to see if your track passes " &
        "the latest linting rules.\n"
 
-  let trackDir = conf.trackDir
+  let trackDir = Path(conf.trackDir)
 
   if allChecksPass(trackDir):
     echo """

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -2,7 +2,7 @@ import std/[json, os]
 import ".."/helpers
 import "."/validators
 
-proc hasValidFiles(data: JsonNode, path: string): bool =
+proc hasValidFiles(data: JsonNode, path: Path): bool =
   const context = "files"
   if hasObject(data, context, path):
     let d = data[context]
@@ -13,7 +13,7 @@ proc hasValidFiles(data: JsonNode, path: string): bool =
     ]
     result = allTrue(checks)
 
-proc isValidPracticeExerciseConfig(data: JsonNode, path: string): bool =
+proc isValidPracticeExerciseConfig(data: JsonNode, path: Path): bool =
   if isObject(data, "", path):
     # TODO: Enable the `files` checks after the tracks have had some time to update.
     let checks = [
@@ -25,7 +25,7 @@ proc isValidPracticeExerciseConfig(data: JsonNode, path: string): bool =
     ]
     result = allTrue(checks)
 
-proc isEveryPracticeExerciseConfigValid*(trackDir: string): bool =
+proc isEveryPracticeExerciseConfigValid*(trackDir: Path): bool =
   let practiceExercisesDir = trackDir / "exercises" / "practice"
   result = true
   # Return true even if the directory does not exist - this allows a future
@@ -38,7 +38,7 @@ proc isEveryPracticeExerciseConfigValid*(trackDir: string): bool =
         if not isValidPracticeExerciseConfig(j, configPath):
           result = false
 
-proc practiceExerciseDocsExist*(trackDir: string): bool =
+proc practiceExerciseDocsExist*(trackDir: Path): bool =
   ## Returns true if every subdirectory in `trackDir/exercises/practice` has the
   ## required Markdown files.
   const

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -42,10 +42,10 @@ const tags = [
   "used_for/web_development",
 ].toHashSet()
 
-proc hasValidTags(data: JsonNode, path: string): bool =
+proc hasValidTags(data: JsonNode; path: Path): bool =
   result = hasArrayOfStrings(data, "", "tags", path, allowed = tags)
 
-proc hasValidStatus(data: JsonNode, path: string): bool =
+proc hasValidStatus(data: JsonNode; path: Path): bool =
   if hasObject(data, "status", path):
     let d = data["status"]
     let checks = [
@@ -56,7 +56,7 @@ proc hasValidStatus(data: JsonNode, path: string): bool =
     ]
     result = allTrue(checks)
 
-proc hasValidOnlineEditor(data: JsonNode, path: string): bool =
+proc hasValidOnlineEditor(data: JsonNode; path: Path): bool =
   if hasObject(data, "online_editor", path):
     let d = data["online_editor"]
     const indentStyles = ["space", "tab"].toHashSet()
@@ -69,7 +69,7 @@ proc hasValidOnlineEditor(data: JsonNode, path: string): bool =
 const
   statuses = ["wip", "beta", "active", "deprecated"].toHashSet()
 
-proc isValidConceptExercise(data: JsonNode; context, path: string): bool =
+proc isValidConceptExercise(data: JsonNode; context: string; path: Path): bool =
   if isObject(data, context, path):
     let checks = [
       hasString(data, "slug", path),
@@ -82,7 +82,8 @@ proc isValidConceptExercise(data: JsonNode; context, path: string): bool =
     ]
     result = allTrue(checks)
 
-proc isValidPracticeExercise(data: JsonNode; context, path: string): bool =
+proc isValidPracticeExercise(data: JsonNode; context: string;
+                             path: Path): bool =
   if isObject(data, context, path):
     let checks = [
       hasString(data, "slug", path),
@@ -98,7 +99,7 @@ proc isValidPracticeExercise(data: JsonNode; context, path: string): bool =
     ]
     result = allTrue(checks)
 
-proc hasValidExercises(data: JsonNode; path: string): bool =
+proc hasValidExercises(data: JsonNode; path: Path): bool =
   if hasObject(data, "exercises", path):
     let exercises = data["exercises"]
     let checks = [
@@ -110,7 +111,7 @@ proc hasValidExercises(data: JsonNode; path: string): bool =
     ]
     result = allTrue(checks)
 
-proc isValidConcept(data: JsonNode, context: string, path: string): bool =
+proc isValidConcept(data: JsonNode; context: string; path: Path): bool =
   if isObject(data, context, path):
     let checks = [
       hasString(data, "uuid", path),
@@ -119,11 +120,11 @@ proc isValidConcept(data: JsonNode, context: string, path: string): bool =
     ]
     result = allTrue(checks)
 
-proc hasValidConcepts(data: JsonNode; path: string): bool =
+proc hasValidConcepts(data: JsonNode; path: Path): bool =
   result = hasArrayOf(data, "concepts", path, isValidConcept,
                       allowedLength = 0..int.high)
 
-proc isValidKeyFeature(data: JsonNode, context: string, path: string): bool =
+proc isValidKeyFeature(data: JsonNode; context: string; path: Path): bool =
   if isObject(data, context, path):
     const icons = [
       "todo",
@@ -136,11 +137,11 @@ proc isValidKeyFeature(data: JsonNode, context: string, path: string): bool =
     ]
     result = allTrue(checks)
 
-proc hasValidKeyFeatures(data: JsonNode, path: string): bool =
+proc hasValidKeyFeatures(data: JsonNode; path: Path): bool =
   result = hasArrayOf(data, "key_features", path, isValidKeyFeature,
                       isRequired = false, allowedLength = 6..6)
 
-proc isValidTrackConfig(data: JsonNode, path: string): bool =
+proc isValidTrackConfig(data: JsonNode; path: Path): bool =
   if isObject(data, "", path):
     let checks = [
       hasString(data, "language", path),
@@ -157,7 +158,7 @@ proc isValidTrackConfig(data: JsonNode, path: string): bool =
     ]
     result = allTrue(checks)
 
-proc isTrackConfigValid*(trackDir: string): bool =
+proc isTrackConfigValid*(trackDir: Path): bool =
   result = true
   let trackConfigPath = trackDir / "config.json"
   let j = parseJsonFile(trackConfigPath, result)


### PR DESCRIPTION
This gives us more type safety, and helps some implementations of the
context handling. For example: it was previously possible to write
`context` and `path` in the wrong order when calling some procs, which
might go unnoticed until it affects an error message.

We can consider doing this across the whole configlet codebase, but
let's keep it within the linting code for now.

---

This PR keeps the output of `configlet lint` the same for every track.

See the [distinct type section of the Nim Manual](https://nim-lang.github.io/Nim/manual.html#types-distinct-type) for more details.

There's a couple of places where the `borrow` is a little more awkward, so I just did a `.string` for now.

We might want `context = ""` as a parameter in some proc signatures, and this PR helps.

The `{.requiresInit.}` pragma for distinct types is silently ignored in Nim 1.4.x, but works in the current development version of Nim and will be in the next major version bump (Nim 1.6.x). It's not important for us, but it's nice to guarantee for free that we don't write
```Nim
var p: Path
```

---

The `distinct` feature in Nim is nice, and relatively uncommon in popular programming languages.

See also the correctness section of this blog post:
https://nim-lang.org/blog/2020/06/30/ray-tracing-in-nim.html