### PR TITLE
lint: remove ace_editor_language check

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -66,7 +66,6 @@ proc hasValidOnlineEditor(data: JsonNode; path: Path): bool =
     let checks = [
       hasString(d, "indent_style", path, k, allowed = indentStyles),
       hasInteger(d, "indent_size", path, k, allowed = 0..8),
-      hasString(d, "ace_editor_language", path, k),
       hasString(d, "highlightjs_language", path, k),
     ]
     result = allTrue(checks)


### PR DESCRIPTION
With the switch to CodeMirror as the online editor library, the
`online_editor.ace_editor_language` key is now obsolete and its presence
should not be checked anymore. This PR removes that check.
