### PR TITLE
lint: validate concept .meta/config.json file

### DIFF
--- a/src/lint/concepts.nim
+++ b/src/lint/concepts.nim
@@ -36,6 +36,26 @@ proc isEveryConceptLinksFileValid*(trackDir: Path): bool =
         if not isValidLinksFile(j, linksPath):
           result = false
 
+proc isValidConceptConfig(data: JsonNode, path: Path): bool =
+  if isObject(data, "", path):
+    let checks = [
+      hasString(data, "blurb", path, maxLen = 350),
+      hasArrayOfStrings(data, "authors", path),
+      hasArrayOfStrings(data, "contributors", path, isRequired = false),
+    ]
+    result = allTrue(checks)
+
+proc isEveryConceptConfigValid*(trackDir: Path): bool =
+  let conceptsDir = trackDir / "concepts"
+  result = true
+  if dirExists(conceptsDir):
+    for conceptDir in getSortedSubdirs(conceptsDir):
+      let configPath = conceptDir / ".meta" / "config.json"
+      let j = parseJsonFile(configPath, result)
+      if j != nil:
+        if not isValidConceptConfig(j, configPath):
+          result = false
+
 proc conceptDocsExist*(trackDir: Path): bool =
   ## Returns true if every subdirectory in `trackDir/concepts` has the required
   ## Markdown files.

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -12,6 +12,7 @@ proc allChecksPass(trackDir: Path): bool =
     practiceExerciseDocsExist(trackDir),
     conceptDocsExist(trackDir),
     isEveryConceptLinksFileValid(trackDir),
+    isEveryConceptConfigValid(trackDir),
     isEveryConceptExerciseConfigValid(trackDir),
     isEveryPracticeExerciseConfigValid(trackDir),
   ]
@@ -32,6 +33,7 @@ Basic linting finished successfully:
     language, slug, active, blurb, version, status, online_editor, key_features, tags
 - Every concept has the required .md files
 - Every concept has a valid links.json file
+- Every concept has a valid .meta/config.json file
 - Every concept exercise has the required .md files
 - Every concept exercise has a valid .meta/config.json file
 - Every practice exercise has the required .md files


### PR DESCRIPTION
This PR implements the rules for the .meta/config.json file of a concept:
- The file must be valid JSON
- The JSON root must be an object
- The "blurb" key is required
- The "blurb" value must be a non-blank string¹ with length <= 350
- The "authors" key is required
- The "authors" value must be an array
- The "authors" values must be non-blank strings
- The "contributors" key is optional
- The "contributors" value must be an array
- The "contributors" values must be non-blank strings

It doesn't yet implement the uniqueness rules, which will be added once https://github.com/exercism/configlet/pull/295 is merged.
