### PR TITLE
lint(validators): enforce `nimcall` for per-item procs

### DIFF
--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -184,10 +184,13 @@ proc hasArrayOfStrings*(data: JsonNode;
   elif not isRequired:
     result = true
 
+type
+  ItemCall = proc(data: JsonNode; context: string; path: Path): bool {.nimcall.}
+
 proc isArrayOf*(data: JsonNode;
                 context: string;
                 path: Path;
-                call: proc(d: JsonNode; key: string; path: Path): bool;
+                call: ItemCall;
                 isRequired = true;
                 allowedLength: Slice): bool =
   ## Returns true in any of these cases:
@@ -227,7 +230,7 @@ proc isArrayOf*(data: JsonNode;
 proc hasArrayOf*(data: JsonNode;
                  key: string;
                  path: Path;
-                 call: proc(d: JsonNode; key: string; path: Path): bool;
+                 call: ItemCall;
                  isRequired = true;
                  allowedLength: Slice = 1..int.high): bool =
   ## Returns true in any of these cases:


### PR DESCRIPTION
This makes it a compile-time error for one of these `call` procs to
capture a non-global variable. Our existing per-item validator procs
already had the `nimcall` calling convention, but this commit means
we'll notice if we accidentally make one into a `closure`, which has
more overhead.

This commit keeps the output of `configlet lint` the same for every 
track.

For more details, see the Nim Manual:
- https://nim-lang.org/docs/manual.html#types-procedural-type

Excerpts:
> A procedural type is internally a pointer to a procedure.

> A subtle issue with procedural types is that the calling convention of
  the procedure influences the type compatibility: procedural types are
  only compatible if they have the same calling convention. As a special
  extension, a procedure of the calling convention `nimcall` can be
  passed to a parameter that expects a proc of the calling convention
  `closure`.

> Nim supports these calling conventions:

> nimcall
> is the default convention used for a Nim proc. It is the same as
`fastcall`, but only for C compilers that support `fastcall`.

> closure
> is the default calling convention for a procedural type that lacks any
> pragma annotations. It indicates that the procedure has a hidden
> implicit parameter (an _environment_). Proc vars that have the calling
> convention `closure` take up two machine words: One for the proc
> pointer and another one for the pointer to implicitly passed
> environment.

> fastcall
> Fastcall means different things to different C compilers. One gets
> whatever the C `__fastcall` means.

> The default calling convention is `nimcall`, unless it is an inner proc
> (a proc inside of a proc). For an inner proc an analysis is performed
> whether it accesses its environment. If it does so, it has the calling
> convention `closure`, otherwise it has the calling convention `nimcall`.


See also [this recent Nim forum thread](https://forum.nim-lang.org/t/7738#49100), where Araq says:
> Closures have been so hard to implement correctly that no resources
> were left for an optimizing implementation. (And Nim's closure design
> predates C++11, iirc.) Eventually the compiler will get better, in the
> meantime please use the shown workarounds.

---

An example:

```Nim
proc b(p: proc: int) =
  echo p()

proc main =
  let n = 1
  proc a: int =
    n

  b(a)

main()
```

In the above, `a` is a closure because it captures `n` (which is not a global variable or a parameter of `a`). And we can pass `a` to `b` because the default calling convention for a procedural type is `closure` (and by a special rule, the `a` proc would also be accepted even if it was not a closure). The above works because the compiler makes `n` available in `b` by implicitly passing a pointer to the environment of `a`.

The output is:
```
1
```

But if we instead write the first line as
```Nim
proc b(p: proc: int {.nimcall.}) =
```

Then we get a compile-time error because `a` is a closure:
```
/tmp/foo.nim(10, 4) Error: type mismatch: got <proc (): int{.closure, noSideEffect, gcsafe, locks: 0.}>
but expected one of: 
proc b(p: proc (): int {.nimcall.})
  first type mismatch at position: 1
  required type for p: proc (): int{.nimcall.}
  but expression 'a' is of type: proc (): int{.closure, noSideEffect, gcsafe, locks: 0.}
```

The point is that it's much more difficult for the compiler to optimize the pattern that requires a hidden environment, and it's better to pass state around via parameters when possible.