### PR TITLE
lint(track_config): disable empty `prerequisites` error

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -79,7 +79,8 @@ proc isValidConceptExercise(data: JsonNode; context: string; path: Path): bool =
       hasString(data, "uuid", path, context),
       hasBoolean(data, "deprecated", path, context, isRequired = false),
       hasArrayOfStrings(data, "concepts", path, context),
-      hasArrayOfStrings(data, "prerequisites", path, context),
+      hasArrayOfStrings(data, "prerequisites", path, context,
+                        allowedArrayLen = 0..int.high),
       hasString(data, "status", path, context, isRequired = false,
                 allowed = statuses),
     ]


### PR DESCRIPTION
Previously, there were some incorrect error messages because
`configlet lint` does not yet implement these rules:
> - The `"exercises.concept[].prerequisites"` value must be a non-empty
  array of strings if `"exercises.concept[].status"` is not equal to
  `deprecated`, except for exactly one exercise which _is_ allowed to
  have an empty array as its value
> - The `"exercises.concept[].prerequisites"` value must be an empty array
  if `"exercises.concept[].status"` is equal to `deprecated`

This commit temporarily allows the array to be empty.

---

This PR produces the following diff to the output of `configlet lint`

#### clojure
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### common-lisp
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### csharp
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
-Configlet detected at least one problem.
-For more information on resolving the problems, please see the documentation:
-https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### dart
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### elixir
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### elm
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
-Configlet detected at least one problem.
-For more information on resolving the problems, please see the documentation:
-https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### fsharp
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
-Configlet detected at least one problem.
-For more information on resolving the problems, please see the documentation:
-https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### go
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### java
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### javascript
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### julia
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### kotlin
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### purescript
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### python
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
-Configlet detected at least one problem.
-For more information on resolving the problems, please see the documentation:
-https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### ruby
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### rust
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
-Configlet detected at least one problem.
-For more information on resolving the problems, please see the documentation:
-https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### swift
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```

#### x86-64-assembly
```diff
-The `exercises.concept.prerequisites` array is empty:
-./config.json
-
```