### PR TITLE
review: "sync: output reimplements property (#317)"

### DIFF
--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -124,7 +124,7 @@ proc toToml(exercise: Exercise, testsPath: string): string =
       if testCase.uuid notin exercise.tests.included:
         result.add "include = false\n"
 
-      # Always output the `reimplements` value, if present
+      # Always add the `reimplements` property, if present
       if testCase.reimplements.isSome():
         result.add &"reimplements = \"{testCase.reimplements.get().uuid}\"\n"
 

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -125,8 +125,8 @@ proc toToml(exercise: Exercise, testsPath: string): string =
         result.add "include = false\n"
 
       # Always output the `reimplements` value, if present
-      if testCase.reimplements.isSome:
-        result.add &"reimplements = \"{testCase.reimplements.get.uuid}\"\n"
+      if testCase.reimplements.isSome():
+        result.add &"reimplements = \"{testCase.reimplements.get().uuid}\"\n"
 
       if fileExists(testsPath):
         let currContents = parsetoml.parseFile(testsPath)

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -139,10 +139,12 @@ All exercises are synced!
 +++ exercises/practice/hamming/.meta/tests.toml
 +[db92e77e-7c72-499d-8fe6-9354d2bfd504]
 +description = "disallow left empty strand"
++reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
 +
 +
 +[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
 +description = "disallow right empty strand"
++reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
 --- exercises/practice/high-scores/.meta/tests.toml
 +++ exercises/practice/high-scores/.meta/tests.toml
 +


### PR DESCRIPTION
Some suggestions for #317.

Changes:
- Make the tests pass.
- Add some parens. This is an opinionated change, and isn't a strict improvement in readability. But I think it helps make the codebase more reader-friendly when done consistently. It also currently improves the syntax highlighting on GitHub and in many editors.
- Bikeshed comment - I didn't love "output" and "value" because it could sound like it addresses https://github.com/exercism/configlet/issues/61, but we'll address that elsewhere.