### PR TITLE
build: bump Nim from 1.4.4 to 1.4.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@d0c07f7ad4ed045c29cfcffbc1402643f8147184 # 1.3.2
         with:
-          nim-version: "1.4.4"
+          nim-version: "1.4.6"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@d0c07f7ad4ed045c29cfcffbc1402643f8147184 # 1.3.2
         with:
-          nim-version: "1.4.4"
+          nim-version: "1.4.6"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -7,7 +7,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 1.4.4"
+requires "nim >= 1.4.6"
 requires "parsetoml"
 requires "cligen"
 requires "uuids >= 0.1.11"


### PR DESCRIPTION
This is a small patch release.

See:
- https://nim-lang.org/blog/2021/04/15/versions-146-and-1212-released.html
- https://github.com/nim-lang/Nim/compare/v1.4.4...v1.4.6

---

In case anybody was wondering: bumping the version in `configlet.nimble` isn't necessary, but I do it deliberately. Our codebase will likely compile with some older version, but I don't want to keep track of the lowest supported Nim version (or add earlier Nim versions to CI).

People use `configlet` as a binary, not a library, so we're just forcing `configlet` developers to have the latest stable (or a recent `devel`) version of Nim installed. That's a little annoying, but it does eliminate an entire class of issues. And it's more user-friendly than seeing errors due to old/untested Nim versions.