### PR TITLE
README: prefer link to linting checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Global options:
 
 ## Linting
 
-The primary function of configlet is to do _linting_: checking if a track's configuration files are properly structured - both syntactically and semantically. Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism. The full list of rules that are checked by the linter can be found [here](https://github.com/exercism/docs/blob/main/building/configlet/lint.md).
+The primary function of configlet is to do _linting_: checking if a track's configuration files are properly structured - both syntactically and semantically. Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism.
 
-The `configlet lint` command is currently in the process of being implemented.
+The `configlet lint` command is still under development. The list of currently implemented checks can be found [here](https://github.com/exercism/configlet/issues/249).
+
 
 ## Sync
 


### PR DESCRIPTION
We now have a GitHub issue that tracks the currently implemented linting
rules, but still shows the entirety, so let's link to that instead.