### PR TITLE
ci: use `--styleCheck:hint` not `--styleCheck:error`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,5 +52,5 @@ jobs:
       - name: Install our Nimble dependencies
         run: nimble --accept install --depsOnly
 
-      - name: Run `tests/all_tests.nim`
-        run: nim c --styleCheck:error -r ./tests/all_tests.nim
+      - name: Run our test suite
+        run: nimble test


### PR DESCRIPTION
`--styleCheck:error` is useful because it makes a identifier naming
inconsistency cause a failing CI check. However, it also checks the
identifier naming in dependencies, such as the Nimble packages that we
import. This has become too inconvenient.

This commit alters our CI to use `nimble test`, which effectively moves
us back to `--styleCheck:hint` (as specified by our `config.nims` file).

The development version of Nim has a new CLI option that allows turning
a hint into an error. That is, in the future we could use
`--hintAsError[Name]:on` to get the best of both worlds.