### PR TITLE
lint: check file paths in exercise `.meta/config.json` files

### DIFF
--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -13,7 +13,8 @@ proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
     ]
     result = allTrue(checks)
 
-proc isValidConceptExerciseConfig(data: JsonNode; path, exerciseDir: Path): bool =
+proc isValidConceptExerciseConfig(data: JsonNode;
+                                  path, exerciseDir: Path): bool =
   if isObject(data, "", path):
     let checks = [
       hasString(data, "blurb", path, maxLen = 350),

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -2,25 +2,25 @@ import std/[json, os]
 import ".."/helpers
 import "."/validators
 
-proc hasValidFiles(data: JsonNode, path: Path): bool =
+proc hasValidFiles(data: JsonNode, path, exerciseDir: Path): bool =
   const k = "files"
   if hasObject(data, k, path):
     let d = data[k]
     let checks = [
-      hasArrayOfStrings(d, "solution", path, k),
-      hasArrayOfStrings(d, "test", path, k),
-      hasArrayOfStrings(d, "exemplar", path, k),
+      hasArrayOfFiles(d, "solution", path, k, exerciseDir),
+      hasArrayOfFiles(d, "test", path, k, exerciseDir),
+      hasArrayOfFiles(d, "exemplar", path, k, exerciseDir),
     ]
     result = allTrue(checks)
 
-proc isValidConceptExerciseConfig(data: JsonNode, path: Path): bool =
+proc isValidConceptExerciseConfig(data: JsonNode, path, exerciseDir: Path): bool =
   if isObject(data, "", path):
     let checks = [
       hasString(data, "blurb", path, maxLen = 350),
       hasArrayOfStrings(data, "authors", path, uniqueValues = true),
       hasArrayOfStrings(data, "contributors", path, isRequired = false,
                         uniqueValues = true),
-      hasValidFiles(data, path),
+      hasValidFiles(data, path, exerciseDir),
       hasArrayOfStrings(data, "forked_from", path, isRequired = false,
                         uniqueValues = true),
       hasString(data, "language_versions", path, isRequired = false),
@@ -36,7 +36,7 @@ proc isEveryConceptExerciseConfigValid*(trackDir: Path): bool =
       let configPath = exerciseDir / ".meta" / "config.json"
       let j = parseJsonFile(configPath, result)
       if j != nil:
-        if not isValidConceptExerciseConfig(j, configPath):
+        if not isValidConceptExerciseConfig(j, configPath, exerciseDir):
           result = false
 
 proc conceptExerciseDocsExist*(trackDir: Path): bool =

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -2,7 +2,7 @@ import std/[json, os]
 import ".."/helpers
 import "."/validators
 
-proc hasValidFiles(data: JsonNode, path, exerciseDir: Path): bool =
+proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
   const k = "files"
   if hasObject(data, k, path):
     let d = data[k]
@@ -13,7 +13,7 @@ proc hasValidFiles(data: JsonNode, path, exerciseDir: Path): bool =
     ]
     result = allTrue(checks)
 
-proc isValidConceptExerciseConfig(data: JsonNode, path, exerciseDir: Path): bool =
+proc isValidConceptExerciseConfig(data: JsonNode; path, exerciseDir: Path): bool =
   if isObject(data, "", path):
     let checks = [
       hasString(data, "blurb", path, maxLen = 350),

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -2,18 +2,18 @@ import std/[json, os]
 import ".."/helpers
 import "."/validators
 
-proc hasValidFiles(data: JsonNode, path: Path): bool =
+proc hasValidFiles(data: JsonNode, path, exerciseDir: Path): bool =
   const k = "files"
   if hasObject(data, k, path):
     let d = data[k]
     let checks = [
-      hasArrayOfStrings(d, "solution", path, k),
-      hasArrayOfStrings(d, "test", path, k),
-      hasArrayOfStrings(d, "example", path, k),
+      hasArrayOfFiles(d, "solution", path, k, exerciseDir),
+      hasArrayOfFiles(d, "test", path, k, exerciseDir),
+      hasArrayOfFiles(d, "example", path, k, exerciseDir),
     ]
     result = allTrue(checks)
 
-proc isValidPracticeExerciseConfig(data: JsonNode, path: Path): bool =
+proc isValidPracticeExerciseConfig(data: JsonNode, path, exerciseDir: Path): bool =
   if isObject(data, "", path):
     # TODO: Enable the `files` checks after the tracks have had some time to update.
     let checks = [
@@ -22,7 +22,7 @@ proc isValidPracticeExerciseConfig(data: JsonNode, path: Path): bool =
                         uniqueValues = true),
       hasArrayOfStrings(data, "contributors", path, isRequired = false,
                         uniqueValues = true),
-      if false: hasValidFiles(data, path) else: true,
+      hasValidFiles(data, path, exerciseDir),
       hasString(data, "language_versions", path, isRequired = false),
     ]
     result = allTrue(checks)
@@ -37,7 +37,7 @@ proc isEveryPracticeExerciseConfigValid*(trackDir: Path): bool =
       let configPath = exerciseDir / ".meta" / "config.json"
       let j = parseJsonFile(configPath, result)
       if j != nil:
-        if not isValidPracticeExerciseConfig(j, configPath):
+        if not isValidPracticeExerciseConfig(j, configPath, exerciseDir):
           result = false
 
 proc practiceExerciseDocsExist*(trackDir: Path): bool =

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -2,7 +2,7 @@ import std/[json, os]
 import ".."/helpers
 import "."/validators
 
-proc hasValidFiles(data: JsonNode, path, exerciseDir: Path): bool =
+proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
   const k = "files"
   if hasObject(data, k, path):
     let d = data[k]
@@ -13,7 +13,7 @@ proc hasValidFiles(data: JsonNode, path, exerciseDir: Path): bool =
     ]
     result = allTrue(checks)
 
-proc isValidPracticeExerciseConfig(data: JsonNode, path, exerciseDir: Path): bool =
+proc isValidPracticeExerciseConfig(data: JsonNode; path, exerciseDir: Path): bool =
   if isObject(data, "", path):
     # TODO: Enable the `files` checks after the tracks have had some time to update.
     let checks = [

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -16,7 +16,6 @@ proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
 proc isValidPracticeExerciseConfig(data: JsonNode;
                                    path, exerciseDir: Path): bool =
   if isObject(data, "", path):
-    # TODO: Enable the `files` checks after the tracks have had some time to update.
     let checks = [
       hasString(data, "blurb", path, maxLen = 350),
       hasArrayOfStrings(data, "authors", path, isRequired = false,

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -13,7 +13,8 @@ proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
     ]
     result = allTrue(checks)
 
-proc isValidPracticeExerciseConfig(data: JsonNode; path, exerciseDir: Path): bool =
+proc isValidPracticeExerciseConfig(data: JsonNode;
+                                   path, exerciseDir: Path): bool =
   if isObject(data, "", path):
     # TODO: Enable the `files` checks after the tracks have had some time to update.
     let checks = [


### PR DESCRIPTION
This PR implements the below checks for each exercise's
`.meta/config.json` file.

- The files listed in the "files.solution" array must exist
- The files listed in the "files.test" array must exist
- The files listed in the "files.exemplar" array must exist
- The files listed in the "files.example" array must exist