### PR TITLE
sync(tracks): improve some error messages

### DIFF
--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -29,22 +29,27 @@ func testsFile*(exercise: TrackExercise): string =
   PracticeExercisePath("").testsFile()
 
 proc getPracticeExercisePaths(trackDir: TrackDir): seq[PracticeExercisePath] =
-  let config = json.parseFile(trackDir / "config.json")
-  if config.hasKey("exercises"):
-    let exercises = config["exercises"]
-    if exercises.hasKey("practice"):
-      let practiceExercises = exercises["practice"]
-      result = newSeqOfCap[PracticeExercisePath](practiceExercises.len)
+  let configFile = trackDir / "config.json"
+  if fileExists(configFile):
+    let config = json.parseFile(configFile)
+    if config.hasKey("exercises"):
+      let exercises = config["exercises"]
+      if exercises.hasKey("practice"):
+        let practiceExercises = exercises["practice"]
+        result = newSeqOfCap[PracticeExercisePath](practiceExercises.len)
 
-      for exercise in practiceExercises:
-        if exercise.hasKey("slug"):
-          if exercise["slug"].kind == JString:
-            let slug = exercise["slug"].getStr()
-            let path = trackDir / "exercises" / "practice" / slug
-            result.add PracticeExercisePath(path)
+        for exercise in practiceExercises:
+          if exercise.hasKey("slug"):
+            if exercise["slug"].kind == JString:
+              let slug = exercise["slug"].getStr()
+              let path = trackDir / "exercises" / "practice" / slug
+              result.add PracticeExercisePath(path)
+    else:
+      stderr.writeLine "Error: file does not have an `exercises` key:\n" &
+                      configFile
+      quit(1)
   else:
-    stderr.writeLine "Error: file does not have an `exercises` key:\n" &
-                     trackDir / "config.json"
+    stderr.writeLine "Error: file does not exist:\n" & configFile
     quit(1)
 
 proc initTrackExerciseTests(exercisePath: PracticeExercisePath): TrackExerciseTests =

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -46,7 +46,7 @@ proc getPracticeExercisePaths(trackDir: TrackDir): seq[PracticeExercisePath] =
               result.add PracticeExercisePath(path)
     else:
       stderr.writeLine "Error: file does not have an `exercises` key:\n" &
-                      configFile
+                       configFile
       quit(1)
   else:
     stderr.writeLine "Error: file does not exist:\n" & configFile

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -29,18 +29,23 @@ func testsFile*(exercise: TrackExercise): string =
   PracticeExercisePath("").testsFile()
 
 proc getPracticeExercisePaths(trackDir: TrackDir): seq[PracticeExercisePath] =
-  let config = json.parseFile(trackDir / "config.json")["exercises"]
+  let config = json.parseFile(trackDir / "config.json")
+  if config.hasKey("exercises"):
+    let exercises = config["exercises"]
+    if exercises.hasKey("practice"):
+      let practiceExercises = exercises["practice"]
+      result = newSeqOfCap[PracticeExercisePath](practiceExercises.len)
 
-  if config.hasKey("practice"):
-    let practiceExercises = config["practice"]
-    result = newSeqOfCap[PracticeExercisePath](practiceExercises.len)
-
-    for exercise in practiceExercises:
-      if exercise.hasKey("slug"):
-        if exercise["slug"].kind == JString:
-          let slug = exercise["slug"].getStr()
-          let path = trackDir / "exercises" / "practice" / slug
-          result.add PracticeExercisePath(path)
+      for exercise in practiceExercises:
+        if exercise.hasKey("slug"):
+          if exercise["slug"].kind == JString:
+            let slug = exercise["slug"].getStr()
+            let path = trackDir / "exercises" / "practice" / slug
+            result.add PracticeExercisePath(path)
+  else:
+    stderr.writeLine "Error: file does not have an `exercises` key:\n" &
+                     trackDir / "config.json"
+    quit(1)
 
 proc initTrackExerciseTests(exercisePath: PracticeExercisePath): TrackExerciseTests =
   let testsFile = testsFile(exercisePath)


### PR DESCRIPTION
This PR tries to improve the error message for:
- a missing `exercises` key in a track `config.json` file
- a missing track `config.json` file