### PR TITLE
tests(binary): speed up local testing

### DIFF
--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -570,7 +570,8 @@ proc main =
   let binaryPath = repoRootDir / binaryName
   const helpStart = &"Usage:\n  {binaryName} [global-options] <command> [command-options]"
 
-  const cmd = "nimble --verbose build -d:release"
+  const cmdBase = "nimble --verbose build"
+  let cmd = if existsEnv("CI"): &"{cmdBase} -d:release" else: cmdBase
   stderr.write(&"Running `{cmd}`... ")
   let (buildOutput, buildExitCode) = execCmdEx(cmd, workingDir = repoRootDir)
   if buildExitCode == 0:


### PR DESCRIPTION
Before running our tests of the configlet executable, our setup
automatically builds configlet (so that we don't forget).

We should test an executable that is as close as possible to that we
distribute, which means we should build with the same compilation flags.
However, a debug build should usually produce the same test status -
with this commit, we perform the longer build only during CI so that
running the tests locally is faster.