### PR TITLE
lint(concept_exercises): validate `icon` property

### DIFF
--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -22,6 +22,7 @@ proc isValidConceptExerciseConfig(data: JsonNode, path: Path): bool =
       hasValidFiles(data, path),
       hasArrayOfStrings(data, "forked_from", path, isRequired = false),
       hasString(data, "language_versions", path, isRequired = false),
+      hasString(data, "icon", path, isRequired = false, checkIsKebab = true),
     ]
     result = allTrue(checks)
 


### PR DESCRIPTION
Check the `icon` property of the `.meta/config.json` file of Concept Exercises.

See https://github.com/exercism/docs/pull/123
