### PR TITLE
lint: require more arrays to have unique values

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -43,7 +43,8 @@ const tags = [
 ].toHashSet()
 
 proc hasValidTags(data: JsonNode; path: Path): bool =
-  result = hasArrayOfStrings(data, "tags", path, allowed = tags)
+  result = hasArrayOfStrings(data, "tags", path, allowed = tags,
+                             uniqueValues = true)
 
 proc hasValidStatus(data: JsonNode; path: Path): bool =
   const k = "status"
@@ -121,7 +122,7 @@ proc hasValidExercises(data: JsonNode; path: Path): bool =
       hasArrayOf(exercises, "practice", path, isValidPracticeExercise, k,
                  allowedLength = 0..int.high),
       hasArrayOfStrings(exercises, "foregone", path, k, isRequired = false,
-                        checkIsKebab = true),
+                        checkIsKebab = true, uniqueValues = true),
     ]
     result = allTrue(checks)
 

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -333,11 +333,18 @@ proc hasArrayOfFiles*(data: JsonNode;
                       relativeToPath: Path): bool =
   if hasArrayOfStrings(data, key, path, context):
     result = true
+    var processedItems = initHashSet[string](data[key].len)
 
     for item in data[key]:
       let relativeFilePath = item.getStr()
       let absoluteFilePath = relativeToPath / relativeFilePath
-      if not fileExists(absoluteFilePath):
+      if fileExists(absoluteFilePath):
+        let itemStr = item.getStr()
+        if processedItems.containsOrIncl(itemStr):
+          let msg = &"The {q context} array contains duplicate " &
+                    &"{q itemStr} values"
+          result.setFalseAndPrint(msg, path)
+      else:
         let msg = &"The {q context} array contains value " &
                   &"{q relativeFilePath} but {q $absoluteFilePath} could not be found"
         result.setFalseAndPrint(msg, path)


### PR DESCRIPTION
This PR adds the new linting rules from https://github.com/exercism/docs/pull/127

With this commit, `configlet lint` now checks the following rules for a
track-level `config.json` file:
- The `exercises.foregone` values must not have duplicates
- The `tags` values must not have duplicates

And these rules for a Concept Exercise `config.json` file:
- The `files.solution` values must not have duplicates
- The `files.test` values must not have duplicates
- The `files.exemplar` values must not have duplicates

And these rules for a Practice Exercise `config.json` file:
- The `files.solution` values must not have duplicates
- The `files.test` values must not have duplicates
- The `files.example` values must not have duplicates

---

This PR currently keeps the output of `configlet lint` the same on every track.