### PR TITLE
sync: prefer `init` for initializing non-ref objects

### DIFF
--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -47,7 +47,7 @@ proc newExerciseTestCase(testCase: ProbSpecsTestCase): ExerciseTestCase =
     json: testCase.json,
   )
 
-proc newExerciseTestCases(testCases: seq[ProbSpecsTestCase]): seq[ExerciseTestCase] =
+proc initExerciseTestCases(testCases: seq[ProbSpecsTestCase]): seq[ExerciseTestCase] =
   for testCase in testCases:
     result.add(newExerciseTestCase(testCase))
 
@@ -62,7 +62,7 @@ proc initExercise(trackExercise: TrackExercise, probSpecsExercise: ProbSpecsExer
   Exercise(
     slug: trackExercise.slug,
     tests: initExerciseTests(trackExercise, probSpecsExercise),
-    testCases: newExerciseTestCases(probSpecsExercise.testCases),
+    testCases: initExerciseTestCases(probSpecsExercise.testCases),
   )
 
 proc findExercises*(conf: Conf): seq[Exercise] =

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -46,7 +46,7 @@ proc parseConfigJson(filePath: string): ConfigJson =
   let json = json.parseFile(filePath)["exercises"]
   to(json, ConfigJson)
 
-func newTrackRepoExercise(repo: TrackRepo,
+func initTrackRepoExercise(repo: TrackRepo,
     exercise: ConfigJsonExercise): TrackRepoExercise =
   TrackRepoExercise(dir: repo.practiceExerciseDir(exercise))
 
@@ -54,7 +54,7 @@ proc exercises(repo: TrackRepo): seq[TrackRepoExercise] =
   let config = parseConfigJson(repo.configJsonFile)
 
   for exercise in config.practice:
-    result.add(newTrackRepoExercise(repo, exercise))
+    result.add(initTrackRepoExercise(repo, exercise))
 
 proc newTrackExerciseTests(exercise: TrackRepoExercise): TrackExerciseTests =
   if not fileExists(exercise.testsFile):

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -78,7 +78,7 @@ proc initTrackExerciseTests(exercise: TrackRepoExercise): TrackExerciseTests =
     else:
       result.included.incl(uuid)
 
-proc newTrackExercise(exercise: TrackRepoExercise): TrackExercise =
+proc initTrackExercise(exercise: TrackRepoExercise): TrackExercise =
   TrackExercise(
     slug: exercise.slug,
     tests: initTrackExerciseTests(exercise),
@@ -87,7 +87,7 @@ proc newTrackExercise(exercise: TrackRepoExercise): TrackExercise =
 proc findTrackExercises(repo: TrackRepo, conf: Conf): seq[TrackExercise] =
   for repoExercise in repo.exercises:
     if conf.action.exercise.len == 0 or conf.action.exercise == repoExercise.slug:
-      result.add(newTrackExercise(repoExercise))
+      result.add(initTrackExercise(repoExercise))
 
 proc findTrackExercises*(conf: Conf): seq[TrackExercise] =
   let trackRepo = TrackRepo(dir: conf.trackDir)

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -56,7 +56,7 @@ proc exercises(repo: TrackRepo): seq[TrackRepoExercise] =
   for exercise in config.practice:
     result.add(initTrackRepoExercise(repo, exercise))
 
-proc newTrackExerciseTests(exercise: TrackRepoExercise): TrackExerciseTests =
+proc initTrackExerciseTests(exercise: TrackRepoExercise): TrackExerciseTests =
   if not fileExists(exercise.testsFile):
     return
 
@@ -81,7 +81,7 @@ proc newTrackExerciseTests(exercise: TrackRepoExercise): TrackExerciseTests =
 proc newTrackExercise(exercise: TrackRepoExercise): TrackExercise =
   TrackExercise(
     slug: exercise.slug,
-    tests: newTrackExerciseTests(exercise),
+    tests: initTrackExerciseTests(exercise),
   )
 
 proc findTrackExercises(repo: TrackRepo, conf: Conf): seq[TrackExercise] =


### PR DESCRIPTION
From the [Nim standard library style guide](https://nim-lang.github.io/Nim/nep1.html#introduction-naming-conventions):

> `initFoo` initializes a value type `Foo`

> `newFoo`: initializes a reference type `Foo` via `new` or a value type `Foo` with reference semantics.

However, in the generated code, any object bigger than 24 bytes is
actually passed by reference. Therefore we don't need to think about
performance when deciding between `object` and `ref object`.

Note that `newSeq` and `newString` were named before Nim had this naming
convention - they do not comply with it. That is, `string` and `seq`
each have value semantics by default (an assignment creates a copy).

See also: #64