### PR TITLE
lint: add kebab-case checks

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -74,14 +74,14 @@ const
 proc isValidConceptExercise(data: JsonNode; context: string; path: Path): bool =
   if isObject(data, context, path):
     let checks = [
-      hasString(data, "slug", path, context),
+      hasString(data, "slug", path, context, checkIsKebab = true),
       hasString(data, "name", path, context),
       hasString(data, "uuid", path, context),
       hasBoolean(data, "deprecated", path, context, isRequired = false),
       hasArrayOfStrings(data, "concepts", path, context,
-                        allowedArrayLen = 0..int.high),
+                        allowedArrayLen = 0..int.high, checkIsKebab = true),
       hasArrayOfStrings(data, "prerequisites", path, context,
-                        allowedArrayLen = 0..int.high),
+                        allowedArrayLen = 0..int.high, checkIsKebab = true),
       hasString(data, "status", path, context, isRequired = false,
                 allowed = statuses),
     ]
@@ -91,15 +91,15 @@ proc isValidPracticeExercise(data: JsonNode; context: string;
                              path: Path): bool =
   if isObject(data, context, path):
     let checks = [
-      hasString(data, "slug", path, context),
+      hasString(data, "slug", path, context, checkIsKebab = true),
       hasString(data, "name", path, context),
       hasString(data, "uuid", path, context),
       hasBoolean(data, "deprecated", path, context, isRequired = false),
       hasInteger(data, "difficulty", path, context, allowed = 0..10),
       hasArrayOfStrings(data, "practices", path, context,
-                        allowedArrayLen = 0..int.high),
+                        allowedArrayLen = 0..int.high, checkIsKebab = true),
       hasArrayOfStrings(data, "prerequisites", path, context,
-                        allowedArrayLen = 0..int.high),
+                        allowedArrayLen = 0..int.high, checkIsKebab = true),
       hasString(data, "status", path, context, isRequired = false,
                 allowed = statuses),
     ]
@@ -114,7 +114,8 @@ proc hasValidExercises(data: JsonNode; path: Path): bool =
                  allowedLength = 0..int.high),
       hasArrayOf(exercises, "practice", path, isValidPracticeExercise, k,
                  allowedLength = 0..int.high),
-      hasArrayOfStrings(exercises, "foregone", path, k, isRequired = false),
+      hasArrayOfStrings(exercises, "foregone", path, k, isRequired = false,
+                        checkIsKebab = true),
     ]
     result = allTrue(checks)
 
@@ -122,7 +123,7 @@ proc isValidConcept(data: JsonNode; context: string; path: Path): bool =
   if isObject(data, context, path):
     let checks = [
       hasString(data, "uuid", path, context),
-      hasString(data, "slug", path, context),
+      hasString(data, "slug", path, context, checkIsKebab = true),
       hasString(data, "name", path, context),
     ]
     result = allTrue(checks)
@@ -153,7 +154,7 @@ proc isValidTrackConfig(data: JsonNode; path: Path): bool =
   if isObject(data, "", path):
     let checks = [
       hasString(data, "language", path),
-      hasString(data, "slug", path),
+      hasString(data, "slug", path, checkIsKebab = true),
       hasBoolean(data, "active", path),
       hasString(data, "blurb", path, maxLen = 400),
       hasInteger(data, "version", path, allowed = 3..3),

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -83,21 +83,18 @@ func isKebabCase*(s: string): bool =
   ## - Does not contain two adjacent `-` characters
   ## This corresponds to the regex pattern `^[a-z0-9]+(-[a-z0-9]+)*$`.
   const lowerAndDigits = {'a'..'z', '0'..'9'}
-  let L = s.len
-
-  if L > 0 and s[0] in lowerAndDigits and s[^1] in lowerAndDigits:
-    var i = 0
-    while true:
-      i += s.skipWhile(lowerAndDigits, start = i)
-      if i == L:
-        return true
-      elif s[i] == '-':
-        if s[i-1] == '-':
-          return false
-        else:
-          inc i
-      else:
-        return false
+  let sLen = s.len
+  var i = 0
+  while i < sLen:
+    if s[i] == '-':
+      return false
+    i += s.skipWhile(lowerAndDigits, start = i)
+    if i == sLen:
+      return true
+    elif s[i] == '-':
+      inc i
+    else:
+      return false
 
 proc isString*(data: JsonNode; key: string; path: Path; context: string;
                isRequired = true; allowed = emptySetOfStrings;

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -211,7 +211,8 @@ proc hasArrayOfStrings*(data: JsonNode;
   if data.hasKey(key, path, context, isRequired):
     let contextAndKey = joinWithDot(context, key)
     result = isArrayOfStrings(data[key], contextAndKey, path, isRequired,
-                              allowed, allowedArrayLen, checkIsKebab = checkIsKebab)
+                              allowed, allowedArrayLen,
+                              checkIsKebab = checkIsKebab)
   elif not isRequired:
     result = true
 

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -76,12 +76,23 @@ const
   emptySetOfStrings = initHashSet[string](0)
 
 func isKebabCase*(s: string): bool =
-  ## Returns true if `s` satisfies these rules:
-  ## - Has a length > 0
-  ## - Begins and ends with a character in [a-z0-9]
-  ## - Consists only of characters in [a-z0-9-]
-  ## - Does not contain two adjacent `-` characters
-  ## This corresponds to the regex pattern `^[a-z0-9]+(-[a-z0-9]+)*$`.
+  ## Returns true if `s` is a kebab-case string. By our definition, `s` must:
+  ## - Have a non-zero length
+  ## - Begin and end with a character in [a-z0-9]
+  ## - Consist only of characters in [a-z0-9-]
+  ## - Not contain consecutive `-` characters
+  ## This corresponds to the regex pattern `^[a-z0-9]+(?:-[a-z0-9]+)*$`.
+  runnableExamples:
+    assert isKebabCase("hello")
+    assert isKebabCase("hello-world")
+    assert isKebabCase("123")              # Can contain only digits.
+    assert not isKebabCase("")             # Cannot be the empty string.
+    assert not isKebabCase("hello world")  # Cannot contain a space.
+    assert not isKebabCase("hello_world")  # Cannot contain an underscore.
+    assert not isKebabCase("helloWorld")   # Cannot contain an uppercase letter.
+    assert not isKebabCase("hello--world") # Cannot contain consecutive dashes.
+    assert not isKebabCase("hello!")       # Cannot contain a special character.
+
   const lowerAndDigits = {'a'..'z', '0'..'9'}
   let sLen = s.len
   var i = 0

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -143,11 +143,11 @@ proc isString*(data: JsonNode; key: string; path: Path; context: string;
           if not isKebabCase(s):
             let msg =
               if isInArray:
-                &"The {format(context, key)} array contains {s}, but every " &
+                &"The {format(context, key)} array contains {q s}, but every " &
                  "value must be lowercase and kebab-case"
               else:
-                &"The {format(context, key)} value is {s}, but it must be a " &
-                "lowercase and kebab-case string"
+                &"The {format(context, key)} value is {q s}, but it must be " &
+                 "a lowercase and kebab-case string"
             result.setFalseAndPrint(msg, path)
         if not hasValidRuneLength(s, key, path, context, maxLen):
           result = false

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -78,10 +78,16 @@ const
 func isKebabCase*(s: string): bool =
   ## Returns true if `s` is a kebab-case string. By our definition, `s` must:
   ## - Have a non-zero length
-  ## - Begin and end with a character in [a-z0-9]
-  ## - Consist only of characters in [a-z0-9-]
+  ## - Start and end with a character in `[a-z0-9]`
+  ## - Consist only of characters in `[a-z0-9-]`
   ## - Not contain consecutive `-` characters
-  ## This corresponds to the regex pattern `^[a-z0-9]+(?:-[a-z0-9]+)*$`.
+  ##
+  ## This is equivalent to matching the below regular expression:
+  ##
+  ## `^[a-z0-9]+(?:-[a-z0-9]+)*$`.
+  ##
+  ## However, this func's implementation is faster than one that uses
+  ## `re.match`, and doesn't add a PCRE dependency.
   runnableExamples:
     assert isKebabCase("hello")
     assert isKebabCase("hello-world")

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -85,13 +85,13 @@ func isKebabCase*(s: string): bool =
   runnableExamples:
     assert isKebabCase("hello")
     assert isKebabCase("hello-world")
-    assert isKebabCase("123")              # Can contain only digits.
-    assert not isKebabCase("")             # Cannot be the empty string.
-    assert not isKebabCase("hello world")  # Cannot contain a space.
-    assert not isKebabCase("hello_world")  # Cannot contain an underscore.
-    assert not isKebabCase("helloWorld")   # Cannot contain an uppercase letter.
+    assert isKebabCase("123") # Can contain only digits.
+    assert not isKebabCase("") # Cannot be the empty string.
+    assert not isKebabCase("hello world") # Cannot contain a space.
+    assert not isKebabCase("hello_world") # Cannot contain an underscore.
+    assert not isKebabCase("helloWorld") # Cannot contain an uppercase letter.
     assert not isKebabCase("hello--world") # Cannot contain consecutive dashes.
-    assert not isKebabCase("hello!")       # Cannot contain a special character.
+    assert not isKebabCase("hello!") # Cannot contain a special character.
 
   const lowerAndDigits = {'a'..'z', '0'..'9'}
   let sLen = s.len

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -1,5 +1,6 @@
 import "."/[
   test_binary,
+  test_lint,
   test_probspecs,
   test_uuid,
 ]

--- a/tests/test_lint.nim
+++ b/tests/test_lint.nim
@@ -1,0 +1,63 @@
+import std/unittest
+import "."/[lint/validators]
+
+proc main =
+  suite "isKebabCase":
+    test "invalid kebab strings":
+      check:
+        # Some short, bad strings
+        not isKebabCase("")
+        not isKebabCase(" ")
+        not isKebabCase("-")
+        not isKebabCase("_")
+        not isKebabCase("a ")
+        not isKebabCase(" a")
+        not isKebabCase("a-")
+        not isKebabCase("-a")
+        not isKebabCase("--a")
+        not isKebabCase("a--")
+        not isKebabCase("-a-")
+        not isKebabCase("a--b")
+        # With symbols
+        not isKebabCase("&")
+        not isKebabCase("&str")
+        not isKebabCase("hello!")
+        # Bad dash usage
+        not isKebabCase("hello-world-")
+        not isKebabCase("-hello-world")
+        not isKebabCase("-hello-world-")
+        not isKebabCase("hello--world")
+        not isKebabCase("hello---world")
+        # With space
+        not isKebabCase("hello world")
+        not isKebabCase("hello World")
+        not isKebabCase("Hello world")
+        not isKebabCase("Hello World")
+        not isKebabCase("HELLO WORLD")
+        # With underscore
+        not isKebabCase("hello_world")
+        not isKebabCase("hello_World")
+        not isKebabCase("Hello_world")
+        not isKebabCase("Hello_World")
+        not isKebabCase("HELLO_WORLD")
+        # With dash
+        not isKebabCase("hello-World")
+        not isKebabCase("Hello-world")
+        not isKebabCase("Hello-World")
+        not isKebabCase("HELLO-WORLD")
+        # No spaces, but with capitals
+        not isKebabCase("helloWorld")
+        not isKebabCase("Helloworld")
+        not isKebabCase("HelloWorld")
+        not isKebabCase("HELLOWORLD")
+
+    test "valid kebab strings":
+      check:
+        isKebabCase("a")
+        isKebabCase("hello")
+        isKebabCase("hello-world")
+        isKebabCase("hello-world-hello")
+        isKebabCase("hello-world-hello-world")
+
+main()
+{.used.}

--- a/tests/test_lint.nim
+++ b/tests/test_lint.nim
@@ -5,7 +5,7 @@ proc main =
   suite "isKebabCase":
     test "invalid kebab-case strings":
       check:
-        # Some short, bad strings
+        # Some short, invalid strings
         not isKebabCase("")
         not isKebabCase(" ")
         not isKebabCase("-")
@@ -20,34 +20,34 @@ proc main =
         not isKebabCase("a--")
         not isKebabCase("-a-")
         not isKebabCase("a--b")
-        # With symbols
+        # Containing character not in [a-z0-9]
         not isKebabCase("&")
         not isKebabCase("&str")
         not isKebabCase("hello!")
-        # Bad dash usage
+        # Invalid dash usage
         not isKebabCase("hello-world-")
         not isKebabCase("-hello-world")
         not isKebabCase("-hello-world-")
         not isKebabCase("hello--world")
         not isKebabCase("hello---world")
-        # With space
+        # Invalid separator: space
         not isKebabCase("hello world")
         not isKebabCase("hello World")
         not isKebabCase("Hello world")
         not isKebabCase("Hello World")
         not isKebabCase("HELLO WORLD")
-        # With underscore
+        # Invalid separator: underscore
         not isKebabCase("hello_world")
         not isKebabCase("hello_World")
         not isKebabCase("Hello_world")
         not isKebabCase("Hello_World")
         not isKebabCase("HELLO_WORLD")
-        # With dash
+        # Containing uppercase, with dash
         not isKebabCase("hello-World")
         not isKebabCase("Hello-world")
         not isKebabCase("Hello-World")
         not isKebabCase("HELLO-WORLD")
-        # No separator, but with capitals
+        # Containing uppercase, with no separator
         not isKebabCase("helloWorld")
         not isKebabCase("Helloworld")
         not isKebabCase("HelloWorld")

--- a/tests/test_lint.nim
+++ b/tests/test_lint.nim
@@ -3,13 +3,15 @@ import "."/[lint/validators]
 
 proc main =
   suite "isKebabCase":
-    test "invalid kebab strings":
+    test "invalid kebab-case strings":
       check:
         # Some short, bad strings
         not isKebabCase("")
         not isKebabCase(" ")
         not isKebabCase("-")
         not isKebabCase("_")
+        not isKebabCase("--")
+        not isKebabCase("---")
         not isKebabCase("a ")
         not isKebabCase(" a")
         not isKebabCase("a-")
@@ -45,15 +47,20 @@ proc main =
         not isKebabCase("Hello-world")
         not isKebabCase("Hello-World")
         not isKebabCase("HELLO-WORLD")
-        # No spaces, but with capitals
+        # No separator, but with capitals
         not isKebabCase("helloWorld")
         not isKebabCase("Helloworld")
         not isKebabCase("HelloWorld")
         not isKebabCase("HELLOWORLD")
 
-    test "valid kebab strings":
+    test "valid kebab-case strings":
       check:
         isKebabCase("a")
+        isKebabCase("1")
+        isKebabCase("123")
+        isKebabCase("123-456")
+        isKebabCase("hello-123")
+        isKebabCase("123-hello")
         isKebabCase("hello")
         isKebabCase("hello-world")
         isKebabCase("hello-world-hello")


### PR DESCRIPTION
This commit implements these checks for a track `config.json`:
> - The `"slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
> - The `"exercises.concept[].slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
> - The `"exercises.concept[].concepts"` values must be non-empty, non-blank, lowercased strings using kebab-case
> - The `"exercises.concept[].prerequisites"` values must be non-empty, non-blank, lowercased strings using kebab-case
> - The `"exercises.practice[].slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
> - The `"exercises.practice[].practices"` values must be non-empty, non-blank, lowercased strings using kebab-case
> - The `"exercises.practice[].prerequisites"` values must be non-empty, non-blank, lowercased strings using kebab-case
> - The `"exercises.foregone"` values must be non-empty, non-blank, lowercased strings using kebab-case
> - The `"concepts[].slug"` value must be a non-empty, non-blank, lowercased string using kebab-case

--- 

This PR currently causes the following diff to the output of `configlet lint`:

#### rust
```diff
+The `exercises.concept.prerequisites` array contains `&str`, but every value must be lowercase and kebab-case:
+./config.json
+
+The `concepts.slug` value is `&str`, but it must be a lowercase and kebab-case string:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

What should the definition of "kebab string" be?
- ~A string that only contains characters in `{'a'..'z', '0'..'9', '-'}` (the definition in e8983241bb72757cc4a0d0f5aff96dfc47f69fa0)~
- A string that matches `^([a-z0-9]+)(-[a-z0-9]+)*$`
- ~A string that does not contain a character in `{'A'..'Z', '_', ' '}`~
- ~Something else~

I think we can either
1. Disallow special characters for all kebab strings, and tell the Rust track to write the concept name as something like "string-slices" instead.
1. ~Allow special characters in a concept name, so something like `&str` is allowed, but disallow them in the other kebab strings.~

See e.g.
- https://doc.rust-lang.org/std/str/index.html
- https://doc.rust-lang.org/book/ch04-03-slices.html?highlight=%26str#string-slices