### PR TITLE
tests(sync/tracks): compare objects, not strings

### DIFF
--- a/tests/test_tracks.nim
+++ b/tests/test_tracks.nim
@@ -1,22 +1,6 @@
 # This file implements tests for `src/tracks.nim`
-import std/[os, osproc, parseutils, sets, strformat, unittest]
+import std/[os, osproc, sets, strformat, unittest]
 import "."/[cli, sync/tracks]
-
-func oneLine(s: string): string =
-  ## Returns the string `s`, but:
-  ## - replaces each newline character with a single space.
-  ## - strips all per-line leading whitespace.
-  ## - strips trailing whitespace.
-  result = newStringOfCap(s.len)
-  var i = 0
-  var line: string
-  while i < s.len:
-    i += s.skipWhitespace(i)
-    i += s.parseUntil(line, '\n', i)
-    result.add line
-    result.add " "
-  # Remove final two space characters.
-  result.setLen(result.len - 2)
 
 proc main =
   suite "findTrackExercises":
@@ -42,31 +26,33 @@ proc main =
       check:
         trackExercises.len == 68
 
-    # Here, just test against the string representation of each object (as we
-    # don't want to export more types from `tracks.nim` just for testing).
-    # This is one way of testing the public interface rather than implementation
-    # details.
     test "returns the expected object for `hello-world`":
-      const expectedHelloWorld = """
-        (slug: "hello-world",
-        tests: (included: {"af9ffe10-dc13-42d8-a742-e7bdafac449d"},
-                excluded: {}))
-      """.oneLine()
+      const expectedHelloWorld =
+        TrackExercise(
+          slug: "hello-world",
+          tests: TrackExerciseTests(
+            included: ["af9ffe10-dc13-42d8-a742-e7bdafac449d"].toHashSet(),
+            excluded: initHashSet[string](0)
+          )
+        )
 
       check:
-        trackExercises[0].`$` == expectedHelloWorld
+        trackExercises[0] == expectedHelloWorld
 
     test "returns the expected object for `two-fer`":
-      const expectedTwoFer = """
-        (slug: "two-fer",
-        tests: (included: {"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce",
-                           "3549048d-1a6e-4653-9a79-b0bda163e8d5",
-                           "b4c6dbb8-b4fb-42c2-bafd-10785abe7709"},
-                excluded: {}))
-      """.oneLine()
+      const expectedTwoFer =
+        TrackExercise(
+          slug: "two-fer",
+          tests: TrackExerciseTests(
+            included: ["1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce",
+                       "3549048d-1a6e-4653-9a79-b0bda163e8d5",
+                       "b4c6dbb8-b4fb-42c2-bafd-10785abe7709"].toHashSet(),
+            excluded: initHashSet[string](0)
+          )
+        )
 
       check:
-        trackExercises[1].`$` == expectedTwoFer
+        trackExercises[1] == expectedTwoFer
 
     # Try to remove the track directory, but allow the tests to pass if there
     # was an error removing it.


### PR DESCRIPTION
We refactored `sync/tracks.nim` to remove a non-exported field from the
`TrackExercise` object. Therefore we can now simplify the test like
this, without changing field/type visibility just for the purpose of
testing.