### PR TITLE
lint: add more context in error messages

### DIFF
--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -3,13 +3,13 @@ import ".."/helpers
 import "."/validators
 
 proc hasValidFiles(data: JsonNode, path: Path): bool =
-  const context = "files"
-  if hasObject(data, context, path):
-    let d = data[context]
+  const k = "files"
+  if hasObject(data, k, path):
+    let d = data[k]
     let checks = [
-      hasArrayOfStrings(d, context, "solution", path),
-      hasArrayOfStrings(d, context, "test", path),
-      hasArrayOfStrings(d, context, "exemplar", path),
+      hasArrayOfStrings(d, "solution", path, k),
+      hasArrayOfStrings(d, "test", path, k),
+      hasArrayOfStrings(d, "exemplar", path, k),
     ]
     result = allTrue(checks)
 
@@ -17,10 +17,10 @@ proc isValidConceptExerciseConfig(data: JsonNode, path: Path): bool =
   if isObject(data, "", path):
     let checks = [
       hasString(data, "blurb", path, maxLen = 350),
-      hasArrayOfStrings(data, "", "authors", path),
-      hasArrayOfStrings(data, "", "contributors", path, isRequired = false),
+      hasArrayOfStrings(data, "authors", path),
+      hasArrayOfStrings(data, "contributors", path, isRequired = false),
       hasValidFiles(data, path),
-      hasArrayOfStrings(data, "", "forked_from", path, isRequired = false),
+      hasArrayOfStrings(data, "forked_from", path, isRequired = false),
       hasString(data, "language_versions", path, isRequired = false),
     ]
     result = allTrue(checks)

--- a/src/lint/concepts.nim
+++ b/src/lint/concepts.nim
@@ -10,15 +10,15 @@ proc isValidLinkObject(data: JsonNode, context: string, path: Path): bool =
   ## - if it has a `icon_url` key, the corresponding value is a URL-like string.
   if isObject(data, context, path):
     let checks = [
-      hasString(data, "url", path, checkIsUrlLike = true),
-      hasString(data, "description", path),
-      hasString(data, "icon_url", path, isRequired = false,
+      hasString(data, "url", path, context, checkIsUrlLike = true),
+      hasString(data, "description", path, context),
+      hasString(data, "icon_url", path, context, isRequired = false,
                 checkIsUrlLike = true),
     ]
     result = allTrue(checks)
   else:
     result.setFalseAndPrint("At least one element of the top-level array is " &
-                            "not an object: " & $data[context], path)
+                            "not an object: " & $data, path)
 
 proc isValidLinksFile(data: JsonNode, path: Path): bool =
   result = isArrayOf(data, "", path, isValidLinkObject, isRequired = false,

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -3,13 +3,13 @@ import ".."/helpers
 import "."/validators
 
 proc hasValidFiles(data: JsonNode, path: Path): bool =
-  const context = "files"
-  if hasObject(data, context, path):
-    let d = data[context]
+  const k = "files"
+  if hasObject(data, k, path):
+    let d = data[k]
     let checks = [
-      hasArrayOfStrings(d, context, "solution", path),
-      hasArrayOfStrings(d, context, "test", path),
-      hasArrayOfStrings(d, context, "example", path),
+      hasArrayOfStrings(d, "solution", path, k),
+      hasArrayOfStrings(d, "test", path, k),
+      hasArrayOfStrings(d, "example", path, k),
     ]
     result = allTrue(checks)
 
@@ -18,8 +18,8 @@ proc isValidPracticeExerciseConfig(data: JsonNode, path: Path): bool =
     # TODO: Enable the `files` checks after the tracks have had some time to update.
     let checks = [
       hasString(data, "blurb", path, maxLen = 350),
-      hasArrayOfStrings(data, "", "authors", path, isRequired = false),
-      hasArrayOfStrings(data, "", "contributors", path, isRequired = false),
+      hasArrayOfStrings(data, "authors", path, isRequired = false),
+      hasArrayOfStrings(data, "contributors", path, isRequired = false),
       if false: hasValidFiles(data, path) else: true,
       hasString(data, "language_versions", path, isRequired = false),
     ]

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -43,26 +43,28 @@ const tags = [
 ].toHashSet()
 
 proc hasValidTags(data: JsonNode; path: Path): bool =
-  result = hasArrayOfStrings(data, "", "tags", path, allowed = tags)
+  result = hasArrayOfStrings(data, "tags", path, allowed = tags)
 
 proc hasValidStatus(data: JsonNode; path: Path): bool =
-  if hasObject(data, "status", path):
-    let d = data["status"]
+  const k = "status"
+  if hasObject(data, k, path):
+    let d = data[k]
     let checks = [
-      hasBoolean(d, "concept_exercises", path),
-      hasBoolean(d, "test_runner", path),
-      hasBoolean(d, "representer", path),
-      hasBoolean(d, "analyzer", path),
+      hasBoolean(d, "concept_exercises", path, k),
+      hasBoolean(d, "test_runner", path, k),
+      hasBoolean(d, "representer", path, k),
+      hasBoolean(d, "analyzer", path, k),
     ]
     result = allTrue(checks)
 
 proc hasValidOnlineEditor(data: JsonNode; path: Path): bool =
-  if hasObject(data, "online_editor", path):
-    let d = data["online_editor"]
+  const k = "online_editor"
+  if hasObject(data, k, path):
+    let d = data[k]
     const indentStyles = ["space", "tab"].toHashSet()
     let checks = [
-      hasString(d, "indent_style", path, allowed = indentStyles),
-      hasInteger(d, "indent_size", path, allowed = 0..8),
+      hasString(d, "indent_style", path, k, allowed = indentStyles),
+      hasInteger(d, "indent_size", path, k, allowed = 0..8),
     ]
     result = allTrue(checks)
 
@@ -72,13 +74,14 @@ const
 proc isValidConceptExercise(data: JsonNode; context: string; path: Path): bool =
   if isObject(data, context, path):
     let checks = [
-      hasString(data, "slug", path),
-      hasString(data, "name", path),
-      hasString(data, "uuid", path),
-      hasBoolean(data, "deprecated", path, isRequired = false),
-      hasArrayOfStrings(data, "", "concepts", path),
-      hasArrayOfStrings(data, "", "prerequisites", path),
-      hasString(data, "status", path, isRequired = false, allowed = statuses),
+      hasString(data, "slug", path, context),
+      hasString(data, "name", path, context),
+      hasString(data, "uuid", path, context),
+      hasBoolean(data, "deprecated", path, context, isRequired = false),
+      hasArrayOfStrings(data, "concepts", path, context),
+      hasArrayOfStrings(data, "prerequisites", path, context),
+      hasString(data, "status", path, context, isRequired = false,
+                allowed = statuses),
     ]
     result = allTrue(checks)
 
@@ -86,37 +89,39 @@ proc isValidPracticeExercise(data: JsonNode; context: string;
                              path: Path): bool =
   if isObject(data, context, path):
     let checks = [
-      hasString(data, "slug", path),
-      hasString(data, "name", path),
-      hasString(data, "uuid", path),
-      hasBoolean(data, "deprecated", path, isRequired = false),
-      hasInteger(data, "difficulty", path, allowed = 0..10),
-      hasArrayOfStrings(data, "", "practices", path,
+      hasString(data, "slug", path, context),
+      hasString(data, "name", path, context),
+      hasString(data, "uuid", path, context),
+      hasBoolean(data, "deprecated", path, context, isRequired = false),
+      hasInteger(data, "difficulty", path, context, allowed = 0..10),
+      hasArrayOfStrings(data, "practices", path, context,
                         allowedArrayLen = 0..int.high),
-      hasArrayOfStrings(data, "", "prerequisites", path,
+      hasArrayOfStrings(data, "prerequisites", path, context,
                         allowedArrayLen = 0..int.high),
-      hasString(data, "status", path, isRequired = false, allowed = statuses),
+      hasString(data, "status", path, context, isRequired = false,
+                allowed = statuses),
     ]
     result = allTrue(checks)
 
 proc hasValidExercises(data: JsonNode; path: Path): bool =
-  if hasObject(data, "exercises", path):
-    let exercises = data["exercises"]
+  const k = "exercises"
+  if hasObject(data, k, path):
+    let exercises = data[k]
     let checks = [
-      hasArrayOf(exercises, "concept", path, isValidConceptExercise,
+      hasArrayOf(exercises, "concept", path, isValidConceptExercise, k,
                  allowedLength = 0..int.high),
-      hasArrayOf(exercises, "practice", path, isValidPracticeExercise,
+      hasArrayOf(exercises, "practice", path, isValidPracticeExercise, k,
                  allowedLength = 0..int.high),
-      hasArrayOfStrings(exercises, "", "foregone", path, isRequired = false),
+      hasArrayOfStrings(exercises, "foregone", path, k, isRequired = false),
     ]
     result = allTrue(checks)
 
 proc isValidConcept(data: JsonNode; context: string; path: Path): bool =
   if isObject(data, context, path):
     let checks = [
-      hasString(data, "uuid", path),
-      hasString(data, "slug", path),
-      hasString(data, "name", path),
+      hasString(data, "uuid", path, context),
+      hasString(data, "slug", path, context),
+      hasString(data, "name", path, context),
     ]
     result = allTrue(checks)
 
@@ -131,9 +136,10 @@ proc isValidKeyFeature(data: JsonNode; context: string; path: Path): bool =
     ].toHashSet()
     # TODO: Enable the `icon` checks when we have a list of valid icons.
     let checks = [
-      if false: hasString(data, "icon", path, allowed = icons) else: true,
-      hasString(data, "title", path, maxLen = 25),
-      hasString(data, "content", path, maxLen = 100),
+      if false: hasString(data, "icon", path, context,
+                          allowed = icons) else: true,
+      hasString(data, "title", path, context, maxLen = 25),
+      hasString(data, "content", path, context, maxLen = 100),
     ]
     result = allTrue(checks)
 

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -14,7 +14,7 @@ func q*(s: string): string =
   else:
     "root"
 
-func concat(context, key: string): string =
+func joinWithDot(context, key: string): string =
   if context.len > 0:
     &"{context}.{key}"
   else:
@@ -42,7 +42,8 @@ proc isObject*(data: JsonNode; key: string; path: Path; context = ""): bool =
   if data.kind == JObject:
     result = true
   else:
-    result.setFalseAndPrint(&"The value of {format(context, key)} is not an object", path)
+    result.setFalseAndPrint(&"The value of {format(context, key)} is not an object",
+                            path)
 
 proc hasObject*(data: JsonNode; key: string; path: Path; context = "";
                 isRequired = true): bool =
@@ -60,9 +61,9 @@ proc hasValidRuneLength(s, key: string; path: Path; context: string;
     if sRuneLen > maxLen:
       const truncLen = 25
       let sTrunc = if sRuneLen > truncLen: s.runeSubStr(0, truncLen) else: s
-      let msg = &"The value of {format(context, key)} that starts with {q sTrunc}... is " &
-                &"{sRuneLen} characters, but it must not exceed {maxLen} " &
-                 "characters"
+      let msg = &"The value of {format(context, key)} that starts with " &
+                &"{q sTrunc}... is {sRuneLen} characters, but it must not " &
+                &"exceed {maxLen} characters"
       result.setFalseAndPrint(msg, path)
 
 proc isUrlLike(s: string): bool =
@@ -188,7 +189,7 @@ proc hasArrayOfStrings*(data: JsonNode;
   ## - `isArrayOfStrings` returns true for `data[key]`.
   ## - `data` lacks the key `key` and `isRequired` is false.
   if data.hasKey(key, path, context, isRequired):
-    let contextAndKey = concat(context, key)
+    let contextAndKey = joinWithDot(context, key)
     result = isArrayOfStrings(data[key], contextAndKey, path, isRequired,
                               allowed, allowedArrayLen)
   elif not isRequired:
@@ -248,8 +249,9 @@ proc hasArrayOf*(data: JsonNode;
   ## - `isArrayOf` returns true for `data[key]`.
   ## - `data` lacks the key `key` and `isRequired` is false.
   if data.hasKey(key, path, context, isRequired):
-    let contextAndKey = concat(context, key)
-    result = isArrayOf(data[key], contextAndKey, path, call, isRequired, allowedLength)
+    let contextAndKey = joinWithDot(context, key)
+    result = isArrayOf(data[key], contextAndKey, path, call, isRequired,
+                       allowedLength)
   elif not isRequired:
     result = true
 

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -14,17 +14,23 @@ func q*(s: string): string =
   else:
     "root"
 
+func concat(context, key: string): string =
+  if context.len > 0:
+    &"{context}.{key}"
+  else:
+    key
+
 const
   qNull* = q("null") # So we don't have to write &"""Foo is {q "null"}""" later
 
-func format(context, key: string): string =
+func format*(context, key: string): string =
   if context.len > 0:
     q(&"{context}.{key}")
   else:
     q(key)
 
-proc hasKey(data: JsonNode; key: string; path: Path; isRequired: bool;
-            context = ""): bool =
+proc hasKey(data: JsonNode; key: string; path: Path; context: string;
+            isRequired: bool): bool =
   ## Returns true if `data` contains the key `key`. Otherwise, returns false
   ## and, if `isRequired` is true, prints an error message.
   if data.hasKey(key):
@@ -32,20 +38,21 @@ proc hasKey(data: JsonNode; key: string; path: Path; isRequired: bool;
   elif isRequired:
     result.setFalseAndPrint(&"The {format(context, key)} key is missing", path)
 
-proc isObject*(data: JsonNode; context: string; path: Path): bool =
+proc isObject*(data: JsonNode; key: string; path: Path; context = ""): bool =
   if data.kind == JObject:
     result = true
   else:
-    result.setFalseAndPrint(&"The value of {q context} is not an object", path)
+    result.setFalseAndPrint(&"The value of {format(context, key)} is not an object", path)
 
-proc hasObject*(data: JsonNode; key: string; path: Path;
+proc hasObject*(data: JsonNode; key: string; path: Path; context = "";
                 isRequired = true): bool =
-  if data.hasKey(key, path, isRequired):
+  if data.hasKey(key, path, context, isRequired):
     result = isObject(data[key], key, path)
   elif not isRequired:
     result = true
 
-proc hasValidRuneLength(s, key: string; path: Path; maxLen: int): bool =
+proc hasValidRuneLength(s, key: string; path: Path; context: string;
+                        maxLen: int): bool =
   ## Returns true if `s` has a rune length that does not exceed `maxLen`.
   result = true
   if s.len > maxLen:
@@ -53,7 +60,7 @@ proc hasValidRuneLength(s, key: string; path: Path; maxLen: int): bool =
     if sRuneLen > maxLen:
       const truncLen = 25
       let sTrunc = if sRuneLen > truncLen: s.runeSubStr(0, truncLen) else: s
-      let msg = &"The value of {q key} that starts with {q sTrunc}... is " &
+      let msg = &"The value of {format(context, key)} that starts with {q sTrunc}... is " &
                 &"{sRuneLen} characters, but it must not exceed {maxLen} " &
                  "characters"
       result.setFalseAndPrint(msg, path)
@@ -67,9 +74,10 @@ proc isUrlLike(s: string): bool =
 const
   emptySetOfStrings = initHashSet[string](0)
 
-proc isString*(data: JsonNode; key: string; path: Path; isRequired = true;
-               allowed = emptySetOfStrings; checkIsUrlLike = false;
-               maxLen = int.high; isInArray = false): bool =
+proc isString*(data: JsonNode; key: string; path: Path; context: string;
+               isRequired = true; allowed = emptySetOfStrings;
+               checkIsUrlLike = false; maxLen = int.high;
+               isInArray = false): bool =
   result = true
   case data.kind
   of JString:
@@ -78,9 +86,9 @@ proc isString*(data: JsonNode; key: string; path: Path; isRequired = true;
       if s notin allowed:
         let msgStart =
           if isInArray:
-            &"The {q key} array contains {q s}, which is not one of "
+            &"The {format(context, key)} array contains {q s}, which is not one of "
           else:
-            &"The value of {q key} is {q s}, but it must be one of "
+            &"The value of {format(context, key)} is {q s}, but it must be one of "
         let msgEnd =
           if allowed.len < 6:
             $allowed
@@ -92,45 +100,45 @@ proc isString*(data: JsonNode; key: string; path: Path; isRequired = true;
         result.setFalseAndPrint(&"Not a valid URL: {q s}", path)
     elif s.len > 0:
       if not isEmptyOrWhitespace(s):
-        if not hasValidRuneLength(s, key, path, maxLen):
+        if not hasValidRuneLength(s, key, path, context, maxLen):
           result = false
       else:
         let msg =
           if isInArray:
-            &"The {q key} array contains a whitespace-only string"
+            &"The {format(context, key)} array contains a whitespace-only string"
           else:
-            &"The value of {q key} is a whitespace-only string"
+            &"The value of {format(context, key)} is a whitespace-only string"
         result.setFalseAndPrint(msg, path)
     else:
       let msg =
         if isInArray:
-          &"The {q key} array contains a zero-length string"
+          &"The {format(context, key)} array contains a zero-length string"
         else:
-          &"The value of {q key} is a zero-length string"
+          &"The value of {format(context, key)} is a zero-length string"
       result.setFalseAndPrint(msg, path)
   of JNull:
     if isRequired:
-      result.setFalseAndPrint(&"The value of {q key} is {qNull}, " &
+      result.setFalseAndPrint(&"The value of {format(context, key)} is {qNull}, " &
                                "but it must be a string", path)
   else:
     let msg =
       if isInArray:
-        &"The {q key} array contains a non-string: {q $data}"
+        &"The {format(context, key)} array contains a non-string: {q $data}"
       else:
-        &"The value of {q key} is {q $data}, but it must be a string"
+        &"The value of {format(context, key)} is {q $data}, but it must be a string"
     result.setFalseAndPrint(msg, path)
 
-proc hasString*(data: JsonNode; key: string; path: Path; isRequired = true;
-                allowed = emptySetOfStrings; checkIsUrlLike = false;
-                maxLen = int.high): bool =
-  if data.hasKey(key, path, isRequired):
-    result = isString(data[key], key, path, isRequired, allowed, checkIsUrlLike,
-                      maxLen)
+proc hasString*(data: JsonNode; key: string; path: Path; context = "";
+                isRequired = true; allowed = emptySetOfStrings;
+                checkIsUrlLike = false; maxLen = int.high): bool =
+  if data.hasKey(key, path, context, isRequired):
+    result = isString(data[key], key, path, context, isRequired, allowed,
+                      checkIsUrlLike, maxLen)
   elif not isRequired:
     result = true
 
 proc isArrayOfStrings*(data: JsonNode;
-                       context, key: string;
+                       context: string;
                        path: Path;
                        isRequired = true;
                        allowed: HashSet[string];
@@ -143,15 +151,15 @@ proc isArrayOfStrings*(data: JsonNode;
 
   case data.kind
   of JArray:
-    let k = if context.len > 0: &"{context}.{key}" else: key
     let arrayLen = data.len
     if arrayLen > 0:
       if arrayLen in allowedArrayLen:
         for item in data:
-          if not isString(item, k, path, isRequired, allowed, isInArray = true):
+          if not isString(item, context, path, "", isRequired, allowed,
+                          isInArray = true):
             result = false
       else:
-        let msgStart = &"The {q k} array has length {arrayLen}, " &
+        let msgStart = &"The {q context} array has length {arrayLen}, " &
                         "but it must have length "
         let msgEnd =
           if allowedArrayLen.len == 1:
@@ -160,26 +168,28 @@ proc isArrayOfStrings*(data: JsonNode;
             &"between {allowedArrayLen.a} and {allowedArrayLen.b} (inclusive)"
     elif isRequired:
       if 0 notin allowedArrayLen:
-        result.setFalseAndPrint(&"The {q k} array is empty", path)
+        result.setFalseAndPrint(&"The {q context} array is empty", path)
   of JNull:
     if isRequired:
-      result.setFalseAndPrint(&"The value of {format(context, key)} is " &
+      result.setFalseAndPrint(&"The value of {q context} is " &
                               &"{qNull}, but it must be an array", path)
   else:
-    result.setFalseAndPrint(&"The value of {format(context, key)} is " &
+    result.setFalseAndPrint(&"The value of {q context} is " &
                              "not an array", path)
 
 proc hasArrayOfStrings*(data: JsonNode;
-                        context, key: string;
+                        key: string;
                         path: Path;
+                        context = "";
                         isRequired = true;
                         allowed = emptySetOfStrings;
                         allowedArrayLen = 1..int.high): bool =
   ## Returns true in any of these cases:
   ## - `isArrayOfStrings` returns true for `data[key]`.
   ## - `data` lacks the key `key` and `isRequired` is false.
-  if data.hasKey(key, path, isRequired, context):
-    result = isArrayOfStrings(data[key], context, key, path, isRequired,
+  if data.hasKey(key, path, context, isRequired):
+    let contextAndKey = concat(context, key)
+    result = isArrayOfStrings(data[key], contextAndKey, path, isRequired,
                               allowed, allowedArrayLen)
   elif not isRequired:
     result = true
@@ -231,17 +241,19 @@ proc hasArrayOf*(data: JsonNode;
                  key: string;
                  path: Path;
                  call: ItemCall;
+                 context = "";
                  isRequired = true;
                  allowedLength: Slice = 1..int.high): bool =
   ## Returns true in any of these cases:
   ## - `isArrayOf` returns true for `data[key]`.
   ## - `data` lacks the key `key` and `isRequired` is false.
-  if data.hasKey(key, path, isRequired):
-    result = isArrayOf(data[key], key, path, call, isRequired, allowedLength)
+  if data.hasKey(key, path, context, isRequired):
+    let contextAndKey = concat(context, key)
+    result = isArrayOf(data[key], contextAndKey, path, call, isRequired, allowedLength)
   elif not isRequired:
     result = true
 
-proc isBoolean*(data: JsonNode; key: string; path: Path;
+proc isBoolean*(data: JsonNode; key: string; path: Path; context: string;
                 isRequired = true): bool =
   result = true
   case data.kind
@@ -249,27 +261,27 @@ proc isBoolean*(data: JsonNode; key: string; path: Path;
     return true
   of JNull:
     if isRequired:
-      result.setFalseAndPrint(&"The value of {q key} is {qNull}, " &
+      result.setFalseAndPrint(&"The value of {format(context, key)} is {qNull}, " &
                                "but it must be a bool", path)
   else:
-    result.setFalseAndPrint(&"The value of {q key} is {q $data}, " &
+    result.setFalseAndPrint(&"The value of {format(context, key)} is {q $data}, " &
                              "but it must be a bool", path)
 
-proc hasBoolean*(data: JsonNode; key: string; path: Path;
+proc hasBoolean*(data: JsonNode; key: string; path: Path; context = "";
                  isRequired = true): bool =
-  if data.hasKey(key, path, isRequired):
-    result = isBoolean(data[key], key, path, isRequired)
+  if data.hasKey(key, path, context, isRequired):
+    result = isBoolean(data[key], key, path, context, isRequired)
   elif not isRequired:
     result = true
 
-proc isInteger*(data: JsonNode; key: string; path: Path; isRequired = true;
-                allowed: Slice): bool =
+proc isInteger*(data: JsonNode; key: string; path: Path; context: string;
+                isRequired = true; allowed: Slice): bool =
   result = true
   case data.kind
   of JInt:
     let num = data.getInt()
     if num notin allowed:
-      let msgStart = &"The value of {q key} is {num}, but it must be "
+      let msgStart = &"The value of {format(context, key)} is {num}, but it must be "
       let msgEnd =
         if allowed.len == 1:
           &"{allowed.a}"
@@ -278,16 +290,16 @@ proc isInteger*(data: JsonNode; key: string; path: Path; isRequired = true;
       result.setFalseAndPrint(msgStart & msgEnd, path)
   of JNull:
     if isRequired:
-      result.setFalseAndPrint(&"The value of {q key} is {qNull}, " &
+      result.setFalseAndPrint(&"The value of {format(context, key)} is {qNull}, " &
                                "but it must be an integer", path)
   else:
-    result.setFalseAndPrint(&"The value of {q key} is {q $data}, " &
+    result.setFalseAndPrint(&"The value of {format(context, key)} is {q $data}, " &
                              "but it must be an integer", path)
 
-proc hasInteger*(data: JsonNode; key: string; path: Path; isRequired = true;
-                 allowed: Slice): bool =
-  if data.hasKey(key, path, isRequired):
-    result = isInteger(data[key], key, path, isRequired, allowed)
+proc hasInteger*(data: JsonNode; key: string; path: Path; context = "";
+                 isRequired = true; allowed: Slice): bool =
+  if data.hasKey(key, path, context, isRequired):
+    result = isInteger(data[key], key, path, context, isRequired, allowed)
   elif not isRequired:
     result = true
 


### PR DESCRIPTION
I'm not exactly happy with the implementation yet, but I think we can tidy it up later. And this at least produces better output.

But some of these error messages are still a bit unclear/confusing, especially the ones that are in arrays.

If we stick with the current approach, I'm leaning towards making `context` a required parameter everywhere (without a default value of `""`). I think the benefit of ensuring that we don't forget to write `context` somewhere is worth the cost of the extra verbosity at the callsite.

---

This PR produces the following diff to the output of `configlet lint`:

#### bash
```diff
-The `practices` key is missing:
+The `exercises.practice.practices` key is missing:
```

#### clojure
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### common-lisp
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### cpp
```diff
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `prerequisites` array contains a zero-length string:
+The `exercises.concept.prerequisites` array contains a zero-length string:
```

#### csharp
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### dart
```diff
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `prerequisites` key is missing:
+The `exercises.concept.prerequisites` key is missing:
```

#### elixir
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
-The `concepts` array is empty:
+The `exercises.concept.concepts` array is empty:
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### elm
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### fsharp
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### go
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### j
```diff
-The `difficulty` key is missing:
+The `exercises.practice.difficulty` key is missing:
-The `difficulty` key is missing:
+The `exercises.practice.difficulty` key is missing:
-The `difficulty` key is missing:
+The `exercises.practice.difficulty` key is missing:
-The `difficulty` key is missing:
+The `exercises.practice.difficulty` key is missing:
-The `difficulty` key is missing:
+The `exercises.practice.difficulty` key is missing:
-The `difficulty` key is missing:
+The `exercises.practice.difficulty` key is missing:
-The `difficulty` key is missing:
+The `exercises.practice.difficulty` key is missing:
```

#### java
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
```

#### javascript
```diff
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
```

#### julia
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
```

#### kotlin
```diff
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### lua
```diff
-The value of `content` that starts with `Lua is primarily designed`... is 167 characters, but it must not exceed 100 characters:
+The value of `key_features.content` that starts with `Lua is primarily designed`... is 167 characters, but it must not exceed 100 characters:
-The value of `content` that starts with `Lua is known to be one of`... is 149 characters, but it must not exceed 100 characters:
+The value of `key_features.content` that starts with `Lua is known to be one of`... is 149 characters, but it must not exceed 100 characters:
-The value of `content` that starts with `Lua has a simple, yet pow`... is 112 characters, but it must not exceed 100 characters:
+The value of `key_features.content` that starts with `Lua has a simple, yet pow`... is 112 characters, but it must not exceed 100 characters:
-The value of `content` that starts with `Lua offers a small, yet f`... is 133 characters, but it must not exceed 100 characters:
+The value of `key_features.content` that starts with `Lua offers a small, yet f`... is 133 characters, but it must not exceed 100 characters:
```

#### purescript
```diff
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### python
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### ruby
```diff
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `concepts` array is empty:
+The `exercises.concept.concepts` array is empty:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `concepts` array is empty:
+The `exercises.concept.concepts` array is empty:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
```

#### rust
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### swift
```diff
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### x86-64-assembly
```diff
-The `name` key is missing:
+The `exercises.concept.name` key is missing:
-The `prerequisites` array is empty:
+The `exercises.concept.prerequisites` array is empty:
```

#### zig
```diff
-The `practices` key is missing:
+The `exercises.practice.practices` key is missing:
```

---

See below for the full `configlet lint` output.

### Tracks that exit with 0

```
c
delphi
nim
pharo-smalltalk
php
reasonml
shen
tcl
```



### Tracks that exit with 1

<details>
  <summary>click to expand</summary>

#### 05ab1e
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### ada
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### arm64-assembly
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### babashka
```
The `tags` array is empty:
./config.json
```




#### ballerina
```
The `tags` array is empty:
./config.json

Missing file:
./exercises/practice/calculator-service/.docs/instructions.md

Missing file:
./exercises/practice/echo-service/.docs/instructions.md

Missing file:
./exercises/practice/greeting-service/.docs/instructions.md

Missing file:
./exercises/practice/hello-world-service/.docs/instructions.md

Missing file:
./exercises/practice/legacy-service-client/.docs/instructions.md

Missing file:
./exercises/practice/order-management/.docs/instructions.md

Missing file:
./exercises/practice/service-composition/.docs/instructions.md

Missing file:
./exercises/practice/service-invocation/.docs/instructions.md

The `blurb` key is missing:
./exercises/practice/calculator-service/.meta/config.json

The `blurb` key is missing:
./exercises/practice/echo-service/.meta/config.json

The `blurb` key is missing:
./exercises/practice/greeting-service/.meta/config.json

The `blurb` key is missing:
./exercises/practice/hello-world-service/.meta/config.json

The `blurb` key is missing:
./exercises/practice/legacy-service-client/.meta/config.json

The `blurb` key is missing:
./exercises/practice/order-management/.meta/config.json

The `blurb` key is missing:
./exercises/practice/service-composition/.meta/config.json

The `blurb` key is missing:
./exercises/practice/service-invocation/.meta/config.json
```




#### bash
```
The `exercises.practice.practices` key is missing:
./config.json

The `blurb` key is missing:
./exercises/practice/list-ops/.meta/config.json
```




#### ceylon
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### cfml
```
The `tags` array is empty:
./config.json
```




#### clojure
```
The `exercises.concept.prerequisites` array is empty:
./config.json

The `tags` array is empty:
./config.json

Missing file:
./exercises/concept/bird-watcher/.docs/hints.md

Missing file:
./exercises/concept/cars-assemble/.docs/hints.md

Missing file:
./exercises/concept/interest-is-interesting/.docs/hints.md

Missing file:
./exercises/concept/international-calling-connoisseur/.docs/hints.md

Missing file:
./exercises/concept/international-calling-connoisseur/.docs/introduction.md

Missing file:
./exercises/concept/log-levels/.docs/hints.md

Missing file:
./exercises/concept/squeaky-clean/.docs/hints.md

Missing file:
./exercises/concept/squeaky-clean/.docs/introduction.md

File is empty, but must contain at least the empty array, `[]`:
./concepts/basics/links.json

The `files.solution` array is empty:
./exercises/concept/annalyns-infiltration/.meta/config.json

The `files.test` array is empty:
./exercises/concept/annalyns-infiltration/.meta/config.json

The `files.solution` array is empty:
./exercises/concept/bird-watcher/.meta/config.json

The `files.test` array is empty:
./exercises/concept/bird-watcher/.meta/config.json

The `files.exemplar` array is empty:
./exercises/concept/bird-watcher/.meta/config.json

The `files.solution` array is empty:
./exercises/concept/cars-assemble/.meta/config.json

The `files.test` array is empty:
./exercises/concept/cars-assemble/.meta/config.json

Missing file:
./exercises/concept/interest-is-interesting/.meta/config.json

Missing file:
./exercises/concept/international-calling-connoisseur/.meta/config.json

The `files.solution` array is empty:
./exercises/concept/log-levels/.meta/config.json

The `files.test` array is empty:
./exercises/concept/log-levels/.meta/config.json

The `files.solution` array is empty:
./exercises/concept/lucians-luscious-lasagna/.meta/config.json

The `files.test` array is empty:
./exercises/concept/lucians-luscious-lasagna/.meta/config.json

Missing file:
./exercises/concept/squeaky-clean/.meta/config.json

The `authors` key is missing:
./exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json

The `files.solution` array is empty:
./exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json

The `files.test` array is empty:
./exercises/concept/tracks-on-tracks-on-tracks/.meta/config.json
```




#### clojurescript
```
The `tags` array is empty:
./config.json
```




#### coffeescript
```
The `tags` array is empty:
./config.json
```




#### common-lisp
```
The `exercises.concept.prerequisites` array is empty:
./config.json

Missing file:
./concepts/algorithms/about.md

Missing file:
./concepts/algorithms/introduction.md

Missing file:
./concepts/bitwise-operations/about.md

Missing file:
./concepts/bitwise-operations/introduction.md

Missing file:
./concepts/dates/about.md

Missing file:
./concepts/dates/introduction.md

Missing file:
./concepts/filtering/about.md

Missing file:
./concepts/filtering/introduction.md

Missing file:
./concepts/games/about.md

Missing file:
./concepts/games/introduction.md

Missing file:
./concepts/interfaces/about.md

Missing file:
./concepts/interfaces/introduction.md

Missing file:
./concepts/iteration/about.md

Missing file:
./concepts/iteration/introduction.md

Missing file:
./concepts/logic/about.md

Missing file:
./concepts/logic/introduction.md

Missing file:
./concepts/loop/about.md

Missing file:
./concepts/loop/introduction.md

Missing file:
./concepts/maps/about.md

Missing file:
./concepts/maps/introduction.md

Missing file:
./concepts/parsing/about.md

Missing file:
./concepts/parsing/introduction.md

Missing file:
./concepts/randomness/about.md

Missing file:
./concepts/randomness/introduction.md

Missing file:
./concepts/sequences/about.md

Missing file:
./concepts/sequences/introduction.md

Missing file:
./concepts/sorting/about.md

Missing file:
./concepts/sorting/introduction.md

Missing file:
./concepts/text-formatting/about.md

Missing file:
./concepts/text-formatting/introduction.md

Missing file:
./concepts/time/about.md

Missing file:
./concepts/time/introduction.md

Missing file:
./concepts/transforming/about.md

Missing file:
./concepts/transforming/introduction.md

Missing file:
./concepts/algorithms/links.json

Missing file:
./concepts/bitwise-operations/links.json

Missing file:
./concepts/dates/links.json

Missing file:
./concepts/filtering/links.json

Missing file:
./concepts/games/links.json

Missing file:
./concepts/interfaces/links.json

Missing file:
./concepts/iteration/links.json

Missing file:
./concepts/logic/links.json

Missing file:
./concepts/loop/links.json

Missing file:
./concepts/maps/links.json

Missing file:
./concepts/parsing/links.json

Missing file:
./concepts/randomness/links.json

Missing file:
./concepts/sequences/links.json

Missing file:
./concepts/sorting/links.json

Missing file:
./concepts/text-formatting/links.json

Missing file:
./concepts/time/links.json

Missing file:
./concepts/transforming/links.json
```




#### coq
```
The `tags` array is empty:
./config.json

Missing file:
./exercises/practice/tautology/.docs/instructions.md
```




#### cpp
```
The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.prerequisites` array contains a zero-length string:
./config.json

The `tags` array is empty:
./config.json

The `files.solution` array is empty:
./exercises/concept/strings/.meta/config.json

The `files.test` array is empty:
./exercises/concept/strings/.meta/config.json
```




#### crystal
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### csharp
```
The `exercises.concept.prerequisites` array is empty:
./config.json
```




#### d
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### dart
```
The value of `online_editor` is not an object:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.prerequisites` array is empty:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.prerequisites` key is missing:
./config.json

The `tags` array is empty:
./config.json

Missing file:
./exercises/concept/futures/.meta/config.json

Missing file:
./exercises/concept/numbers/.meta/config.json

Missing file:
./exercises/concept/strings/.meta/config.json
```




#### elixir
```
The `exercises.concept.prerequisites` array is empty:
./config.json

The `exercises.concept.concepts` array is empty:
./config.json

The `exercises.concept.prerequisites` array is empty:
./config.json
```




#### elm
```
The `exercises.concept.prerequisites` array is empty:
./config.json
```




#### emacs-lisp
```
The `tags` array is empty:
./config.json
```




#### erlang
```
Missing file:
./exercises/practice/bracket-push/.docs/instructions.md

The `blurb` key is missing:
./exercises/practice/bracket-push/.meta/config.json
```




#### factor
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### forth
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### fortran
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### fsharp
```
The `exercises.concept.prerequisites` array is empty:
./config.json
```




#### gleam
```
The `tags` array is empty:
./config.json
```




#### gnu-apl
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### go
```
The `exercises.concept.prerequisites` array is empty:
./config.json

The `blurb` key is missing:
./exercises/concept/chessboard/.meta/config.json

The `blurb` key is missing:
./exercises/concept/the-farm/.meta/config.json
```




#### groovy
```
The `tags` array is empty:
./config.json
```




#### haskell
```
The `tags` array is empty:
./config.json
```




#### haxe
```
The value of `blurb` that starts with `Haxe is an open source hi`... is 423 characters, but it must not exceed 400 characters:
./config.json

The value of root is not an array:
./concepts/abstract-types/links.json

The value of root is not an array:
./concepts/array-comprehension/links.json

The value of root is not an array:
./concepts/arrays/links.json

The value of root is not an array:
./concepts/basics/links.json

The value of root is not an array:
./concepts/bit-manipulation/links.json

The value of root is not an array:
./concepts/chars/links.json

The value of root is not an array:
./concepts/classes/links.json

The value of root is not an array:
./concepts/constructors/links.json

The value of root is not an array:
./concepts/datetimes/links.json

The value of root is not an array:
./concepts/do-while-loops/links.json

The value of root is not an array:
./concepts/enums/links.json

The value of root is not an array:
./concepts/equality/links.json

The value of root is not an array:
./concepts/exceptions/links.json

The value of root is not an array:
./concepts/final/links.json

The value of root is not an array:
./concepts/flag-enums/links.json

The value of root is not an array:
./concepts/floating-point-numbers/links.json

The value of root is not an array:
./concepts/for-loops/links.json

The value of root is not an array:
./concepts/foreach-loops/links.json

The value of root is not an array:
./concepts/generic-types/links.json

The value of root is not an array:
./concepts/if-statements/links.json

The value of root is not an array:
./concepts/indexers/links.json

The value of root is not an array:
./concepts/inheritance/links.json

The value of root is not an array:
./concepts/integral-numbers/links.json

The value of root is not an array:
./concepts/interfaces/links.json

The value of root is not an array:
./concepts/iterators/links.json

The value of root is not an array:
./concepts/lambda/links.json

The value of root is not an array:
./concepts/lists/links.json

The value of root is not an array:
./concepts/maps/links.json

The value of root is not an array:
./concepts/nullability/links.json

The value of root is not an array:
./concepts/numbers/links.json

The value of root is not an array:
./concepts/operator-overloading/links.json

The value of root is not an array:
./concepts/option-type/links.json

The value of root is not an array:
./concepts/optional-arguments/links.json

The value of root is not an array:
./concepts/pattern-matching/links.json

The value of root is not an array:
./concepts/properties/links.json

The value of root is not an array:
./concepts/randomness/links.json

The value of root is not an array:
./concepts/reflection/links.json

The value of root is not an array:
./concepts/regular-expressions/links.json

The value of root is not an array:
./concepts/rest-args/links.json

The value of root is not an array:
./concepts/string-buffer/links.json

The value of root is not an array:
./concepts/switch-expressions/links.json

The value of root is not an array:
./concepts/templates/links.json

The value of root is not an array:
./concepts/ternary-operators/links.json

The value of root is not an array:
./concepts/throw-expressions/links.json

The value of root is not an array:
./concepts/time/links.json

The value of root is not an array:
./concepts/typedefs/links.json

The value of root is not an array:
./concepts/using-statements/links.json

The value of root is not an array:
./concepts/while-loops/links.json
```




#### idris
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### io
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### j
```
The `exercises.practice.difficulty` key is missing:
./config.json

The `exercises.practice.difficulty` key is missing:
./config.json

The `exercises.practice.difficulty` key is missing:
./config.json

The `exercises.practice.difficulty` key is missing:
./config.json

The `exercises.practice.difficulty` key is missing:
./config.json

The `exercises.practice.difficulty` key is missing:
./config.json

The `exercises.practice.difficulty` key is missing:
./config.json

The `tags` array is empty:
./config.json
```




#### java
```
The `exercises.concept.prerequisites` array is empty:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json
```




#### javascript
```
The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.prerequisites` array is empty:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json
```




#### julia
```
The `exercises.concept.prerequisites` array is empty:
./config.json

The `exercises.concept.name` key is missing:
./config.json

Missing file:
./exercises/concept/annalyns-infiltration/.docs/hints.md

Missing file:
./exercises/concept/annalyns-infiltration/.docs/introduction.md

Missing file:
./exercises/concept/annalyns-infiltration2/.docs/hints.md

Missing file:
./exercises/concept/documented-lasagna/.docs/hints.md

Missing file:
./exercises/concept/emoji-times/.docs/introduction.md

Missing file:
./exercises/concept/exercism-matrix/.docs/hints.md

Missing file:
./exercises/concept/vehicle-purchase/.docs/hints.md

Missing file:
./concepts/abstract-types/introduction.md

Missing file:
./concepts/composite-types/introduction.md

Missing file:
./concepts/constants/introduction.md

Missing file:
./concepts/matrices-concatenation/introduction.md

Missing file:
./concepts/matrices-indices/introduction.md

Missing file:
./concepts/matrices-iteration/introduction.md

Missing file:
./concepts/matrices-mutation/introduction.md

Missing file:
./concepts/methods/introduction.md

Missing file:
./concepts/nothingness/introduction.md

Missing file:
./concepts/symbols/introduction.md
```




#### kotlin
```
The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.prerequisites` array is empty:
./config.json

The `tags` array is empty:
./config.json

The `files.solution` array is empty:
./exercises/concept/annalyns-infiltration/.meta/config.json

The `files.test` array is empty:
./exercises/concept/annalyns-infiltration/.meta/config.json

The `files.exemplar` array is empty:
./exercises/concept/annalyns-infiltration/.meta/config.json

The `files.solution` array is empty:
./exercises/concept/basics/.meta/config.json

The `files.test` array is empty:
./exercises/concept/basics/.meta/config.json

The `files.exemplar` array is empty:
./exercises/concept/basics/.meta/config.json
```




#### lfe
```
The `tags` array is empty:
./config.json
```




#### lua
```
The value of `key_features.content` that starts with `Lua is primarily designed`... is 167 characters, but it must not exceed 100 characters:
./config.json

The value of `key_features.content` that starts with `Lua is known to be one of`... is 149 characters, but it must not exceed 100 characters:
./config.json

The value of `key_features.content` that starts with `Lua has a simple, yet pow`... is 112 characters, but it must not exceed 100 characters:
./config.json

The value of `key_features.content` that starts with `Lua offers a small, yet f`... is 133 characters, but it must not exceed 100 characters:
./config.json
```




#### mips
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### nix
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### objective-c
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json

Missing file:
./exercises/practice/bracket-push/.docs/instructions.md

The `blurb` key is missing:
./exercises/practice/bracket-push/.meta/config.json
```




#### ocaml
```
The `tags` array is empty:
./config.json
```




#### perl5
```
The `tags` array is empty:
./config.json
```




#### plsql
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### pony
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### powershell
```
The `tags` array is empty:
./config.json
```




#### prolog
```
The `tags` array is empty:
./config.json
```




#### purescript
```
The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.prerequisites` array is empty:
./config.json

The `tags` array is empty:
./config.json

Missing file:
./exercises/practice/bracket-push/.docs/instructions.md

The `files.solution` array is empty:
./exercises/concept/booleans/.meta/config.json

The `files.test` array is empty:
./exercises/concept/booleans/.meta/config.json

The `blurb` key is missing:
./exercises/practice/bracket-push/.meta/config.json
```




#### python
```
The `exercises.concept.prerequisites` array is empty:
./config.json
```




#### r
```
Missing file:
./exercises/practice/fizz-buzz/.docs/instructions.md

The `blurb` key is missing:
./exercises/practice/fizz-buzz/.meta/config.json
```




#### racket
```
The `tags` array is empty:
./config.json
```




#### raku
```
The `tags` array is empty:
./config.json
```




#### research_experiment_1
```
The `slug` key is missing:
./config.json

The value of `blurb` is a zero-length string:
./config.json

The `version` key is missing:
./config.json

The `status` key is missing:
./config.json

The `online_editor` key is missing:
./config.json

The value of `exercises` is not an object:
./config.json

The `concepts` key is missing:
./config.json

The `tags` key is missing:
./config.json
```




#### ruby
```
The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.concepts` array is empty:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.concepts` array is empty:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.prerequisites` array is empty:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.name` key is missing:
./config.json

The `tags` array is empty:
./config.json

File is empty, but must contain at least the empty array, `[]`:
./concepts/enumeration/links.json

File is empty, but must contain at least the empty array, `[]`:
./concepts/exceptions/links.json

File is empty, but must contain at least the empty array, `[]`:
./concepts/ostruct/links.json
```




#### rust
```
The `exercises.concept.prerequisites` array is empty:
./config.json
```




#### scala
```
The `tags` array is empty:
./config.json

The `files.solution` array is empty:
./exercises/concept/basics/.meta/config.json

The `files.test` array is empty:
./exercises/concept/basics/.meta/config.json
```




#### scheme
```
The `tags` array is empty:
./config.json
```




#### sml
```
The `tags` array is empty:
./config.json
```




#### solidity
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json

Missing file:
./exercises/practice/token-transfer/.docs/instructions.md

The `blurb` key is missing:
./exercises/practice/token-transfer/.meta/config.json
```




#### swift
```
The `exercises.concept.prerequisites` array is empty:
./config.json

The `tags` array is empty:
./config.json

Missing file:
./exercises/practice/bracket-push/.docs/instructions.md

Missing file:
./concepts/capturing/introduction.md

Missing file:
./concepts/characters/about.md

Missing file:
./concepts/classes/about.md

Missing file:
./concepts/closures/introduction.md

Missing file:
./concepts/constants-and-variables/introduction.md

Missing file:
./concepts/initializers/about.md

Missing file:
./concepts/opaque-indices/about.md

Missing file:
./concepts/shorthand-arguments/introduction.md

Missing file:
./concepts/strings/about.md

Missing file:
./concepts/structs/about.md

Missing file:
./concepts/trailing-closures/introduction.md

Missing file:
./concepts/characters/links.json

Missing file:
./concepts/classes/links.json

Missing file:
./concepts/initializers/links.json

Missing file:
./concepts/opaque-indices/links.json

The `url` key is missing:
./concepts/shorthand-arguments/links.json

The `description` key is missing:
./concepts/shorthand-arguments/links.json

Missing file:
./concepts/strings/links.json

Missing file:
./concepts/structs/links.json

The `blurb` key is missing:
./exercises/practice/bracket-push/.meta/config.json
```




#### system-verilog
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json
```




#### typescript
```
The `tags` array is empty:
./config.json
```




#### vbnet
```
The `tags` array is empty:
./config.json
```




#### vimscript
```
The `tags` array is empty:
./config.json
```




#### x86-64-assembly
```
The `exercises.concept.name` key is missing:
./config.json

The `exercises.concept.prerequisites` array is empty:
./config.json

The `tags` array is empty:
./config.json

The `files.solution` array is empty:
./exercises/concept/basics/.meta/config.json

The `files.test` array is empty:
./exercises/concept/basics/.meta/config.json
```




#### z3
```
The value of `blurb` is a zero-length string:
./config.json

The `tags` array is empty:
./config.json

Missing file:
./exercises/practice/averager/.meta/config.json
```




#### zig
```
The `exercises.practice.practices` key is missing:
./config.json
```

</details>