### PR TITLE
sync: prefer the object construction syntax

### DIFF
--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -25,9 +25,11 @@ type
     testCases*: seq[ExerciseTestCase]
 
 func initExerciseTests*(included, excluded, missing: HashSet[string]): ExerciseTests =
-  result.included = included
-  result.excluded = excluded
-  result.missing = missing
+  ExerciseTests(
+    included: included,
+    excluded: excluded,
+    missing: missing,
+  )
 
 proc initExerciseTests(trackExercise: TrackExercise, probSpecsExercise: ProbSpecsExercise): ExerciseTests =
   for testCase in probSpecsExercise.testCases:
@@ -39,10 +41,11 @@ proc initExerciseTests(trackExercise: TrackExercise, probSpecsExercise: ProbSpec
       result.missing.incl(testCase.uuid)
 
 proc newExerciseTestCase(testCase: ProbSpecsTestCase): ExerciseTestCase =
-  result = new(ExerciseTestCase)
-  result.uuid = testCase.uuid
-  result.description = testCase.description
-  result.json = testCase.json
+  ExerciseTestCase(
+    uuid: testCase.uuid,
+    description: testCase.description,
+    json: testCase.json,
+  )
 
 proc newExerciseTestCases(testCases: seq[ProbSpecsTestCase]): seq[ExerciseTestCase] =
   for testCase in testCases:
@@ -56,9 +59,11 @@ proc newExerciseTestCases(testCases: seq[ProbSpecsTestCase]): seq[ExerciseTestCa
       testCase.reimplements = some(testCasesByUuids[reimplementations[testCase.uuid]])
 
 proc initExercise(trackExercise: TrackExercise, probSpecsExercise: ProbSpecsExercise): Exercise =
-  result.slug = trackExercise.slug
-  result.tests = initExerciseTests(trackExercise, probSpecsExercise)
-  result.testCases = newExerciseTestCases(probSpecsExercise.testCases)
+  Exercise(
+    slug: trackExercise.slug,
+    tests: initExerciseTests(trackExercise, probSpecsExercise),
+    testCases: newExerciseTestCases(probSpecsExercise.testCases),
+  )
 
 proc findExercises*(conf: Conf): seq[Exercise] =
   let probSpecsExercises = findProbSpecsExercises(conf).mapIt((it.slug, it)).toTable

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -23,7 +23,7 @@ proc probSpecsDir: string =
   getCurrentDir() / ".problem-specifications"
 
 proc initProbSpecsRepo: ProbSpecsRepo =
-  result.dir = probSpecsDir()
+  ProbSpecsRepo(dir: probSpecsDir())
 
 proc clone(repo: ProbSpecsRepo) =
   let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {repo.dir}"
@@ -34,7 +34,7 @@ proc remove(repo: ProbSpecsRepo) =
   removeDir(repo.dir)
 
 func initProbSpecsRepoExercise(dir: string): ProbSpecsRepoExercise =
-  result.dir = dir
+  ProbSpecsRepoExercise(dir: dir)
 
 func exercisesDir(repo: ProbSpecsRepo): string =
   repo.dir / "exercises"
@@ -57,7 +57,7 @@ func slug(repoExercise: ProbSpecsRepoExercise): string =
   extractFilename(repoExercise.dir)
 
 func initProbSpecsTestCase(node: JsonNode): ProbSpecsTestCase =
-  result.json = node
+  ProbSpecsTestCase(json: node)
 
 proc uuid*(testCase: ProbSpecsTestCase): string =
   testCase.json["uuid"].getStr()
@@ -94,8 +94,10 @@ proc parseProbSpecsTestCases(repoExercise: ProbSpecsRepoExercise): seq[ProbSpecs
     repoExercise.canonicalDataFile().parseFile().initProbSpecsTestCases()
 
 proc initProbSpecsExercise(repoExercise: ProbSpecsRepoExercise): ProbSpecsExercise =
-  result.slug = repoExercise.slug
-  result.testCases = parseProbSpecsTestCases(repoExercise)
+  ProbSpecsExercise(
+    slug: repoExercise.slug,
+    testCases: parseProbSpecsTestCases(repoExercise),
+  )
 
 proc findProbSpecsExercises(repo: ProbSpecsRepo, conf: Conf): seq[ProbSpecsExercise] =
   for repoExercise in repo.exercisesWithCanonicalData():

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -48,7 +48,7 @@ proc parseConfigJson(filePath: string): ConfigJson =
 
 func newTrackRepoExercise(repo: TrackRepo,
     exercise: ConfigJsonExercise): TrackRepoExercise =
-  result.dir = repo.practiceExerciseDir(exercise)
+  TrackRepoExercise(dir: repo.practiceExerciseDir(exercise))
 
 proc exercises(repo: TrackRepo): seq[TrackRepoExercise] =
   let config = parseConfigJson(repo.configJsonFile)
@@ -79,8 +79,10 @@ proc newTrackExerciseTests(exercise: TrackRepoExercise): TrackExerciseTests =
       result.included.incl(uuid)
 
 proc newTrackExercise(exercise: TrackRepoExercise): TrackExercise =
-  result.slug = exercise.slug
-  result.tests = newTrackExerciseTests(exercise)
+  TrackExercise(
+    slug: exercise.slug,
+    tests: newTrackExerciseTests(exercise),
+  )
 
 proc findTrackExercises(repo: TrackRepo, conf: Conf): seq[TrackExercise] =
   for repoExercise in repo.exercises:


### PR DESCRIPTION
Reasons:
- It works for both `object` and `ref object`. For the latter, we can
  remove the call to `new` - it is invoked implicitly for `ref object`.
- It's easier for the compiler to prove that an object has been fully
  initialized.
- It's arguably more readable.

---

See https://github.com/exercism/configlet/issues/64