### PR TITLE
lint(validators): support checking arrays for duplicates

### DIFF
--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -283,7 +283,9 @@ proc isArrayOfStrings*(data: JsonNode;
           elif uniqueValues:
             let itemStr = item.getStr()
             if processedItems.containsOrIncl(itemStr):
-              result.setFalseAndPrint(&"The {q context} array contains duplicate {q itemStr} values", path)
+              let msg = &"The {q context} array contains duplicate " &
+                        &"{q itemStr} values"
+              result.setFalseAndPrint(msg, path)
       else:
         let msgStart = &"The {q context} array has length {arrayLen}, " &
                         "but it must have length "


### PR DESCRIPTION
Some string arrays have a constraint that their values must be unique, i.e. they must not be repeated.

The `isArrayOfStrings` and `hasArrayOfStrings` functions now take a `uniqueValues` argument with which uniqueness of the array values can be enforced. The default behavior is to allow duplicate values in an array.
