### PR TITLE
lint(track_config): validate editor language properties

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -65,6 +65,8 @@ proc hasValidOnlineEditor(data: JsonNode; path: Path): bool =
     let checks = [
       hasString(d, "indent_style", path, k, allowed = indentStyles),
       hasInteger(d, "indent_size", path, k, allowed = 0..8),
+      hasString(d, "ace_editor_language", path, k),
+      hasString(d, "highlightjs_language", path, k),
     ]
     result = allTrue(checks)
 


### PR DESCRIPTION
This PR implements the rules for two new fields in the `online_editor` key:

- The `"ace_editor_language"` key is required
- The `"ace_editor_language"` value must be a non-blank string
- The `"highlightjs_language"` key is required
- The `"highlightjs_language"` value must be a non-blank string

See https://github.com/exercism/docs/pull/124/files
