### PR TITLE
lint: remove unused imports

### DIFF
--- a/src/lint/concepts.nim
+++ b/src/lint/concepts.nim
@@ -1,4 +1,4 @@
-import std/[json, os]
+import std/json
 import ".."/helpers
 import "."/validators
 

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -1,4 +1,4 @@
-import std/[json, os, sets]
+import std/[json, sets]
 import ".."/helpers
 import "."/validators
 


### PR DESCRIPTION
This resolves these compilation warnings:
>```
> ./src/lint/concepts.nim(1, 11) Warning: imported and not used: 'os' [UnusedImport]
> ./src/lint/track_config.nim(1, 11) Warning: imported and not used: 'os' [UnusedImport]
> ```
---

This issue and that in #276 snuck in because I've been using a helper script to run `nimble build` and do all the `configlet lint` diffing, and that script previously only showed the output of the `nimble build` step if it failed.

In the future we can have GitHub Actions annotations for compiler hints/warnings/errors.