### PR TITLE
build: bump Nim from 1.4.6 to 1.4.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@d0c07f7ad4ed045c29cfcffbc1402643f8147184 # 1.3.2
         with:
-          nim-version: "1.4.6"
+          nim-version: "1.4.8"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@d0c07f7ad4ed045c29cfcffbc1402643f8147184 # 1.3.2
         with:
-          nim-version: "1.4.6"
+          nim-version: "1.4.8"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -7,7 +7,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 1.4.6"
+requires "nim >= 1.4.8"
 requires "parsetoml"
 requires "cligen"
 requires "uuids >= 0.1.11"


### PR DESCRIPTION
See [blog post](https://nim-lang.org/blog/2021/05/25/version-148-released.html) and https://github.com/nim-lang/Nim/compare/v1.4.6...v1.4.8

Showing all the places where we have the Nim version:

```
$ git grep --break --heading '1\.4'
.github/workflows/build.yml
41:          nim-version: "1.4.8"

.github/workflows/tests.yml
46:          nim-version: "1.4.8"

configlet.nimble
10:requires "nim >= 1.4.8"
```