### PR TITLE
fetch-configlet: add comment with upstream location

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# This file is a copy of the
+# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet file.
+# Please submit bugfixes/improvements to the above file to ensure that all tracks
+# benefit from the changes.
+
 set -eo pipefail
 
 readonly LATEST='https://api.github.com/repos/exercism/configlet/releases/latest'

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -1,10 +1,15 @@
+# This file is a copy of the
+# https://github.com/exercism/configlet/blob/main/scripts/fetch-configlet.ps1 file.
+# Please submit bugfixes/improvements to the above file to ensure that all tracks
+# benefit from the changes.
+
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
 $requestOpts = @{
-    Headers = If ($env:GITHUB_TOKEN) { @{ Authorization = "Bearer ${env:GITHUB_TOKEN}" } } Else { @{ } }
+    Headers           = If ($env:GITHUB_TOKEN) { @{ Authorization = "Bearer ${env:GITHUB_TOKEN}" } } Else { @{ } }
     MaximumRetryCount = 3
-    RetryIntervalSec = 1
+    RetryIntervalSec  = 1
 }
 
 $arch = If ([Environment]::Is64BitOperatingSystem) { "64bit" } Else { "32bit" }


### PR DESCRIPTION
This PR adds a comment to the `scripts/fetch-configlet` and `scripts/fetch-configlet.ps1` files to help track maintainers understand that they shouldn't directly change these files in their track's repository, but instead change the upstream source.

Closes https://github.com/exercism/configlet/issues/285
