### PR TITLE
git: ignore all binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,25 @@
-# IDE files
+# The first 3 rules below cause every file without an extension to be ignored
+# Ignore everything
+*
+
+# Unignore all directories, including subdirectories
+!/**/
+
+# Unignore all files with extensions
+!*.*
+
+# Unignore files without an extension in these directories
+!.github/**
+!bin/**
+!scripts/**
+
+# Ignore Windows executables
+*.exe
+
+# Ignore IDE files
 .vscode/
 
-# Application binary
-configlet
-configlet.exe
-
-# Temporary repos
+# Ignore temporary repos
 .problem-specifications/
 .test_binary_problem_specifications/
 .test_binary_nim_track_repo/


### PR DESCRIPTION
This helps to reduce the noise in `git status` for a `configlet`
contributor who, for example:
- wants to compile some already committed Nim files individually, and
  sometimes uses `nim c -r` rather than `nim r`.
- has created some files that should be available on any branch, and so
  are kept uncommitted.

---

Let's just say that even **with** this PR, on my machine:
```
$ git status -s | wc -l
78
```

So this helps a bit.