### PR TITLE
lint(validators): fix array length check

### DIFF
--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -167,6 +167,7 @@ proc isArrayOfStrings*(data: JsonNode;
             &"of exactly {allowedArrayLen.a}"
           else:
             &"between {allowedArrayLen.a} and {allowedArrayLen.b} (inclusive)"
+        result.setFalseAndPrint(msgStart & msgEnd, path)
     elif isRequired:
       if 0 notin allowedArrayLen:
         result.setFalseAndPrint(&"The {q context} array is empty", path)


### PR DESCRIPTION
Previously, we didn't actually print the error (or set `result` to `false`) in `isArrayOfStrings` if the array was a non-allowed length. Oops.

Similarly to #275, this resolves these compiler hints:
> ```
> ./src/lint/validators.nim(165, 13) Hint: 'msgEnd' is declared but not used [XDeclaredButNotUsed]
> ./src/lint/validators.nim(163, 13) Hint: 'msgStart' is declared but not used [XDeclaredButNotUsed]
> ```

This PR does not affect the output of `configlet lint`. That's because we currently don't really use the `allowedArrayLen` feature of `isArrayOfStrings` / `hasArrayOfStrings`.