### PR TITLE
fetch-configlet: tweak style

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -52,7 +52,7 @@ get_download_url() {
 main() {
   if [[ -d ./bin ]]; then
     output_dir="./bin"
-  elif [[ $PWD = */bin ]]; then
+  elif [[ $PWD == */bin ]]; then
     output_dir="$PWD"
   else
     echo "Error: no ./bin directory found. This script should be ran from a repo root." >&2

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -49,7 +49,7 @@ get_download_url() {
     cut -d'"' -f4
 }
 
-main () {
+main() {
   if [[ -d ./bin ]]; then
     output_dir="./bin"
   elif [[ $PWD = */bin ]]; then


### PR DESCRIPTION
This PR:

1. Removes space before some parentheses to be more consistent with 
```
get_download_url() {
```

2. Prefer `==` to `=` inside `[[ ]]`

From https://google.github.io/styleguide/shellguide.html#testing-strings

> For clarity, use `==` for equality rather than `=` even though both
> work. The former encourages the use of `[[` and the latter can be
> confused with an assignment.