### PR TITLE
sync(probspecs): refactor

### DIFF
--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -1,14 +1,14 @@
-import std/[json, options, os, sets, strformat, strutils, tables]
+import std/[options, os, sets, strformat, strutils, tables]
 import pkg/parsetoml
 import ".."/cli
 import "."/[probspecs, tracks]
-export tracks.`$`
+export tracks.`$`, probspecs.ProbSpecsTestCase
 
 type
   ExerciseTestCase* = ref object
     uuid*: string
     description*: string
-    json*: JsonNode
+    json*: ProbSpecsTestCase
     reimplements*: Option[ExerciseTestCase]
 
   ExerciseTests* = object
@@ -45,7 +45,7 @@ proc newExerciseTestCase(testCase: ProbSpecsTestCase): ExerciseTestCase =
   ExerciseTestCase(
     uuid: testCase.uuid,
     description: testCase.description,
-    json: testCase.json,
+    json: testCase,
   )
 
 proc getReimplementations(testCases: seq[ProbSpecsTestCase]): Table[string, string] =

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -77,12 +77,8 @@ proc initExercise(practiceExercise: PracticeExercise,
     testCases: initExerciseTestCases(probSpecsTestCases),
   )
 
-proc probSpecsTable(conf: Conf): Table[string, seq[ProbSpecsTestCase]] =
-  for exercise in findProbSpecsExercises(conf):
-    result[exercise.slug] = exercise.testCases
-
 proc findExercises*(conf: Conf): seq[Exercise] =
-  let probSpecsExercises = probSpecsTable(conf)
+  let probSpecsExercises = findProbSpecsExercises(conf)
 
   for practiceExercise in findPracticeExercises(conf):
     let exercise = initExercise(

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -2,7 +2,7 @@ import std/[options, os, sets, strformat, strutils, tables]
 import pkg/parsetoml
 import ".."/cli
 import "."/[probspecs, tracks]
-export tracks.`$`, probspecs.ProbSpecsTestCase
+export tracks.`$`, probspecs.pretty
 
 type
   ExerciseTestCase* = ref object

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -78,7 +78,7 @@ proc parseProbSpecsTestCases(probSpecsExerciseDir: ProbSpecsExerciseDir): seq[Pr
   ## Parses the `canonical-data.json` file for the given exercise, and returns
   ## a seq of, essentially, the JsonNode for each test.
   let canonicalJsonPath = canonicalDataFile(probSpecsExerciseDir)
-  if probSpecsExerciseDir.slug == "grains":
+  if slug(probSpecsExerciseDir) == "grains":
     canonicalJsonPath.grainsWorkaround().initProbSpecsTestCases()
   else:
     canonicalJsonPath.parseFile().initProbSpecsTestCases()
@@ -91,7 +91,8 @@ proc findProbSpecsExercises(probSpecsDir: ProbSpecsDir, conf: Conf): ProbSpecsEx
   for dir in walkDirs(probSpecsDir / "exercises" / pattern):
     let probSpecsExerciseDir = ProbSpecsExerciseDir(dir)
     if fileExists(probSpecsExerciseDir.canonicalDataFile()):
-      result[probSpecsExerciseDir.slug] = parseProbSpecsTestCases(probSpecsExerciseDir)
+      let slug = slug(probSpecsExerciseDir)
+      result[slug] = parseProbSpecsTestCases(probSpecsExerciseDir)
 
 proc getNameOfRemote(probSpecsDir: ProbSpecsDir; host, location: string): string =
   ## Returns the name of the remote in `probSpecsDir` that points to `location`

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -35,7 +35,9 @@ proc execSuccessElseQuit(cmd: string, message: string): string =
 
 proc clone(probSpecsDir: ProbSpecsDir) =
   ## Downloads the `exercism/problem-specifications` repo to `probSpecsDir`.
-  let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {probSpecsDir}"
+  const cmdBase = "git clone --quiet --depth 1"
+  const url = "https://github.com/exercism/problem-specifications.git"
+  let cmd = &"{cmdBase} {url} {probSpecsDir}"
   logNormal(&"Cloning the problem-specifications repo into {probSpecsDir}...")
   discard execSuccessElseQuit(cmd, "Could not clone problem-specifications repo")
 

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -24,9 +24,6 @@ proc execCmdException*(cmd: string, message: string) =
   if execCmd(cmd) != 0:
     quit(message)
 
-proc initProbSpecsDir: ProbSpecsDir =
-  ProbSpecsDir(getCurrentDir() / ".problem-specifications")
-
 proc clone(probSpecsDir: ProbSpecsDir) =
   let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {probSpecsDir}"
   logNormal(&"Cloning the problem-specifications repo into {probSpecsDir}...")
@@ -172,7 +169,7 @@ proc findProbSpecsExercises*(conf: Conf): seq[ProbSpecsExercise] =
       validate(probSpecsDir)
     result = findProbSpecsExercises(probSpecsDir, conf)
   else:
-    let probSpecsDir = initProbSpecsDir()
+    let probSpecsDir = ProbSpecsDir(getCurrentDir() / ".problem-specifications")
     try:
       removeDir(probSpecsDir)
       clone(probSpecsDir)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -27,7 +27,10 @@ proc execSuccessElseQuit(cmd: string, message: string): string =
   (result, errC) = execCmdEx(cmd)
   if errC != 0:
     stderr.writeLine result
-    stderr.writeLine message
+    if message.len > 0:
+      stderr.writeLine message
+    else:
+      stderr.writeLine &"Error when running '{cmd}'"
     quit(1)
 
 proc clone(probSpecsDir: ProbSpecsDir) =

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -50,16 +50,16 @@ func slug(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
 proc `[]`(testCase: ProbSpecsTestCase, name: string): JsonNode {.borrow.}
 proc hasKey(testCase: ProbSpecsTestCase, key: string): bool {.borrow.}
 
-proc uuid*(testCase: ProbSpecsTestCase): string =
+func uuid*(testCase: ProbSpecsTestCase): string =
   testCase["uuid"].getStr()
 
-proc description*(testCase: ProbSpecsTestCase): string =
+func description*(testCase: ProbSpecsTestCase): string =
   testCase["description"].getStr()
 
 func isReimplementation*(testCase: ProbSpecsTestCase): bool =
   testCase.hasKey("reimplements")
 
-proc reimplements*(testCase: ProbSpecsTestCase): string =
+func reimplements*(testCase: ProbSpecsTestCase): string =
   testCase["reimplements"].getStr()
 
 proc initProbSpecsTestCases(node: JsonNode): seq[ProbSpecsTestCase] =

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -2,20 +2,22 @@ import std/[json, os, osproc, strformat, strscans, strutils, tables]
 import ".."/[cli, helpers, logger]
 
 type
-  ProbSpecsExerciseDir {.requiresInit.} = distinct string
-
   ProbSpecsDir {.requiresInit.} = distinct string
+
+  ProbSpecsExerciseDir {.requiresInit.} = distinct string
 
   ProbSpecsTestCase* = distinct JsonNode
 
   ProbSpecsExercises* = Table[string, seq[ProbSpecsTestCase]]
 
 proc `$`(p: ProbSpecsDir): string {.borrow.}
+proc dirExists(dir: ProbSpecsDir): bool {.borrow.}
+proc removeDir(dir: ProbSpecsDir, checkDir = false) {.borrow.}
 proc `/`(head: ProbSpecsDir, tail: string): string {.borrow.}
 proc `/`(head: ProbSpecsExerciseDir, tail: string): string {.borrow.}
-proc dirExists(dir: ProbSpecsDir): bool {.borrow.}
 proc lastPathPart(path: ProbSpecsExerciseDir): string {.borrow.}
-proc removeDir(dir: ProbSpecsDir, checkDir = false) {.borrow.}
+proc `[]`(testCase: ProbSpecsTestCase, name: string): JsonNode {.borrow.}
+proc hasKey(testCase: ProbSpecsTestCase, key: string): bool {.borrow.}
 proc pretty*(testcase: ProbSpecsTestCase, indent = 2): string {.borrow.}
 
 proc execSuccessElseQuit(cmd: string, message: string): string =
@@ -41,9 +43,6 @@ func canonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
 
 func slug(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   lastPathPart(probSpecsExerciseDir)
-
-proc `[]`(testCase: ProbSpecsTestCase, name: string): JsonNode {.borrow.}
-proc hasKey(testCase: ProbSpecsTestCase, key: string): bool {.borrow.}
 
 func uuid*(testCase: ProbSpecsTestCase): string =
   testCase["uuid"].getStr()

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -36,12 +36,9 @@ proc exercises(probSpecsDir: ProbSpecsDir): seq[ProbSpecsExerciseDir] =
 func canonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   probSpecsExerciseDir / "canonical-data.json"
 
-proc hasCanonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): bool =
-  fileExists(probSpecsExerciseDir.canonicalDataFile())
-
 proc exercisesWithCanonicalData(probSpecsDir: ProbSpecsDir): seq[ProbSpecsExerciseDir] =
   for probSpecsExerciseDir in probSpecsDir.exercises():
-    if hasCanonicalDataFile(probSpecsExerciseDir):
+    if fileExists(probSpecsExerciseDir.canonicalDataFile()):
       result.add(probSpecsExerciseDir)
 
 func slug(probSpecsExerciseDir: ProbSpecsExerciseDir): string =

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -18,6 +18,7 @@ proc `/`(head: ProbSpecsDir, tail: string): string {.borrow.}
 proc `/`(head: ProbSpecsExerciseDir, tail: string): string {.borrow.}
 proc dirExists(dir: ProbSpecsDir): bool {.borrow.}
 proc extractFilename(path: ProbSpecsExerciseDir): string {.borrow.}
+proc removeDir(dir: ProbSpecsDir, checkDir = false) {.borrow.}
 
 proc execCmdException*(cmd: string, message: string) =
   if execCmd(cmd) != 0:
@@ -30,9 +31,6 @@ proc clone(probSpecsDir: ProbSpecsDir) =
   let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {probSpecsDir}"
   logNormal(&"Cloning the problem-specifications repo into {probSpecsDir}...")
   execCmdException(cmd, "Could not clone problem-specifications repo")
-
-proc remove(probSpecsDir: ProbSpecsDir) =
-  removeDir(probSpecsDir.string)
 
 func initProbSpecsExerciseDir(dir: string): ProbSpecsExerciseDir =
   ProbSpecsExerciseDir(dir)
@@ -176,8 +174,8 @@ proc findProbSpecsExercises*(conf: Conf): seq[ProbSpecsExercise] =
   else:
     let probSpecsDir = initProbSpecsDir()
     try:
-      probSpecsDir.remove()
+      probSpecsDir.removeDir()
       probSpecsDir.clone()
       result = probSpecsDir.findProbSpecsExercises(conf)
     finally:
-      probSpecsDir.remove()
+      probSpecsDir.removeDir()

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -29,11 +29,8 @@ proc clone(probSpecsDir: ProbSpecsDir) =
   logNormal(&"Cloning the problem-specifications repo into {probSpecsDir}...")
   execCmdException(cmd, "Could not clone problem-specifications repo")
 
-func exercisesDir(probSpecsDir: ProbSpecsDir): string =
-  probSpecsDir / "exercises"
-
 proc exercises(probSpecsDir: ProbSpecsDir): seq[ProbSpecsExerciseDir] =
-  for exerciseDir in walkDirs(probSpecsDir.exercisesDir / "*"):
+  for exerciseDir in walkDirs(probSpecsDir / "exercises" / "*"):
     result.add ProbSpecsExerciseDir(exerciseDir)
 
 func canonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): string =

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -21,8 +21,11 @@ proc lastPathPart(path: ProbSpecsExerciseDir): string {.borrow.}
 proc removeDir(dir: ProbSpecsDir, checkDir = false) {.borrow.}
 
 proc execCmdException(cmd: string, message: string) =
-  if execCmd(cmd) != 0:
-    quit(message)
+  let (outp, errC) = execCmdEx(cmd)
+  if errC != 0:
+    stderr.writeLine outp
+    stderr.writeLine message
+    quit(1)
 
 proc clone(probSpecsDir: ProbSpecsDir) =
   let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {probSpecsDir}"

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -58,10 +58,10 @@ proc reimplements*(testCase: ProbSpecsTestCase): string =
 
 proc initProbSpecsTestCases(node: JsonNode): seq[ProbSpecsTestCase] =
   if node.hasKey("uuid"):
-    result.add(initProbSpecsTestCase(node))
+    result.add initProbSpecsTestCase(node)
   elif node.hasKey("cases"):
     for childNode in node["cases"].getElems():
-      result.add(initProbSpecsTestCases(childNode))
+      result.add initProbSpecsTestCases(childNode)
 
 proc grainsWorkaround(grainsPath: string): JsonNode =
   ## Parses the canonical data file for `grains`, replacing the too-large
@@ -87,7 +87,7 @@ proc initProbSpecsExercise(probSpecsExerciseDir: ProbSpecsExerciseDir): ProbSpec
 proc findProbSpecsExercises(probSpecsDir: ProbSpecsDir, conf: Conf): seq[ProbSpecsExercise] =
   for probSpecsExerciseDir in probSpecsDir.exercisesWithCanonicalData():
     if conf.action.exercise.len == 0 or conf.action.exercise == probSpecsExerciseDir.slug:
-      result.add(initProbSpecsExercise(probSpecsExerciseDir))
+      result.add initProbSpecsExercise(probSpecsExerciseDir)
 
 proc getNameOfRemote(probSpecsDir: ProbSpecsDir; host, location: string): string =
   ## Returns the name of the remote in `probSpecsDir` that points to `location`

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -16,6 +16,7 @@ proc `/`(head: ProbSpecsExerciseDir, tail: string): string {.borrow.}
 proc dirExists(dir: ProbSpecsDir): bool {.borrow.}
 proc lastPathPart(path: ProbSpecsExerciseDir): string {.borrow.}
 proc removeDir(dir: ProbSpecsDir, checkDir = false) {.borrow.}
+proc pretty*(testcase: ProbSpecsTestCase, indent = 2): string {.borrow.}
 
 proc execSuccessElseQuit(cmd: string, message: string): string =
   ## Runs `cmd` and returns its output. If the command exits with a non-zero

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -2,9 +2,9 @@ import std/[json, os, osproc, strformat, strscans, strutils, tables]
 import ".."/[cli, helpers, logger]
 
 type
-  ProbSpecsExerciseDir = distinct string
+  ProbSpecsExerciseDir {.requiresInit.} = distinct string
 
-  ProbSpecsDir = distinct string
+  ProbSpecsDir {.requiresInit.} = distinct string
 
   ProbSpecsTestCase* = distinct JsonNode
 

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -1,4 +1,4 @@
-import std/[json, os, osproc, sequtils, strformat, strscans, strutils]
+import std/[json, os, osproc, strformat, strscans, strutils]
 import ".."/[cli, helpers, logger]
 
 type
@@ -40,8 +40,9 @@ proc hasCanonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): bool =
   fileExists(probSpecsExerciseDir.canonicalDataFile())
 
 proc exercisesWithCanonicalData(probSpecsDir: ProbSpecsDir): seq[ProbSpecsExerciseDir] =
-  for probSpecsExerciseDir in probSpecsDir.exercises().filter(hasCanonicalDataFile):
-    result.add(probSpecsExerciseDir)
+  for probSpecsExerciseDir in probSpecsDir.exercises():
+    if hasCanonicalDataFile(probSpecsExerciseDir):
+      result.add(probSpecsExerciseDir)
 
 func slug(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   extractFilename(probSpecsExerciseDir)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -169,13 +169,13 @@ proc findProbSpecsExercises*(conf: Conf): seq[ProbSpecsExercise] =
   if conf.action.probSpecsDir.len > 0:
     let probSpecsDir = ProbSpecsDir(conf.action.probSpecsDir)
     if not conf.action.offline:
-      probSpecsDir.validate()
-    result = probSpecsDir.findProbSpecsExercises(conf)
+      validate(probSpecsDir)
+    result = findProbSpecsExercises(probSpecsDir, conf)
   else:
     let probSpecsDir = initProbSpecsDir()
     try:
-      probSpecsDir.removeDir()
-      probSpecsDir.clone()
-      result = probSpecsDir.findProbSpecsExercises(conf)
+      removeDir(probSpecsDir)
+      clone(probSpecsDir)
+      result = findProbSpecsExercises(probSpecsDir, conf)
     finally:
-      probSpecsDir.removeDir()
+      removeDir(probSpecsDir)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -34,6 +34,7 @@ proc execSuccessElseQuit(cmd: string, message: string): string =
     quit(1)
 
 proc clone(probSpecsDir: ProbSpecsDir) =
+  ## Downloads the `exercism/problem-specifications` repo to `probSpecsDir`.
   let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {probSpecsDir}"
   logNormal(&"Cloning the problem-specifications repo into {probSpecsDir}...")
   discard execSuccessElseQuit(cmd, "Could not clone problem-specifications repo")
@@ -57,6 +58,7 @@ func reimplements*(testCase: ProbSpecsTestCase): string =
   testCase["reimplements"].getStr()
 
 proc initProbSpecsTestCases(node: JsonNode): seq[ProbSpecsTestCase] =
+  ## Returns a seq of every individual test case in `node` (flattening).
   if node.hasKey("uuid"):
     result.add ProbSpecsTestCase(node)
   elif node.hasKey("cases"):
@@ -73,12 +75,17 @@ proc grainsWorkaround(grainsPath: string): JsonNode =
   result = parseJson(sanitised)
 
 proc parseProbSpecsTestCases(probSpecsExerciseDir: ProbSpecsExerciseDir): seq[ProbSpecsTestCase] =
+  ## Parses the `canonical-data.json` file for the given exercise, and returns
+  ## a seq of, essentially, the JsonNode for each test.
   if probSpecsExerciseDir.slug == "grains":
     probSpecsExerciseDir.canonicalDataFile().grainsWorkaround().initProbSpecsTestCases()
   else:
     probSpecsExerciseDir.canonicalDataFile().parseFile().initProbSpecsTestCases()
 
 proc findProbSpecsExercises(probSpecsDir: ProbSpecsDir, conf: Conf): ProbSpecsExercises =
+  ## Returns a Table containing the slug and corresponding canonical tests for
+  ## each exercise in `probSpecsDir`. If `conf` specifies a single exercise,
+  ## returns only the tests for that exercise.
   for dir in walkDirs(probSpecsDir / "exercises" / "*"):
     let probSpecsExerciseDir = ProbSpecsExerciseDir(dir)
     if fileExists(probSpecsExerciseDir.canonicalDataFile()):

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -23,11 +23,8 @@ proc execCmdException*(cmd: string, message: string) =
   if execCmd(cmd) != 0:
     quit(message)
 
-proc probSpecsDir: string =
-  getCurrentDir() / ".problem-specifications"
-
 proc initProbSpecsDir: ProbSpecsDir =
-  ProbSpecsDir(probSpecsDir())
+  ProbSpecsDir(getCurrentDir() / ".problem-specifications")
 
 proc clone(probSpecsDir: ProbSpecsDir) =
   let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {probSpecsDir}"

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -47,9 +47,6 @@ iterator exercisesWithCanonicalData(probSpecsDir: ProbSpecsDir): ProbSpecsExerci
 func slug(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   lastPathPart(probSpecsExerciseDir)
 
-func initProbSpecsTestCase(node: JsonNode): ProbSpecsTestCase =
-  ProbSpecsTestCase(node)
-
 proc `[]`(testCase: ProbSpecsTestCase, name: string): JsonNode {.borrow.}
 proc hasKey(testCase: ProbSpecsTestCase, key: string): bool {.borrow.}
 
@@ -67,7 +64,7 @@ proc reimplements*(testCase: ProbSpecsTestCase): string =
 
 proc initProbSpecsTestCases(node: JsonNode): seq[ProbSpecsTestCase] =
   if node.hasKey("uuid"):
-    result.add initProbSpecsTestCase(node)
+    result.add ProbSpecsTestCase(node)
   elif node.hasKey("cases"):
     for childNode in node["cases"].getElems():
       result.add initProbSpecsTestCases(childNode)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -32,11 +32,11 @@ proc clone(probSpecsDir: ProbSpecsDir) =
 func canonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   probSpecsExerciseDir / "canonical-data.json"
 
-proc exercisesWithCanonicalData(probSpecsDir: ProbSpecsDir): seq[ProbSpecsExerciseDir] =
+iterator exercisesWithCanonicalData(probSpecsDir: ProbSpecsDir): ProbSpecsExerciseDir =
   for dir in walkDirs(probSpecsDir / "exercises" / "*"):
     let probSpecsExerciseDir = ProbSpecsExerciseDir(dir)
     if fileExists(probSpecsExerciseDir.canonicalDataFile()):
-      result.add(probSpecsExerciseDir)
+      yield probSpecsExerciseDir
 
 func slug(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   extractFilename(probSpecsExerciseDir)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -10,7 +10,7 @@ type
 
   ProbSpecsExercises* = Table[string, seq[ProbSpecsTestCase]]
 
-proc `$`(p: ProbSpecsDir): string {.borrow.}
+proc `$`(dir: ProbSpecsDir): string {.borrow.}
 proc dirExists(dir: ProbSpecsDir): bool {.borrow.}
 proc removeDir(dir: ProbSpecsDir, checkDir = false) {.borrow.}
 proc `/`(head: ProbSpecsDir, tail: string): string {.borrow.}
@@ -18,7 +18,7 @@ proc `/`(head: ProbSpecsExerciseDir, tail: string): string {.borrow.}
 proc lastPathPart(path: ProbSpecsExerciseDir): string {.borrow.}
 proc `[]`(testCase: ProbSpecsTestCase, name: string): JsonNode {.borrow.}
 proc hasKey(testCase: ProbSpecsTestCase, key: string): bool {.borrow.}
-proc pretty*(testcase: ProbSpecsTestCase, indent = 2): string {.borrow.}
+proc pretty*(testCase: ProbSpecsTestCase, indent = 2): string {.borrow.}
 
 proc execSuccessElseQuit(cmd: string, message: string): string =
   ## Runs `cmd` and returns its output. If the command exits with a non-zero

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -20,7 +20,7 @@ proc dirExists(dir: ProbSpecsDir): bool {.borrow.}
 proc lastPathPart(path: ProbSpecsExerciseDir): string {.borrow.}
 proc removeDir(dir: ProbSpecsDir, checkDir = false) {.borrow.}
 
-proc execCmdException*(cmd: string, message: string) =
+proc execCmdException(cmd: string, message: string) =
   if execCmd(cmd) != 0:
     quit(message)
 

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -77,10 +77,11 @@ proc grainsWorkaround(grainsPath: string): JsonNode =
 proc parseProbSpecsTestCases(probSpecsExerciseDir: ProbSpecsExerciseDir): seq[ProbSpecsTestCase] =
   ## Parses the `canonical-data.json` file for the given exercise, and returns
   ## a seq of, essentially, the JsonNode for each test.
+  let canonicalJsonPath = canonicalDataFile(probSpecsExerciseDir)
   if probSpecsExerciseDir.slug == "grains":
-    probSpecsExerciseDir.canonicalDataFile().grainsWorkaround().initProbSpecsTestCases()
+    canonicalJsonPath.grainsWorkaround().initProbSpecsTestCases()
   else:
-    probSpecsExerciseDir.canonicalDataFile().parseFile().initProbSpecsTestCases()
+    canonicalJsonPath.parseFile().initProbSpecsTestCases()
 
 proc findProbSpecsExercises(probSpecsDir: ProbSpecsDir, conf: Conf): ProbSpecsExercises =
   ## Returns a Table containing the slug and corresponding canonical tests for

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -20,7 +20,7 @@ proc dirExists(dir: ProbSpecsDir): bool {.borrow.}
 proc lastPathPart(path: ProbSpecsExerciseDir): string {.borrow.}
 proc removeDir(dir: ProbSpecsDir, checkDir = false) {.borrow.}
 
-proc execCmdException(cmd: string, message: string) =
+proc execSuccessElseQuit(cmd: string, message: string) =
   let (outp, errC) = execCmdEx(cmd)
   if errC != 0:
     stderr.writeLine outp
@@ -30,7 +30,7 @@ proc execCmdException(cmd: string, message: string) =
 proc clone(probSpecsDir: ProbSpecsDir) =
   let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {probSpecsDir}"
   logNormal(&"Cloning the problem-specifications repo into {probSpecsDir}...")
-  execCmdException(cmd, "Could not clone problem-specifications repo")
+  execSuccessElseQuit(cmd, "Could not clone problem-specifications repo")
 
 func canonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   probSpecsExerciseDir / "canonical-data.json"

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -20,17 +20,20 @@ proc dirExists(dir: ProbSpecsDir): bool {.borrow.}
 proc lastPathPart(path: ProbSpecsExerciseDir): string {.borrow.}
 proc removeDir(dir: ProbSpecsDir, checkDir = false) {.borrow.}
 
-proc execSuccessElseQuit(cmd: string, message: string) =
-  let (outp, errC) = execCmdEx(cmd)
+proc execSuccessElseQuit(cmd: string, message: string): string =
+  ## Runs `cmd` and returns its output. If the command exits with a non-zero
+  ## exit code, prints the output and the given `message`, then quits.
+  var errC = -1
+  (result, errC) = execCmdEx(cmd)
   if errC != 0:
-    stderr.writeLine outp
+    stderr.writeLine result
     stderr.writeLine message
     quit(1)
 
 proc clone(probSpecsDir: ProbSpecsDir) =
   let cmd = &"git clone --quiet --depth 1 https://github.com/exercism/problem-specifications.git {probSpecsDir}"
   logNormal(&"Cloning the problem-specifications repo into {probSpecsDir}...")
-  execSuccessElseQuit(cmd, "Could not clone problem-specifications repo")
+  discard execSuccessElseQuit(cmd, "Could not clone problem-specifications repo")
 
 func canonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   probSpecsExerciseDir / "canonical-data.json"

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -38,12 +38,6 @@ proc clone(probSpecsDir: ProbSpecsDir) =
 func canonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   probSpecsExerciseDir / "canonical-data.json"
 
-iterator exercisesWithCanonicalData(probSpecsDir: ProbSpecsDir): ProbSpecsExerciseDir =
-  for dir in walkDirs(probSpecsDir / "exercises" / "*"):
-    let probSpecsExerciseDir = ProbSpecsExerciseDir(dir)
-    if fileExists(probSpecsExerciseDir.canonicalDataFile()):
-      yield probSpecsExerciseDir
-
 func slug(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   lastPathPart(probSpecsExerciseDir)
 
@@ -85,9 +79,11 @@ proc parseProbSpecsTestCases(probSpecsExerciseDir: ProbSpecsExerciseDir): seq[Pr
     probSpecsExerciseDir.canonicalDataFile().parseFile().initProbSpecsTestCases()
 
 proc findProbSpecsExercises(probSpecsDir: ProbSpecsDir, conf: Conf): ProbSpecsExercises =
-  for probSpecsExerciseDir in probSpecsDir.exercisesWithCanonicalData():
-    if conf.action.exercise.len == 0 or conf.action.exercise == probSpecsExerciseDir.slug:
-      result[probSpecsExerciseDir.slug] = parseProbSpecsTestCases(probSpecsExerciseDir)
+  for dir in walkDirs(probSpecsDir / "exercises" / "*"):
+    let probSpecsExerciseDir = ProbSpecsExerciseDir(dir)
+    if fileExists(probSpecsExerciseDir.canonicalDataFile()):
+      if conf.action.exercise.len == 0 or conf.action.exercise == probSpecsExerciseDir.slug:
+        result[probSpecsExerciseDir.slug] = parseProbSpecsTestCases(probSpecsExerciseDir)
 
 proc getNameOfRemote(probSpecsDir: ProbSpecsDir; host, location: string): string =
   ## Returns the name of the remote in `probSpecsDir` that points to `location`

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -85,7 +85,8 @@ proc parseProbSpecsTestCases(probSpecsExerciseDir: ProbSpecsExerciseDir): seq[Pr
   else:
     canonicalJsonPath.parseFile().initProbSpecsTestCases()
 
-proc findProbSpecsExercises(probSpecsDir: ProbSpecsDir, conf: Conf): ProbSpecsExercises =
+proc findProbSpecsExercises(probSpecsDir: ProbSpecsDir,
+                            conf: Conf): ProbSpecsExercises =
   ## Returns a Table containing the slug and corresponding canonical tests for
   ## each exercise in `probSpecsDir`. If `conf` specifies a single exercise,
   ## returns only the tests for that exercise.
@@ -96,7 +97,8 @@ proc findProbSpecsExercises(probSpecsDir: ProbSpecsDir, conf: Conf): ProbSpecsEx
       let slug = slug(probSpecsExerciseDir)
       result[slug] = parseProbSpecsTestCases(probSpecsExerciseDir)
 
-proc getNameOfRemote(probSpecsDir: ProbSpecsDir; host, location: string): string =
+proc getNameOfRemote(probSpecsDir: ProbSpecsDir;
+                     host, location: string): string =
   ## Returns the name of the remote in `probSpecsDir` that points to `location`
   ## at `host`.
   ##

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -6,8 +6,7 @@ type
 
   ProbSpecsDir = distinct string
 
-  ProbSpecsTestCase* = object
-    json*: JsonNode
+  ProbSpecsTestCase* = distinct JsonNode
 
   ProbSpecsExercise* = object
     slug*: string
@@ -51,19 +50,22 @@ func slug(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   lastPathPart(probSpecsExerciseDir)
 
 func initProbSpecsTestCase(node: JsonNode): ProbSpecsTestCase =
-  ProbSpecsTestCase(json: node)
+  ProbSpecsTestCase(node)
+
+proc `[]`(testCase: ProbSpecsTestCase, name: string): JsonNode {.borrow.}
+proc hasKey(testCase: ProbSpecsTestCase, key: string): bool {.borrow.}
 
 proc uuid*(testCase: ProbSpecsTestCase): string =
-  testCase.json["uuid"].getStr()
+  testCase["uuid"].getStr()
 
 proc description*(testCase: ProbSpecsTestCase): string =
-  testCase.json["description"].getStr()
+  testCase["description"].getStr()
 
 func isReimplementation*(testCase: ProbSpecsTestCase): bool =
-  testCase.json.hasKey("reimplements")
+  testCase.hasKey("reimplements")
 
 proc reimplements*(testCase: ProbSpecsTestCase): string =
-  testCase.json["reimplements"].getStr()
+  testCase["reimplements"].getStr()
 
 proc initProbSpecsTestCases(node: JsonNode): seq[ProbSpecsTestCase] =
   if node.hasKey("uuid"):

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -29,15 +29,12 @@ proc clone(probSpecsDir: ProbSpecsDir) =
   logNormal(&"Cloning the problem-specifications repo into {probSpecsDir}...")
   execCmdException(cmd, "Could not clone problem-specifications repo")
 
-func initProbSpecsExerciseDir(dir: string): ProbSpecsExerciseDir =
-  ProbSpecsExerciseDir(dir)
-
 func exercisesDir(probSpecsDir: ProbSpecsDir): string =
   probSpecsDir / "exercises"
 
 proc exercises(probSpecsDir: ProbSpecsDir): seq[ProbSpecsExerciseDir] =
   for exerciseDir in walkDirs(probSpecsDir.exercisesDir / "*"):
-    result.add(initProbSpecsExerciseDir(exerciseDir))
+    result.add ProbSpecsExerciseDir(exerciseDir)
 
 func canonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   probSpecsExerciseDir / "canonical-data.json"

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -29,15 +29,12 @@ proc clone(probSpecsDir: ProbSpecsDir) =
   logNormal(&"Cloning the problem-specifications repo into {probSpecsDir}...")
   execCmdException(cmd, "Could not clone problem-specifications repo")
 
-proc exercises(probSpecsDir: ProbSpecsDir): seq[ProbSpecsExerciseDir] =
-  for exerciseDir in walkDirs(probSpecsDir / "exercises" / "*"):
-    result.add ProbSpecsExerciseDir(exerciseDir)
-
 func canonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   probSpecsExerciseDir / "canonical-data.json"
 
 proc exercisesWithCanonicalData(probSpecsDir: ProbSpecsDir): seq[ProbSpecsExerciseDir] =
-  for probSpecsExerciseDir in probSpecsDir.exercises():
+  for dir in walkDirs(probSpecsDir / "exercises" / "*"):
+    let probSpecsExerciseDir = ProbSpecsExerciseDir(dir)
     if fileExists(probSpecsExerciseDir.canonicalDataFile()):
       result.add(probSpecsExerciseDir)
 

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -86,11 +86,11 @@ proc findProbSpecsExercises(probSpecsDir: ProbSpecsDir, conf: Conf): ProbSpecsEx
   ## Returns a Table containing the slug and corresponding canonical tests for
   ## each exercise in `probSpecsDir`. If `conf` specifies a single exercise,
   ## returns only the tests for that exercise.
-  for dir in walkDirs(probSpecsDir / "exercises" / "*"):
+  let pattern = if conf.action.exercise.len > 0: conf.action.exercise else: "*"
+  for dir in walkDirs(probSpecsDir / "exercises" / pattern):
     let probSpecsExerciseDir = ProbSpecsExerciseDir(dir)
     if fileExists(probSpecsExerciseDir.canonicalDataFile()):
-      if conf.action.exercise.len == 0 or conf.action.exercise == probSpecsExerciseDir.slug:
-        result[probSpecsExerciseDir.slug] = parseProbSpecsTestCases(probSpecsExerciseDir)
+      result[probSpecsExerciseDir.slug] = parseProbSpecsTestCases(probSpecsExerciseDir)
 
 proc getNameOfRemote(probSpecsDir: ProbSpecsDir; host, location: string): string =
   ## Returns the name of the remote in `probSpecsDir` that points to `location`

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -101,10 +101,9 @@ proc getNameOfRemote(probSpecsDir: ProbSpecsDir; host, location: string): string
   ##
   ## Exits with an error if there is no such remote.
   # There's probably a better way to do this than parsing `git remote -v`.
-  let (remotes, errRemotes) = execCmdEx("git remote -v")
-  if errRemotes != 0:
-    showError("could not run `git remote -v` in the given " &
-              &"problem-specifications directory: '{probSpecsDir}'")
+  let msg = "could not run `git remote -v` in the given " &
+            &"problem-specifications directory: '{probSpecsDir}'"
+  let remotes = execSuccessElseQuit("git remote -v", msg)
   var remoteName, remoteUrl: string
   for line in remotes.splitLines():
     discard line.scanf("$s$w$s$+fetch)$.", remoteName, remoteUrl)
@@ -151,8 +150,9 @@ proc validate(probSpecsDir: ProbSpecsDir) =
 
     # Allow HEAD to be on a non-`main` branch, as long as it's up-to-date
     # with `upstream/main`.
-    let (revHead, _) = execCmdEx("git rev-parse HEAD")
-    let (revUpstream, _) = execCmdEx(&"git rev-parse {remoteName}/{mainBranchName}")
+    let revHead = execSuccessElseQuit("git rev-parse HEAD", "")
+    let revUpstream = execSuccessElseQuit(&"git rev-parse {remoteName}/" &
+                                          &"{mainBranchName}", "")
     if revHead != revUpstream:
       showError("the given problem-specifications directory is not " &
                 &"up-to-date: '{probSpecsDir}'")

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -17,7 +17,7 @@ proc `$`(p: ProbSpecsDir): string {.borrow.}
 proc `/`(head: ProbSpecsDir, tail: string): string {.borrow.}
 proc `/`(head: ProbSpecsExerciseDir, tail: string): string {.borrow.}
 proc dirExists(dir: ProbSpecsDir): bool {.borrow.}
-proc extractFilename(path: ProbSpecsExerciseDir): string {.borrow.}
+proc lastPathPart(path: ProbSpecsExerciseDir): string {.borrow.}
 proc removeDir(dir: ProbSpecsDir, checkDir = false) {.borrow.}
 
 proc execCmdException*(cmd: string, message: string) =
@@ -39,7 +39,7 @@ iterator exercisesWithCanonicalData(probSpecsDir: ProbSpecsDir): ProbSpecsExerci
       yield probSpecsExerciseDir
 
 func slug(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
-  extractFilename(probSpecsExerciseDir)
+  lastPathPart(probSpecsExerciseDir)
 
 func initProbSpecsTestCase(node: JsonNode): ProbSpecsTestCase =
   ProbSpecsTestCase(json: node)

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -1,12 +1,10 @@
-import std/[json, options, sequtils, sets, strformat, strutils]
+import std/[options, sequtils, sets, strformat, strutils]
 import ".."/[cli, logger]
 import "."/exercises
 
 type
   SyncDecision = enum
     sdIncludeTest, sdExcludeTest, sdSkipTest, sdReplaceTest
-
-proc pretty(testcase: ProbSpecsTestCase, indent = 2): string {.borrow.}
 
 proc chooseRegularSyncDecision(testCase: ExerciseTestCase): SyncDecision =
   doAssert(testCase.reimplements.isNone)

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -6,6 +6,8 @@ type
   SyncDecision = enum
     sdIncludeTest, sdExcludeTest, sdSkipTest, sdReplaceTest
 
+proc pretty(testcase: ProbSpecsTestCase, indent = 2): string {.borrow.}
+
 proc chooseRegularSyncDecision(testCase: ExerciseTestCase): SyncDecision =
   doAssert(testCase.reimplements.isNone)
 

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -1,5 +1,5 @@
 # This module contains tests for `src/probspecs.nim`
-import std/[json, os, osproc, strformat, unittest]
+import std/[json, os, osproc, strformat, tables, unittest]
 import "."/[cli, sync/probspecs]
 
 type
@@ -34,15 +34,14 @@ proc main =
         check:
           probSpecsExercises.len >= 116
 
-      test "the first exercise is as expected":
-        let exercise = probSpecsExercises[0]
+      test "the first exercise with canonical data is as expected":
+        let exercise = probSpecsExercises["accumulate"]
 
         check:
-          exercise.slug == "accumulate" # The first exercise with canonical data.
-          exercise.testCases.len >= 5 # Tests are never removed.
+          exercise.len >= 5 # Tests are never removed.
 
       test "the first test case of first exercise is as expected":
-        let firstTestCase = probSpecsExercises[0].testCases[0].JsonNode
+        let firstTestCase = probSpecsExercises["accumulate"][0].JsonNode
         let firstTestCaseExpected = """{
       "uuid": "64d97c14-36dd-44a8-9621-2cecebd6ed23",
       "description": "accumulate empty",
@@ -57,15 +56,14 @@ proc main =
         check:
           firstTestCase == firstTestCaseExpected
 
-      test "the second exercise is as expected":
-        let exercise = probSpecsExercises[1]
+      test "the second exercise with canonical data is as expected":
+        let exercise = probSpecsExercises["acronym"]
 
         check:
-          exercise.slug == "acronym" # The second exercise with canonical data.
-          exercise.testCases.len >= 9 # Tests are never removed.
+          exercise.len >= 9 # Tests are never removed.
 
       test "the first test case of second exercise is as expected":
-        let firstTestCase = probSpecsExercises[1].testCases[0].JsonNode
+        let firstTestCase = probSpecsExercises["acronym"][0].JsonNode
         let firstTestCaseExpected = """{
           "uuid": "1e22cceb-c5e4-4562-9afe-aef07ad1eaf4",
           "description": "basic",

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -42,7 +42,7 @@ proc main =
           exercise.testCases.len >= 5 # Tests are never removed.
 
       test "the first test case of first exercise is as expected":
-        let firstTestCase = probSpecsExercises[0].testCases[0].json
+        let firstTestCase = probSpecsExercises[0].testCases[0].JsonNode
         let firstTestCaseExpected = """{
       "uuid": "64d97c14-36dd-44a8-9621-2cecebd6ed23",
       "description": "accumulate empty",
@@ -65,7 +65,7 @@ proc main =
           exercise.testCases.len >= 9 # Tests are never removed.
 
       test "the first test case of second exercise is as expected":
-        let firstTestCase = probSpecsExercises[1].testCases[0].json
+        let firstTestCase = probSpecsExercises[1].testCases[0].JsonNode
         let firstTestCaseExpected = """{
           "uuid": "1e22cceb-c5e4-4562-9afe-aef07ad1eaf4",
           "description": "basic",


### PR DESCRIPTION
This PR is part of a series that addresses #64.

I've verified that this commit keeps the output of
`configlet sync --check` the same on every track.

This PR is currently a 3–⁠5x speedup, depending on the track.

Measuring the execution time of
```
./configlet sync --check --offline --probSpecsDir=/path/to/local/problem-specifications
```

in different track repos, before and after this PR:

|        |    ada |    nim |   csharp |
| ------ | -----: | -----: | -------: |
| Before | 100 ms | 110 ms |   120 ms |
| After  |  20 ms |  35 ms |    40 ms |

It wasn't particularly slow before for the end-user, but it was
noticeable when running `configlet sync --check` on every track for
regression testing).

An upcoming commit will optimize further: currently we parse every
`canonical-data.json` file in `problem-specifications` even when the
track has no Practice Exercises (like the `ada` track).

With this commit, most of the runtime of `configlet sync --check` is now
spent parsing TOML and JSON, as you'd expect.

See the profiling below for the Nim track, where there are 67 practice
exercises that have a corresponding `canonical-data.json` in
`problem-specifications`. We can see the 67 calls to `parsetoml`, but
119 calls to `parseJson` (and also the special handling of the `grains`
exercise).

![prof1](https://user-images.githubusercontent.com/45465154/119169911-d818d700-ba62-11eb-9942-173c033858d8.png)