### PR TITLE
lint: add offline UUID checks

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -76,7 +76,7 @@ proc isValidConceptExercise(data: JsonNode; context: string; path: Path): bool =
     let checks = [
       hasString(data, "slug", path, context, checkIsKebab = true),
       hasString(data, "name", path, context),
-      hasString(data, "uuid", path, context),
+      hasString(data, "uuid", path, context, checkIsUuid = true),
       hasBoolean(data, "deprecated", path, context, isRequired = false),
       hasArrayOfStrings(data, "concepts", path, context,
                         allowedArrayLen = 0..int.high, checkIsKebab = true),
@@ -93,7 +93,7 @@ proc isValidPracticeExercise(data: JsonNode; context: string;
     let checks = [
       hasString(data, "slug", path, context, checkIsKebab = true),
       hasString(data, "name", path, context),
-      hasString(data, "uuid", path, context),
+      hasString(data, "uuid", path, context, checkIsUuid = true),
       hasBoolean(data, "deprecated", path, context, isRequired = false),
       hasInteger(data, "difficulty", path, context, allowed = 0..10),
       hasArrayOfStrings(data, "practices", path, context,
@@ -122,7 +122,7 @@ proc hasValidExercises(data: JsonNode; path: Path): bool =
 proc isValidConcept(data: JsonNode; context: string; path: Path): bool =
   if isObject(data, context, path):
     let checks = [
-      hasString(data, "uuid", path, context),
+      hasString(data, "uuid", path, context, checkIsUuid = true),
       hasString(data, "slug", path, context, checkIsKebab = true),
       hasString(data, "name", path, context),
     ]

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -170,7 +170,7 @@ func isUuidV4*(s: string): bool =
 proc isString*(data: JsonNode; key: string; path: Path; context: string;
                isRequired = true; allowed = emptySetOfStrings;
                checkIsUrlLike = false; maxLen = int.high; checkIsKebab = false;
-               isInArray = false): bool =
+               checkIsUuid = false; isInArray = false): bool =
   result = true
   case data.kind
   of JString:
@@ -203,6 +203,12 @@ proc isString*(data: JsonNode; key: string; path: Path; context: string;
                 &"The {format(context, key)} value is {q s}, but it must be " &
                  "a lowercase and kebab-case string"
             result.setFalseAndPrint(msg, path)
+        elif checkIsUuid:
+          if not isUuidV4(s):
+            let msg =
+              &"A {format(context, key)} value is {q s}, which is not a " &
+               "lowercased version 4 UUID"
+            result.setFalseAndPrint(msg, path)
         if not hasValidRuneLength(s, key, path, context, maxLen):
           result = false
       else:
@@ -234,10 +240,11 @@ proc isString*(data: JsonNode; key: string; path: Path; context: string;
 proc hasString*(data: JsonNode; key: string; path: Path; context = "";
                 isRequired = true; allowed = emptySetOfStrings;
                 checkIsUrlLike = false; maxLen = int.high;
-                checkIsKebab = false): bool =
+                checkIsKebab = false; checkIsUuid = false): bool =
   if data.hasKey(key, path, context, isRequired):
     result = isString(data[key], key, path, context, isRequired, allowed,
-                      checkIsUrlLike, maxLen, checkIsKebab = checkIsKebab)
+                      checkIsUrlLike, maxLen, checkIsKebab = checkIsKebab,
+                      checkIsUuid = checkIsUuid)
   elif not isRequired:
     result = true
 

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -167,6 +167,8 @@ func isUuidV4*(s: string): bool =
     s[34] in Hex and
     s[35] in Hex
 
+var seenUuids = initHashSet[string](250)
+
 proc isString*(data: JsonNode; key: string; path: Path; context: string;
                isRequired = true; allowed = emptySetOfStrings;
                checkIsUrlLike = false; maxLen = int.high; checkIsKebab = false;
@@ -204,6 +206,11 @@ proc isString*(data: JsonNode; key: string; path: Path; context: string;
                  "a lowercase and kebab-case string"
             result.setFalseAndPrint(msg, path)
         elif checkIsUuid:
+          if seenUuids.containsOrIncl(s):
+            let msg =
+              &"A {format(context, key)} value is {q s}, which is not unique " &
+               "on the track"
+            result.setFalseAndPrint(msg, path)
           if not isUuidV4(s):
             let msg =
               &"A {format(context, key)} value is {q s}, which is not a " &


### PR DESCRIPTION
We should probably disable these checks (or not create a release that includes them) until we've fixed the UUIDs. Pinging @iHiD for some questions:
1. Is there a plan for replacing all the bad UUIDs written somewhere?
2. If not, will we replace the bad UUIDs at ETL-time, or should we mass PR to fix the UUIDs on the tracks in advance?
3. For the UUIDs that are shared by two tracks, will we replace them on both tracks? 

---

The output is overly verbose here - it could just say something like:
> "the track `config.json` contains the below values of `uuid`, which are not valid version 4 UUIDs".

And it could also say **why** the UUID is invalid.

However, we should probably optimise for the long-term when these errors are rare, rather than common. But that still might involve some combining of error messages by category or file.

This PR (as of https://github.com/exercism/configlet/pull/280/commits/6e3b63ca3b21be34a2080e549761e19fc7b9b661) produces the below diff to the output of `configlet lint` for the tracks at the time of writing.

<details>
  <summary>click to expand</summary>

#### babashka
```diff
+A `exercises.practice.uuid` value is `d42g42d7-21b1-4daf-8ddc-a2ab9ee07c98`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### bash
```diff
+A `exercises.practice.uuid` value is `5812c10a-aee1-11e7-add7-ef139384f6eb`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `text_formatting`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### cfml
```diff
+A `exercises.practice.uuid` value is `9894F2F7-2DBE-4001-885B-FD2C029C6731`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `339BACAD-F08F-48EE-8DE9-234D4399B49B`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `C35391BD-900F-4756-8DFE-A96EA04250F8`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `12BBECF4-93EB-40F2-AC13-8CF28B550F0A`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `DECA4C79-DA5D-43A8-90B8-3A5BE73EAFF5`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `4E91AD44-8F3D-40DC-899E-253C91B134F6`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `B0E72A09-49E2-4973-BFF4-88C678F4BE55`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `00B82E7F-804C-4401-BB7F-0565DEA02567`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `E25686EE-B888-4533-86C2-5A5D96F5270E`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `4063A554-424C-4173-81EE-FEAC7CC51E8A`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `FC8922A3-E29D-451D-9947-A2781C0FF787`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `A35C9BE1-F26A-40C8-8C05-99C33C552E6F`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `685ADB7B-1DC9-4409-993D-51034DF6F744`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `15151E41-195C-40DD-B296-C2C19B38CAEA`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `113A2FF7-E72E-49DD-A2CF-0EB25894707D`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `3FDDA0E3-AE90-4834-B6DC-A5E367A5A029`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `9273C0A7-CB7E-4F3F-8993-F1621CE1F700`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `11C48AFF-4A54-4B3C-AF5E-53048D4BA98B`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `063C4BB9-3280-4C69-B164-237732AE00EF`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `1065F8DF-E6C6-4473-A633-4FA4B49A5314`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `0AC79782-B370-4954-8455-6300A734E1B8`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `0B14F23A-DAD4-4965-8ABD-8A107DFD6C00`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `C6F38ACB-A6BD-41EE-A2F8-A9680B3F61D2`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `8D0FA71A-3314-432E-BF1F-E6A5F823FC36`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `C61E97BE-6C66-4F1F-87ED-D21C4ED2A8E2`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `4594B907-8080-4A23-AD06-BE85FC28D088`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### clojure
```diff
+A `exercises.practice.uuid` value is `d42g42d7-21b1-4daf-8ddc-a2ab9ee07c98`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### common-lisp
```diff
+A `exercises.concept.uuid` value is `d780fb3e-c9f8-11ea-af82-3200111e0c80`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.concept.uuid` value is `825df850-2f38-11eb-a817-542696d187f9`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.concept.uuid` value is `44570800-47f5-11eb-9f38-542696d187f9`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `d4af6cfa-d468-15b5-dcdf-7d717ddf6556`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `C8E4BD5A-45C7-49BB-8258-FCD17ADA4AB1`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `0F266C74-D16D-4120-91AD-16B15F0F3C8C`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `7F1F362F-68A1-4D6E-BA55-8EF17C8C1243`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `303BC3DB-B089-45C5-804A-F01945278CD8`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `4a364c88-4d16-11eb-8dd3-542696d187f9`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `AB9BCE83-F376-4276-BEF4-FAB1F2A647CE`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `78C45D84-393A-4BD9-A7F6-953D0EB77180`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `26B42ED8-3CAF-4151-997C-D1C031082FEE`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `AD767D61-6694-4AD1-B32C-5E546A885748`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `2EB9757E-E38C-49A7-B192-41E64D9E535A`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `5bbd40fe-3382-11eb-b6f1-542696d187f9`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `63AAB4A6-5E27-4A48-B8C3-8E6BD94E92B5`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `21035C93-D98F-40E2-9B20-BB3721FAAF87`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `81703629-8F45-46D0-851D-0929DEDFB1D6`, which is not a lowercased version 4 UUID:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### cpp
```diff
+A `exercises.practice.uuid` value is `ea8d6224-0440-6d80-1569-a04127908a200d2ecf0`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `0a3220c6-07a9-ed80-4d2d-1fc65de969b771a46d5`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### csharp
```diff
+A `exercises.concept.uuid` value is `370e7e54-6a96-11ea-bc55-0242ac130003`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `2462D9AE-6483-40C6-955A-79CB2AC25B34`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `4c89b6a8-0e89-46c9-5a7e-31bfe6a57007`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `14395318-c7b9-11e7-abc4-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### elm
```diff
+A `exercises.practice.uuid` value is `5f540090-061e-2f80-40a8-d9782700ed2efdf8965`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `1F9FE5BC-8213-44FD-B7D1-5D4CC7F3A475`, which is not a lowercased version 4 UUID:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### emacs-lisp
```diff
+A `exercises.practice.uuid` value is `28aea3bc-0ca0-4af9-868a-02e71c3d996`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### erlang
```diff
+A `exercises.practice.uuid` value is `8c58533a-7a1f-11e8-adc0-fa7ae01bbebc`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `589b763c-2b3a-11e8-b467-0ed5f89f718b`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `a534bd4a-8a72-11e8-9a94-a6cf71072f73`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `9bb14014-9732-11e8-9eb6-529269fb1459`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `f93f5f18-3e3b-11e8-b467-0ed5f89f718b`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### fsharp
```diff
+A `exercises.concept.uuid` value is `1fc8216e-6519-11ea-bc55-0242ac130003`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.concept.uuid` value is `82470e36-6447-11ea-bc55-0242ac130003`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.concept.uuid` value is `160d7d56-5a0e-11ea-8e2d-0242ac130003`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.concept.uuid` value is `263670c8-6915-11ea-bc55-0242ac130003`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.concept.uuid` value is `ef2df8b0-63a8-11ea-bc55-0242ac130003`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.concept.uuid` value is `6ea2765e-5885-11ea-82b4-0242ac130003`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.concept.uuid` value is `fad55806-69e9-11ea-bc55-0242ac130003`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.concept.uuid` value is `9c2aad8a-53ee-11ea-8d77-2e728ce88125`, which is not a lowercased version 4 UUID:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### go
```diff
+A `exercises.practice.uuid` value is `29ea064e-9d2a-11e7-abc4-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `408f235e-f1ce-11e7-8c3f-9a214cf093ae`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `6b313720-104a-46c2-8290-4b4af121101f `, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `13A25814-67F6-44BC-A3FE-6DD240549701`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### haskell
```diff
+A `exercises.practice.uuid` value is `138db4fc-ee70-11e8-8eb2-f2801f1b9fd1`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### haxe
```diff
+A `exercises.practice.uuid` value is `d30952cf-0b7d-a980-9351-caedebfed16362c6a7a`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### javascript
```diff
+A `exercises.practice.uuid` value is `19b41c4a-1466-5c19-b547-40284189fd18`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `4be85b5e-6b13-11e7-907b-a6006ad3dba0`, which is not a lowercased version 4 UUID:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### kotlin
```diff
+A `exercises.practice.uuid` value is `0000e75e-9b43-11e8-98d0-529269fb1459`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### ocaml
```diff
+A `exercises.practice.uuid` value is `9d26763a-cbd0-11e8-a8d5-f2801f1b9fd1`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### pharo-smalltalk
```diff
+A `exercises.practice.uuid` value is `9e0074be-4a3f-0d00-bb4e-73e5071d6982`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `93dde1bb-8040-0d00-812a-052301deb008`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `49ae8e78-a641-0d00-ba20-5f9f04641ab1`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `bea80017-9d41-0d00-900d-a13308866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `8198e8bb-8040-0d00-812f-dfab01deb008`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `98e35398-a743-0d00-aeac-1c4207045670`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `c698dfbb-8040-0d00-8127-69c701deb008`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `7bec34be-4a3f-0d00-bb23-9404071d6982`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `15f1a716-9d41-0d00-8fc9-66a908866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `7047d916-9d41-0d00-8ff2-3a9808866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `f8080717-9d41-0d00-9011-755a08866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `98fc253b-e642-0d00-8e1a-5ef3059054ed`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `c0bcb6c5-3f3f-0d00-995d-a4720043fb1f`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `d166a016-9d41-0d00-8fc3-1ee008866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `d126be16-9d41-0d00-8fdc-2ff208866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `d6303b3f-0f41-0d00-a5e1-db510c056502`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `aa15f716-9d41-0d00-9006-3c7208866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `69f615da-2b3f-0d00-a2ed-aca409f0590c`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `5f1a9f16-9d41-0d00-8fc2-6a7408866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `c0b69b16-9d41-0d00-8fbf-acfc08866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `b4e3babb-8040-0d00-80fa-71e001deb008`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `973e4910-7940-0d00-bbad-09db01dff3c9`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `6be398be-4a3f-0d00-bb67-0d71071d6982`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `2020ac16-9d41-0d00-8fcd-fe0908866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `cc8b42be-4a3f-0d00-bb2c-6d04071d6982`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `a90be8bb-8040-0d00-812e-0c1701deb008`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `0dc70bf9-e642-0d00-8e2f-4d97059054ed`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `c728b116-9d41-0d00-8fd2-aa8a08866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `ffe8dcbb-8040-0d00-8124-bf5801deb008`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `6298e416-9d41-0d00-8ffa-c83508866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `a5de8cbe-4a3f-0d00-bb5e-8947071d6982`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `1318c616-9d41-0d00-8fe3-676108866539`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `5438fabb-8040-0d00-8145-63f301deb008`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `494d55f9-d941-0d00-a5c2-334307d29f14`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `1109cabb-8040-0d00-810e-7c1b01deb008`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `dbea4db3-5044-0d00-ab77-b35a0c226d01`, which is not a lowercased version 4 UUID:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### php
```diff
+A `exercises.practice.uuid` value is `94AA4B63-66BA-4EF4-8E27-36C146682F05`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `CDEAE0AF-7DBE-4D0E-ACD6-915998D273EA`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `57E13615-4C88-42E1-A4AE-C2DED7A6FDB2`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `C5D81BB4-7041-4EA9-B0ED-C3A17CF3E071`, which is not a lowercased version 4 UUID:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### plsql
```diff
+A `exercises.practice.uuid` value is `53156fc9-0945-f080-08a9-ce269bfc9121a5d2c5c`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### python
```diff
+A `exercises.practice.uuid` value is `e9b0defc-dac5-11e7-9296-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `d4ddeb18-ac22-11e7-abc4-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `f5503274-ac23-11e7-abc4-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `bb07c236-062c-2980-483a-a221e4724445dcd6f32`, which is not a lowercased version 4 UUID:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### r
```diff
+A `exercises.practice.uuid` value is `7cad82d6-0db6-d680-4133-81d850d6e7a925454a0`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### ruby
```diff
+A `exercises.concept.uuid` value is `4d271980-ab4b-11ea-bb37-0242ac130002`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.concept.uuid` value is `e5476046-5289-11ea-8d77-2e728ce88125`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.concept.uuid` value is `71ae39c4-7364-11ea-bc55-0242ac130003`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `b960d0fe-a07f-11ea-bb37-0242ac130002`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### rust
```diff
+A `exercises.concept.uuid` value is `e7d8603e-97a9-11ea-9753-0242ac110002`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `79613fd8-b7da-11e7-abc4-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `ccebfa12-d224-11e7-8941-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `23d82e48-d074-11e7-8fab-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `f424a350-50bd-11e8-9c2d-fa7ae01bbebc`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `c6631a2c-4632-11e8-842f-0ed5f89f718b`, which is not a lowercased version 4 UUID:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### scala
```diff
+A `exercises.practice.uuid` value is `65a76aba-a485-222d-84ba-e9a445b25be6`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### sml
```diff
+A `exercises.practice.uuid` value is `3c6209d0-d095-11e8-a8d5-f2801f1b9fd1`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### solidity
```diff
+A `exercises.practice.uuid` value is `ea77f8c4-2f69-11eb-adc1-0242ac120002`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `6b789dc6-303b-11eb-adc1-0242ac120002`, which is not a lowercased version 4 UUID:
+./config.json
+
```

#### typescript
```diff
+A `exercises.practice.uuid` value is `78645d36-12be-11ea-8d71-362b9e155667`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `7d42dd76-a6cf-11e7-abc4-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `7dd29a19-08f6-8480-2e01-1f7262d8860a`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `4ecf9470-a959-11e7-abc4-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `3cc210e8-b3bb-11e7-abc4-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `8ba2c83e-f544-11e9-802a-5aa538984bd8`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `e16c3064-b2ef-11e7-abc4-cec278b6b50a`, which is not a lowercased version 4 UUID:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### z3
```diff
+A `exercises.practice.uuid` value is `TODO: Add uuid`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `exercises.practice.uuid` value is `TODO: Add uuid`, which is not unique on the track:
+./config.json
+
+A `exercises.practice.uuid` value is `TODO: Add uuid`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not unique on the track:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not unique on the track:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not unique on the track:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not unique on the track:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not unique on the track:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not unique on the track:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not a lowercased version 4 UUID:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not unique on the track:
+./config.json
+
+A `concepts.uuid` value is `TODO: Add uuid`, which is not a lowercased version 4 UUID:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

#### zig
```diff
+A `exercises.practice.uuid` value is `bf256ae9-9e65-48bf-8f27-fde487c05856`, which is not unique on the track:
+./config.json
+
```

</details>