### PR TITLE
sync: don't parse unneeded `canonical-data.json` files

### DIFF
--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -76,15 +76,18 @@ func initExerciseTestCases(testCases: seq[ProbSpecsTestCase]): seq[ExerciseTestC
         testCase.reimplements = some(testCasesByUuids[uuidOfReimplementation])
 
 iterator findExercises*(conf: Conf): Exercise {.inline.} =
-  let probSpecsExercises = findProbSpecsExercises(conf)
-
-  for practiceExercise in findPracticeExercises(conf):
-    let testCases = probSpecsExercises.getOrDefault(practiceExercise.slug.string)
-    yield Exercise(
-      slug: practiceExercise.slug,
-      tests: initExerciseTests(practiceExercise.tests, testCases),
-      testCases: initExerciseTestCases(testCases),
-    )
+  let probSpecsDir = initProbSpecsDir(conf)
+  try:
+    for practiceExercise in findPracticeExercises(conf):
+      let testCases = getCanonicalTests(probSpecsDir, practiceExercise.slug.string)
+      yield Exercise(
+        slug: practiceExercise.slug,
+        tests: initExerciseTests(practiceExercise.tests, testCases),
+        testCases: initExerciseTestCases(testCases),
+      )
+  finally:
+    if conf.action.probSpecsDir.len == 0:
+      removeDir(probSpecsDir)
 
 func status*(exercise: Exercise): ExerciseStatus =
   if exercise.testCases.len == 0:


### PR DESCRIPTION
Running `configlet sync` would previously parse every
`canonical-data.json` file in the problem-specifications repo as the
first step. There are currently 119 of these files, and the execution
time of an offline `configlet sync --check` is usually dominated by JSON
parsing.

With this commit, we only parse a `canonical-data.json` file if the
track implements the corresponding exercise - this is a worthwhile
speedup for tracks that implement only a small fraction of the exercises
in `problem-specifications`.

This commit also reduces the binary size by 10% (at least for the
Linux one).

Measuring the execution time of
```
  configlet sync --check --offline --prob-specs-dir=path/to/problem-specifications
```

in different track repos, before and after this commit:

|                 |           ada |           nim |        csharp |
| --------------- | ------------: | ------------: | ------------: |
| previous commit | 20.3 ± 0.8 ms | 28.9 ± 0.8 ms | 36.0 ± 0.7 ms |
| this commit     |  0.3 ± 0.1 ms | 16.5 ± 0.6 ms | 32.2 ± 0.7 ms |

These tracks have respectively 0, 67, and 112 exercises with canonical
data. Each timing value is the average wall-clock time per run
(mean ± standard deviation) for 1000 runs on a slow machine.

The remaining slowness is because we currently parse the JSON/TOML into
a dynamic structure (`JsonNode`/`TomlTable`), rather than directly
populating a strongly typed object. For now, we'll keep this approach
because it's simplest to stay with the `std/json` and `pkg/parsetoml`
modules for the early implementation.

I've verified that this commit keeps the output of
`configlet sync --check` the same on every track.

See also #64, which tracks the refactoring of the sync code.