### PR TITLE
lint(validators): support checking exercise file paths

### DIFF
--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -344,8 +344,6 @@ proc hasArrayOfFiles*(data: JsonNode;
                   &"{q relativeFilePath} but {q $absoluteFilePath} could not be found"
 
         result.setFalseAndPrint(msg, path)
-  else:
-    result = false
 
 type
   ItemCall = proc(data: JsonNode; context: string; path: Path): bool {.nimcall.}

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -332,14 +332,8 @@ proc hasArrayOfFiles*(data: JsonNode;
                       key: string;
                       path: Path;
                       context = "";
-                      relativeToPath: Path;
-                      isRequired = true;
-                      uniqueValues = false;
-                      allowed = emptySetOfStrings;
-                      allowedArrayLen = 1..int.high;
-                      checkIsKebab = false): bool =
-  if hasArrayOfStrings(data, key, path, context, isRequired, uniqueValues,
-                       allowed, allowedArrayLen, checkIsKebab):
+                      relativeToPath: Path): bool =
+  if hasArrayOfStrings(data, key, path, context):
     result = true
 
     for item in data[key]:

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -342,7 +342,6 @@ proc hasArrayOfFiles*(data: JsonNode;
       if not fileExists(absoluteFilePath):
         let msg = &"The {q context} array contains value " &
                   &"{q relativeFilePath} but {q $absoluteFilePath} could not be found"
-
         result.setFalseAndPrint(msg, path)
 
 type

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -337,13 +337,13 @@ proc hasArrayOfFiles*(data: JsonNode;
     result = true
 
     for item in data[key]:
-        let relativeFilePath = item.getStr()
-        let absoluteFilePath = relativeToPath / relativeFilePath
-        if not fileExists(absoluteFilePath):
-          let msg = &"The {q context} array contains value " &
-                    &"{q relativeFilePath} but {q $absoluteFilePath} could not be found"
+      let relativeFilePath = item.getStr()
+      let absoluteFilePath = relativeToPath / relativeFilePath
+      if not fileExists(absoluteFilePath):
+        let msg = &"The {q context} array contains value " &
+                  &"{q relativeFilePath} but {q $absoluteFilePath} could not be found"
 
-          result.setFalseAndPrint(msg, path)
+        result.setFalseAndPrint(msg, path)
   else:
     result = false
 

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -326,6 +326,33 @@ proc hasArrayOfStrings*(data: JsonNode;
   elif not isRequired:
     result = true
 
+proc fileExists(path: Path): bool {.borrow.}
+
+proc hasArrayOfFiles*(data: JsonNode;
+                      key: string;
+                      path: Path;
+                      context = "";
+                      relativeToPath: Path;
+                      isRequired = true;
+                      uniqueValues = false;
+                      allowed = emptySetOfStrings;
+                      allowedArrayLen = 1..int.high;
+                      checkIsKebab = false): bool =
+  if hasArrayOfStrings(data, key, path, context, isRequired, uniqueValues,
+                       allowed, allowedArrayLen, checkIsKebab):
+    result = true
+
+    for item in data[key]:
+        let relativeFilePath = item.getStr()
+        let absoluteFilePath = relativeToPath / relativeFilePath
+        if not fileExists(absoluteFilePath):
+          let msg = &"The {q context} array contains value " &
+                    &"{q relativeFilePath} but {q $absoluteFilePath} could not be found"
+
+          result.setFalseAndPrint(msg, path)
+  else:
+    result = false
+
 type
   ItemCall = proc(data: JsonNode; context: string; path: Path): bool {.nimcall.}
 
@@ -437,7 +464,6 @@ proc hasInteger*(data: JsonNode; key: string; path: Path; context = "";
     result = true
 
 proc dirExists*(path: Path): bool {.borrow.}
-proc fileExists(path: Path): bool {.borrow.}
 proc readFile(path: Path): string {.borrow.}
 proc parseJson(s: Stream; filename: Path; rawIntegers = false;
                rawFloats = false): JsonNode {.borrow.}


### PR DESCRIPTION
The `.meta/config.json` file of Concept and Practice Exercises contains a
`files` property, which contains the (relative) path to the various files
of the exercise. This PR adds a `hasArrayOfFiles` function that:

1. Check if the property is a string array using `hasArrayOfStrings`
2. For each string value, prepend that value with the exercise dir
   and check if a file exists at that path
