### PR TITLE
build: bump `jiro4989/setup-nim-action` from 1.3.1 to 1.3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
 
       - name: Install Nim
-        uses: jiro4989/setup-nim-action@06254954e9ca216111b384b60904a587f1a7b22e # 1.3.1
+        uses: jiro4989/setup-nim-action@d0c07f7ad4ed045c29cfcffbc1402643f8147184 # 1.3.2
         with:
           nim-version: "1.4.2"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
 
       - name: Install Nim
-        uses: jiro4989/setup-nim-action@06254954e9ca216111b384b60904a587f1a7b22e # 1.3.1
+        uses: jiro4989/setup-nim-action@d0c07f7ad4ed045c29cfcffbc1402643f8147184 # 1.3.2
         with:
           nim-version: "1.4.2"
 


### PR DESCRIPTION
See:
- https://github.com/jiro4989/setup-nim-action/releases/tag/v1.3.2
- https://github.com/jiro4989/setup-nim-action/compare/06254954e9ca...d0c07f7ad4ed

---

Maybe this will fix the Windows SSL cert issue.