### PR TITLE
all: remove brackets from single module imports

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -1,5 +1,5 @@
 import std/[os, parseutils, strformat, strutils, terminal]
-import pkg/[cligen/parseopt3]
+import pkg/cligen/parseopt3
 
 type
   Verbosity* = enum
@@ -208,7 +208,7 @@ func formatOpt(kind: CmdLineKind, key: string, val = ""): string =
   ## Returns a string that describes an option, given its `kind`, `key` and
   ## optionally `val`. This is useful for displaying in error messages.
   runnableExamples:
-    import pkg/[cligen/parseopt3]
+    import pkg/cligen/parseopt3
     assert formatOpt(cmdShortOption, "h") == "'-h'"
     assert formatOpt(cmdLongOption, "help") == "'--help'"
     assert formatOpt(cmdShortOption, "v", "quiet") == "'-v': 'quiet'"

--- a/src/configlet.nim
+++ b/src/configlet.nim
@@ -1,4 +1,4 @@
-import std/[posix]
+import std/posix
 import "."/[cli, lint/lint, logger, sync/check, sync/sync, uuid/uuid]
 
 proc main =

--- a/src/logger.nim
+++ b/src/logger.nim
@@ -1,5 +1,5 @@
-import std/[logging]
-import "."/[cli]
+import std/logging
+import "."/cli
 
 func levelThreshold(verbosity: Verbosity): Level =
   case verbosity

--- a/src/sync/check.nim
+++ b/src/sync/check.nim
@@ -1,6 +1,6 @@
 import std/[sets, strformat]
 import ".."/[cli, logger]
-import "."/[exercises]
+import "."/exercises
 
 proc check*(conf: Conf) =
   logNormal("Checking exercises...")

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -1,5 +1,5 @@
 import std/[algorithm, json, options, os, sequtils, sets, strformat, tables]
-import ".."/[cli]
+import ".."/cli
 import "."/[probspecs, tracks]
 
 type

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -1,6 +1,6 @@
 import std/[json, options, sequtils, sets, strformat, strutils]
 import ".."/[cli, logger]
-import "."/[exercises]
+import "."/exercises
 
 type
   SyncDecision = enum

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -1,6 +1,6 @@
 import std/[json, os, sets]
-import pkg/[parsetoml]
-import ".."/[cli]
+import pkg/parsetoml
+import ".."/cli
 
 type
   ConfigJsonExercise = object

--- a/src/uuid/uuid.nim
+++ b/src/uuid/uuid.nim
@@ -1,6 +1,6 @@
-import std/[strformat]
-import pkg/[uuids]
-import ".."/[logger]
+import std/strformat
+import pkg/uuids
+import ".."/logger
 
 proc outputUuids(n: Positive) =
   ## Writes `n` version 4 UUIDs to stdout. Writes only 1000 UUIDs if `n` is

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -1,5 +1,5 @@
 import std/[os, osproc, strformat, strscans, strutils, unittest]
-import "."/[uuid/uuid]
+import "."/uuid/uuid
 
 const
   binaryExt =

--- a/tests/test_lint.nim
+++ b/tests/test_lint.nim
@@ -1,5 +1,5 @@
 import std/unittest
-import "."/[lint/validators]
+import "."/lint/validators
 
 proc main =
   suite "isKebabCase":

--- a/tests/test_uuid.nim
+++ b/tests/test_uuid.nim
@@ -1,6 +1,6 @@
-import std/[unittest]
-import pkg/[uuids]
-import "."/[uuid/uuid]
+import std/unittest
+import pkg/uuids
+import "."/uuid/uuid
 
 proc main =
   suite "genUUID: returns a string that isValidUuidV4 says is valid":


### PR DESCRIPTION
The style guide now takes a position on this matter:
> Use `std` prefix for standard library modules, namely use `std/os` for
> single module and use `std/[os, sysrand, posix]` for multiple modules.

See:
- https://nim-lang.github.io/Nim/nep1.html#introduction-miscellaneous
- https://github.com/nim-lang/Nim/pull/17105/files

---

With this PR:
```
$ git grep --break --heading 'import'
```

```Nim
src/cli.nim
1:import std/[os, parseutils, strformat, strutils, terminal]
2:import pkg/cligen/parseopt3
211:    import pkg/cligen/parseopt3

src/configlet.nim
1:import std/posix
2:import "."/[cli, lint/lint, logger, sync/check, sync/sync, uuid/uuid]

src/helpers.nim
1:import std/[algorithm, os, terminal]
2:import "."/cli

src/lint/concept_exercises.nim
1:import std/[json, os]
2:import ".."/helpers
3:import "."/validators

src/lint/concepts.nim
1:import std/json
2:import ".."/helpers
3:import "."/validators

src/lint/lint.nim
1:import ".."/[cli, helpers]
2:import "."/[concept_exercises, concepts, practice_exercises, track_config,

src/lint/practice_exercises.nim
1:import std/[json, os]
2:import ".."/helpers
3:import "."/validators

src/lint/track_config.nim
1:import std/[json, sets]
2:import ".."/helpers
3:import "."/validators

src/lint/validators.nim
1:import std/[json, os, parseutils, sets, streams, strformat, strutils, unicode]
2:import ".."/helpers

src/logger.nim
1:import std/logging
2:import "."/cli

src/sync/check.nim
1:import std/[sets, strformat]
2:import ".."/[cli, logger]
3:import "."/exercises

src/sync/exercises.nim
1:import std/[algorithm, json, options, os, sequtils, sets, strformat, tables]
2:import ".."/cli
3:import "."/[probspecs, tracks]

src/sync/probspecs.nim
1:import std/[json, os, osproc, sequtils, strformat, strscans, strutils]
2:import ".."/[cli, helpers, logger]

src/sync/sync.nim
1:import std/[json, options, sequtils, sets, strformat, strutils]
2:import ".."/[cli, logger]
3:import "."/exercises

src/sync/tracks.nim
1:import std/[json, os, sets]
2:import pkg/parsetoml
3:import ".."/cli

src/uuid/uuid.nim
1:import std/strformat
2:import pkg/uuids
3:import ".."/logger

tests/all_tests.nim
1:import "."/[

tests/test_binary.nim
1:import std/[os, osproc, strformat, strscans, strutils, unittest]
2:import "."/uuid/uuid

tests/test_lint.nim
1:import std/unittest
2:import "."/lint/validators

tests/test_probspecs.nim
2:import std/[json, os, osproc, strformat, unittest]
3:import "."/[cli, sync/probspecs]

tests/test_uuid.nim
1:import std/unittest
2:import pkg/uuids
3:import "."/uuid/uuid
```