### PR TITLE
lint: check `test_runner.average_run_time`

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -81,7 +81,7 @@ proc hasValidTestRunner(data: JsonNode; path: Path): bool =
           result = hasFloat(data[k], "average_run_time", path, k,
                             requirePositive = true, decimalPlaces = 1)
       else:
-        return true
+        result = true
 
 const
   statuses = ["wip", "beta", "active", "deprecated"].toHashSet()

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -70,6 +70,19 @@ proc hasValidOnlineEditor(data: JsonNode; path: Path): bool =
     ]
     result = allTrue(checks)
 
+proc hasValidTestRunner(data: JsonNode; path: Path): bool =
+  const s = "status"
+  if hasObject(data, s, path):
+    const k = "test_runner"
+    if hasBoolean(data[s], k, path, s):
+      # Only check the `test_runner` object if `status.test_runner` is `true`.
+      if data[s][k].getBool():
+        if hasObject(data, k, path):
+          result = hasFloat(data[k], "average_run_time", path, k,
+                            requirePositive = true, decimalPlaces = 1)
+      else:
+        return true
+
 const
   statuses = ["wip", "beta", "active", "deprecated"].toHashSet()
 
@@ -166,6 +179,7 @@ proc isValidTrackConfig(data: JsonNode; path: Path): bool =
       hasInteger(data, "version", path, allowed = 3..3),
       hasValidStatus(data, path),
       hasValidOnlineEditor(data, path),
+      hasValidTestRunner(data, path),
       hasValidExercises(data, path),
       hasValidConcepts(data, path),
       hasValidKeyFeatures(data, path),

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -1,4 +1,5 @@
-import std/[json, os, parseutils, sets, streams, strformat, strutils, unicode]
+import std/[json, os, parseutils, sets, streams, strformat, strscans, strutils,
+            unicode]
 import ".."/helpers
 
 func allTrue*(bools: openArray[bool]): bool =
@@ -449,6 +450,53 @@ proc hasInteger*(data: JsonNode; key: string; path: Path; context = "";
                  isRequired = true; allowed: Slice): bool =
   if data.hasKey(key, path, context, isRequired):
     result = isInteger(data[key], key, path, context, isRequired, allowed)
+  elif not isRequired:
+    result = true
+
+proc isFloat*(data: JsonNode; key: string; path: Path; context: string;
+              isRequired = true; requirePositive: bool;
+              decimalPlaces: int): bool =
+  result = true
+  case data.kind
+  of JFloat:
+    let num = data.getFloat()
+    if requirePositive:
+      if num <= 0:
+        let msg = &"The value of {format(context, key)} is {num}, but it " &
+                   "must be greater than 0"
+        result.setFalseAndPrint(msg, path)
+    if decimalPlaces >= 0:
+      var digitsBeforeDecimalPoint = ""
+      var digitsAfterDecimalPoint = "" # An int would fail for e.g. 1.01
+      for line in path.string.lines:
+        if line.scanf("$s\"average_run_time\"$s:$s$*.$*$.",
+                      digitsBeforeDecimalPoint,
+                      digitsAfterDecimalPoint):
+          if digitsAfterDecimalPoint.`$`.len == decimalPlaces:
+            return # Not `return true`. Must still return `false` if negative.
+          else:
+            let s = &"{digitsBeforeDecimalPoint}.{digitsAfterDecimalPoint}"
+            let wording = if decimalPlaces == 1: "digit" else: "digits"
+            let msg = &"The value of {format(context, key)} is {s}, but it " &
+                      &"must have only {decimalPlaces} {wording} after the decimal point"
+            result.setFalseAndPrint(msg, path)
+            return false
+      let msg = &"The value of {format(context, key)} doesn't look like a float"
+      result.setFalseAndPrint(msg, path)
+  of JNull:
+    if isRequired:
+      result.setFalseAndPrint(&"The value of {format(context, key)} is {qNull}, " &
+                               "but it must be a float", path)
+  else:
+    result.setFalseAndPrint(&"The value of {format(context, key)} is {q $data}, " &
+                             "but it must be a float", path)
+
+proc hasFloat*(data: JsonNode; key: string; path: Path; context = "";
+               isRequired = true; requirePositive: bool;
+               decimalPlaces: int): bool =
+  if data.hasKey(key, path, context, isRequired):
+    result = isFloat(data[key], key, path, context, isRequired, requirePositive,
+                     decimalPlaces)
   elif not isRequired:
     result = true
 

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -453,9 +453,9 @@ proc hasInteger*(data: JsonNode; key: string; path: Path; context = "";
   elif not isRequired:
     result = true
 
-proc isFloat*(data: JsonNode; key: static string; path: Path; context: string;
-              isRequired = true; requirePositive: bool;
-              decimalPlaces: int): bool =
+proc isFloat(data: JsonNode; key: static string; path: Path; context: string;
+             isRequired = true; requirePositive: bool;
+             decimalPlaces: int): bool =
   result = true
   case data.kind
   of JFloat:

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -453,7 +453,7 @@ proc hasInteger*(data: JsonNode; key: string; path: Path; context = "";
   elif not isRequired:
     result = true
 
-proc isFloat*(data: JsonNode; key: string; path: Path; context: string;
+proc isFloat*(data: JsonNode; key: static string; path: Path; context: string;
               isRequired = true; requirePositive: bool;
               decimalPlaces: int): bool =
   result = true
@@ -469,7 +469,7 @@ proc isFloat*(data: JsonNode; key: string; path: Path; context: string;
       var digitsBeforeDecimalPoint = ""
       var digitsAfterDecimalPoint = "" # An int would fail for e.g. 1.01
       for line in path.string.lines:
-        if line.scanf("$s\"average_run_time\"$s:$s$*.$*$.",
+        if line.scanf(&"""$s"{key}"$s:$s$*.$*$.""",
                       digitsBeforeDecimalPoint,
                       digitsAfterDecimalPoint):
           if digitsAfterDecimalPoint.`$`.len == decimalPlaces:
@@ -491,7 +491,7 @@ proc isFloat*(data: JsonNode; key: string; path: Path; context: string;
     result.setFalseAndPrint(&"The value of {format(context, key)} is {q $data}, " &
                              "but it must be a float", path)
 
-proc hasFloat*(data: JsonNode; key: string; path: Path; context = "";
+proc hasFloat*(data: JsonNode; key: static string; path: Path; context = "";
                isRequired = true; requirePositive: bool;
                decimalPlaces: int): bool =
   if data.hasKey(key, path, context, isRequired):

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -474,15 +474,13 @@ proc isFloat(data: JsonNode; key: static string; path: Path; context: string;
         if line.scanf(&"""$s"{key}"$s:$s$*.$*$.""",
                       digitsBeforeDecimalPoint,
                       digitsAfterDecimalPoint):
-          if digitsAfterDecimalPoint.len == decimalPlaces:
-            return # Not `return true`. Must still return `false` if negative.
-          else:
+          if digitsAfterDecimalPoint.len != decimalPlaces:
             let s = &"{digitsBeforeDecimalPoint}.{digitsAfterDecimalPoint}"
             let wording = if decimalPlaces == 1: "digit" else: "digits"
             let msg = &"The value of {format(context, key)} is {s}, but it " &
                       &"must have only {decimalPlaces} {wording} after the decimal point"
             result.setFalseAndPrint(msg, path)
-            return false
+          return
       let msg = &"The value of {format(context, key)} doesn't look like a float"
       result.setFalseAndPrint(msg, path)
   of JNull:

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -466,6 +466,8 @@ proc isFloat*(data: JsonNode; key: static string; path: Path; context: string;
                    "must be greater than 0"
         result.setFalseAndPrint(msg, path)
     if decimalPlaces >= 0:
+      # To check the number of digits after the decimal place, we must parse
+      # the value as a string.
       var digitsBeforeDecimalPoint = ""
       var digitsAfterDecimalPoint = "" # An int would fail for e.g. 1.01
       for line in path.string.lines:

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -478,7 +478,8 @@ proc isFloat(data: JsonNode; key: static string; path: Path; context: string;
             let s = &"{digitsBeforeDecimalPoint}.{digitsAfterDecimalPoint}"
             let wording = if decimalPlaces == 1: "digit" else: "digits"
             let msg = &"The value of {format(context, key)} is {s}, but it " &
-                      &"must have only {decimalPlaces} {wording} after the decimal point"
+                      &"must have exactly {decimalPlaces} {wording} after " &
+                       "the decimal point"
             result.setFalseAndPrint(msg, path)
           return
       let msg = &"The value of {format(context, key)} doesn't look like a float"

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -474,7 +474,7 @@ proc isFloat*(data: JsonNode; key: static string; path: Path; context: string;
         if line.scanf(&"""$s"{key}"$s:$s$*.$*$.""",
                       digitsBeforeDecimalPoint,
                       digitsAfterDecimalPoint):
-          if digitsAfterDecimalPoint.`$`.len == decimalPlaces:
+          if digitsAfterDecimalPoint.len == decimalPlaces:
             return # Not `return true`. Must still return `false` if negative.
           else:
             let s = &"{digitsBeforeDecimalPoint}.{digitsAfterDecimalPoint}"


### PR DESCRIPTION
With this commit, `configlet lint` now checks the below rules for a
track's root `config.json` file.

- The `test_runner.average_run_time` key is required if
  `status.test_runner` is equal to `true`
- The `test_runner.average_run_time` value must be a floating-point
  number > 0 with one decimal point of precision

---

The requirement for

> "with one decimal point of precision"

is quite painful, since it requires parsing the value as a string.

---

Some sample error messages for bad values:

```
The value of `test_runner.average_run_time` is 3., but it must have exactly 1 digit after the decimal point:
./config.json

The value of `test_runner.average_run_time` is 3.00, but it must have exactly 1 digit after the decimal point:
./config.json

The value of `test_runner.average_run_time` is -0.1, but it must be greater than 0:
./config.json
```