### PR TITLE
generate: add `generate` command

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -157,7 +157,7 @@ func genHelpText: string =
 
   var optSeen: set[Opt] = {}
   for actionKind in ActionKind:
-    if actionKind notin {actNil, actLint}:
+    if actionKind notin {actNil, actLint, actGenerate}:
       result &= &"\nOptions for {actionKind}:\n"
       let action = Action(kind: actionKind)
       for key, val in fieldPairs(action):

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -17,6 +17,7 @@ type
     actLint = "lint"
     actSync = "sync"
     actUuid = "uuid"
+    actGenerate = "generate"
 
   Action* = object
     case kind*: ActionKind
@@ -32,6 +33,8 @@ type
       offline*: bool
     of actUuid:
       num*: int
+    of actGenerate:
+      discard
 
   Conf* = object
     action*: Action
@@ -233,6 +236,8 @@ func initAction*(actionKind: ActionKind, probSpecsDir = ""): Action =
     Action(kind: actionKind, probSpecsDir: probSpecsDir)
   of actUuid:
     Action(kind: actionKind, num: 1)
+  of actGenerate:
+    Action(kind: actionKind)
 
 func initConf*(action = initAction(actNil), trackDir = getCurrentDir(),
                verbosity = verNormal): Conf =
@@ -372,6 +377,8 @@ proc handleOption(conf: var Conf; kind: CmdLineKind; key, val: string) =
         setActionOpt(num, num)
       else:
         discard
+    of actGenerate:
+      discard
 
   if not isGlobalOpt and not isActionOpt:
     case conf.action.kind
@@ -404,4 +411,6 @@ proc processCmdLine*: Conf =
       showError(&"'{list(optSyncOffline)}' was given without passing " &
                 &"'{list(optSyncProbSpecsDir)}'")
   of actUuid:
+    discard
+  of actGenerate:
     discard

--- a/src/configlet.nim
+++ b/src/configlet.nim
@@ -1,5 +1,5 @@
 import std/posix
-import "."/[cli, lint/lint, logger, sync/check, sync/sync, uuid/uuid]
+import "."/[cli, generate/generate, lint/lint, logger, sync/check, sync/sync, uuid/uuid]
 
 proc main =
   onSignal(SIGTERM):
@@ -21,5 +21,7 @@ proc main =
       sync(conf)
   of actUuid:
     uuid(conf.action.num)
+  of actGenerate:
+    generate(conf)
 
 main()

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -10,7 +10,8 @@ proc writeError(description: string, path: Path) =
   stderr.writeLine(path)
   stderr.write "\n"
 
-proc conceptIntroduction(trackDir: Path, slug: string, templatePath: Path): string =
+proc conceptIntroduction(trackDir: Path, slug: string,
+                         templatePath: Path): string =
   ## Returns the contents of the `introduction.md` file for a `slug`, but
   ## without any top-level heading, and without any leading/trailing whitespace.
   let conceptDir = trackDir / "concepts" / slug
@@ -20,7 +21,8 @@ proc conceptIntroduction(trackDir: Path, slug: string, templatePath: Path): stri
       let content = readFile(path)
       var idx = 0
       # Strip the top-level heading (if any)
-      if scanp(content, idx, *{' ', '\t', '\v', '\c', '\n', '\f'}, "#", +' ', +(~'\n')):
+      if scanp(content, idx, *{' ', '\t', '\v', '\c', '\n', '\f'}, "#", +' ',
+               +(~'\n')):
         result = content.substr(idx).strip
       else:
         result = content.strip
@@ -28,7 +30,8 @@ proc conceptIntroduction(trackDir: Path, slug: string, templatePath: Path): stri
       writeError(&"File {path} not found for concept '{slug}'", templatePath)
       quit(1)
   else:
-    writeError(&"Directory {conceptDir} not found for concept '{slug}'", templatePath)
+    writeError(&"Directory {conceptDir} not found for concept '{slug}'",
+               templatePath)
     quit(1)
 
 proc generateIntroduction(trackDir: Path, templatePath: Path): string =

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -43,11 +43,11 @@ proc generateIntroduction(trackDir: Path, templatePath: Path): string =
   while idx < content.len:
     var conceptSlug = ""
     # Here, we implement the syntax for a placeholder as %{concept:some-slug}
-    # where we allow spaces/tabs after the opening brace, around the
-    # colon, and before the closing brace. The slug must be in kebab-case.
+    # where we allow spaces after the opening brace, around the colon,
+    # and before the closing brace. The slug must be in kebab-case.
     if scanp(content, idx,
-            "%{", *{' ', '\t'}, "concept", *{' ', '\t'}, ':', *{' ', '\t'},
-            +{'a'..'z', '-'} -> conceptSlug.add($_), *{' ', '\t'}, '}'):
+             "%{", *{' '}, "concept", *{' '}, ':', *{' '},
+             +{'a'..'z', '-'} -> conceptSlug.add($_), *{' '}, '}'):
       result.add conceptIntroduction(trackDir, conceptSlug, templatePath)
     else:
       result.add content[idx]

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -3,12 +3,12 @@ import ".."/[cli, helpers]
 
 proc writeError(description, path: string) =
   let descriptionPrefix = description & ":"
-  if colorStdout:
-    stdout.styledWriteLine(fgRed, descriptionPrefix)
+  if colorStderr:
+    stderr.styledWriteLine(fgRed, descriptionPrefix)
   else:
-    stdout.writeLine(descriptionPrefix)
-  stdout.writeLine(path)
-  stdout.write "\n"
+    stderr.writeLine(descriptionPrefix)
+  stderr.writeLine(path)
+  stderr.write "\n"
 
 proc conceptIntroduction(conf: Conf, slug: string, templateFilePath: Path): string =
   let conceptDir = conf.trackDir / "concepts" / slug

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -11,6 +11,8 @@ proc writeError(description: string, path: Path) =
   stderr.write "\n"
 
 proc conceptIntroduction(trackDir: Path, slug: string, templatePath: Path): string =
+  ## Returns the contents of the `introduction.md` file for a `slug`, but
+  ## without any top-level heading, and without any leading/trailing whitespace.
   let conceptDir = trackDir / "concepts" / slug
   if dirExists(conceptDir):
     let path = conceptDir / "introduction.md"
@@ -30,11 +32,16 @@ proc conceptIntroduction(trackDir: Path, slug: string, templatePath: Path): stri
     quit(1)
 
 proc generateIntroduction(trackDir: Path, templatePath: Path): string =
+  ## Reads the file at `templatePath` and returns the content of the
+  ## corresponding `introduction.md` file.
   let content = readFile(templatePath)
 
   var idx = 0
   while idx < content.len:
     var conceptSlug = ""
+    # Here, we implement the syntax for a placeholder as %{concept:some-slug}
+    # where we allow spaces/tabs after the opening brace, around the
+    # colon, and before the closing brace. The slug must be in kebab-case.
     if scanp(content, idx,
             "%{", *{' ', '\t'}, "concept", *{' ', '\t'}, ':', *{' ', '\t'},
             +{'a'..'z', '-'} -> conceptSlug.add($_), *{' ', '\t'}, '}'):
@@ -44,6 +51,8 @@ proc generateIntroduction(trackDir: Path, templatePath: Path): string =
       inc idx
 
 proc generate*(conf: Conf) =
+  ## For every Concept Exercise in `conf.trackDir` with an `introduction.md.tpl`
+  ## file, write the corresponding `introduction.md` file.
   let trackDir = Path(conf.trackDir)
 
   let conceptExercisesDir = trackDir / "exercises" / "concept"

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -10,7 +10,7 @@ proc writeError(description: string, path: Path) =
   stderr.writeLine(path)
   stderr.write "\n"
 
-proc conceptIntroduction(trackDir: Path, slug: string, templateFilePath: Path): string =
+proc conceptIntroduction(trackDir: Path, slug: string, templatePath: Path): string =
   let conceptDir = trackDir / "concepts" / slug
   if dirExists(conceptDir):
     let path = conceptDir / "introduction.md"
@@ -23,14 +23,14 @@ proc conceptIntroduction(trackDir: Path, slug: string, templateFilePath: Path): 
       else:
         result = content.strip
     else:
-      writeError(&"File {path} not found for concept '{slug}'", templateFilePath)
+      writeError(&"File {path} not found for concept '{slug}'", templatePath)
       quit(1)
   else:
-    writeError(&"Directory {conceptDir} not found for concept '{slug}'", templateFilePath)
+    writeError(&"Directory {conceptDir} not found for concept '{slug}'", templatePath)
     quit(1)
 
-proc generateIntroduction(trackDir: Path, templateFilePath: Path): string =
-  let content = readFile(templateFilePath)
+proc generateIntroduction(trackDir: Path, templatePath: Path): string =
+  let content = readFile(templatePath)
 
   var idx = 0
   while idx < content.len:
@@ -38,7 +38,7 @@ proc generateIntroduction(trackDir: Path, templateFilePath: Path): string =
     if scanp(content, idx,
             "%{", *{' ', '\t'}, "concept", *{' ', '\t'}, ':', *{' ', '\t'},
             +{'a'..'z', '-'} -> conceptSlug.add($_), *{' ', '\t'}, '}'):
-      result.add conceptIntroduction(trackDir, conceptSlug, templateFilePath)
+      result.add conceptIntroduction(trackDir, conceptSlug, templatePath)
     else:
       result.add content[idx]
       inc idx
@@ -49,8 +49,8 @@ proc generate*(conf: Conf) =
   let conceptExercisesDir = trackDir / "exercises" / "concept"
   if dirExists(conceptExercisesDir):
     for conceptExerciseDir in getSortedSubdirs(conceptExercisesDir):
-      let introductionTemplateFilePath = conceptExerciseDir / ".docs" / "introduction.md.tpl"
-      if fileExists(introductionTemplateFilePath):
-        let introduction = generateIntroduction(trackDir, introductionTemplateFilePath)
-        let introductionFilePath = conceptExerciseDir / ".docs" / "introduction.md"
-        writeFile(introductionFilePath, introduction)
+      let introductionTemplatePath = conceptExerciseDir / ".docs" / "introduction.md.tpl"
+      if fileExists(introductionTemplatePath):
+        let introduction = generateIntroduction(trackDir, introductionTemplatePath)
+        let introductionPath = conceptExerciseDir / ".docs" / "introduction.md"
+        writeFile(introductionPath, introduction)

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -1,0 +1,56 @@
+import std/[os, strformat, strscans, strutils, terminal]
+import ".."/[cli, helpers]
+
+proc writeError(description, path: string) =
+  let descriptionPrefix = description & ":"
+  if colorStdout:
+    stdout.styledWriteLine(fgRed, descriptionPrefix)
+  else:
+    stdout.writeLine(descriptionPrefix)
+  stdout.writeLine(path)
+  stdout.write "\n"
+
+proc conceptIntroduction(conf: Conf, slug: string, templateFilePath: Path): string =
+  let conceptDir = conf.trackDir / "concepts" / slug
+  if dirExists(conceptDir):
+    let path = conceptDir / "introduction.md"
+    if fileExists(path):
+      let content = readFile(path)
+      var idx = 0
+      # Strip the top-level heading (if any)
+      if scanp(content, idx, *{' ', '\t', '\v', '\c', '\n', '\f'}, "#", +' ', +(~'\n')):
+        result = content.substr(idx).strip
+      else:
+        result = content.strip
+    else:
+      writeError(&"File {path} not found for concept '{slug}'", $templateFilePath)
+      quit(1)
+  else:
+    writeError(&"Directory {conceptDir} not found for concept '{slug}'", $templateFilePath)
+    quit(1)
+
+proc generateIntroduction(conf: Conf, templateFilePath: Path): string =
+  let content = readFile(templateFilePath)
+  
+  var idx = 0
+  while idx < content.len:
+    var conceptSlug = ""
+    if scanp(content, idx, 
+            "%{", *{' ', '\t'}, "concept", *{' ', '\t'}, ':', *{' ', '\t'},
+            +{'a'..'z', '-'} -> conceptSlug.add($_), *{' ', '\t'}, '}'):
+      result.add(conceptIntroduction(conf, conceptSlug, templateFilePath))
+    else:
+      result.add(content[idx])
+      inc idx
+
+proc generate*(conf: Conf) =
+  let trackDir = Path(conf.trackDir)
+
+  let conceptExercisesDir = trackDir / "exercises" / "concept"
+  if dirExists(conceptExercisesDir):
+    for conceptExerciseDir in getSortedSubdirs(conceptExercisesDir):
+      let introductionTemplateFilePath = conceptExerciseDir / ".docs" / "introduction.md.tpl"
+      if fileExists(introductionTemplateFilePath):
+        let introduction = generateIntroduction(conf, introductionTemplateFilePath)
+        let introductionFilePath = conceptExerciseDir / ".docs" / "introduction.md"
+        writeFile(introductionFilePath, introduction)

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -38,9 +38,9 @@ proc generateIntroduction(trackDir: Path, templateFilePath: Path): string =
     if scanp(content, idx,
             "%{", *{' ', '\t'}, "concept", *{' ', '\t'}, ':', *{' ', '\t'},
             +{'a'..'z', '-'} -> conceptSlug.add($_), *{' ', '\t'}, '}'):
-      result.add(conceptIntroduction(trackDir, conceptSlug, templateFilePath))
+      result.add conceptIntroduction(trackDir, conceptSlug, templateFilePath)
     else:
-      result.add(content[idx])
+      result.add content[idx]
       inc idx
 
 proc generate*(conf: Conf) =

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -31,11 +31,11 @@ proc conceptIntroduction(conf: Conf, slug: string, templateFilePath: Path): stri
 
 proc generateIntroduction(conf: Conf, templateFilePath: Path): string =
   let content = readFile(templateFilePath)
-  
+
   var idx = 0
   while idx < content.len:
     var conceptSlug = ""
-    if scanp(content, idx, 
+    if scanp(content, idx,
             "%{", *{' ', '\t'}, "concept", *{' ', '\t'}, ':', *{' ', '\t'},
             +{'a'..'z', '-'} -> conceptSlug.add($_), *{' ', '\t'}, '}'):
       result.add(conceptIntroduction(conf, conceptSlug, templateFilePath))

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -43,4 +43,4 @@ proc `/`*(head: Path; tail: string): Path {.borrow.}
 proc dirExists*(path: Path): bool {.borrow.}
 proc fileExists*(path: Path): bool {.borrow.}
 proc readFile*(path: Path): string {.borrow.}
-proc writeFile*(path: Path, content: string) {.borrow.}
+proc writeFile*(path: Path; content: string) {.borrow.}

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -39,3 +39,8 @@ proc setFalseAndPrint*(b: var bool; description: string; path: Path) =
 
 proc `$`*(path: Path): string {.borrow.}
 proc `/`*(head: Path; tail: string): Path {.borrow.}
+
+proc dirExists*(path: Path): bool {.borrow.}
+proc fileExists*(path: Path): bool {.borrow.}
+proc readFile*(path: Path): string {.borrow.}
+proc writeFile*(path: Path, content: string) {.borrow.}

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -326,8 +326,6 @@ proc hasArrayOfStrings*(data: JsonNode;
   elif not isRequired:
     result = true
 
-proc fileExists(path: Path): bool {.borrow.}
-
 proc hasArrayOfFiles*(data: JsonNode;
                       key: string;
                       path: Path;
@@ -454,8 +452,6 @@ proc hasInteger*(data: JsonNode; key: string; path: Path; context = "";
   elif not isRequired:
     result = true
 
-proc dirExists*(path: Path): bool {.borrow.}
-proc readFile(path: Path): string {.borrow.}
 proc parseJson(s: Stream; filename: Path; rawIntegers = false;
                rawFloats = false): JsonNode {.borrow.}
 


### PR DESCRIPTION
This PR adds basic support for the `generate` command: https://github.com/exercism/docs/blob/main/building/configlet/generating-documents.md

I'd really appreciate feedback on the code to see if there is anything wrong with it.

For now, I've decided to remove the level one heading from the Concept's `introduction.md` file when including it in the generated `introduction.md` file, as tracks might not want multiple level one headings. Also, a lot of the Concept `introduction.md` files have `# Introduction` as their starting (totally valid) level one heading, which would look really weird.

This PR currently does not support only generate the `introduction.md` for a single exercise, due to the inability to share properties within a `case`. This will be supported in a future version of Nim, but for now we should try an alternative approach.

