### PR TITLE
sync: improve readability in interactive mode

### DIFF
--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -7,7 +7,8 @@ type
     sdIncludeTest, sdExcludeTest, sdSkipTest, sdReplaceTest
 
 proc chooseRegularSyncDecision(testCase: ExerciseTestCase): SyncDecision =
-  echo &"""The following test case is missing:
+  echo &"""
+The following test case is missing:
 {testCase.json.pretty()}
 
 Do you want to include the test case ([y]es/[n]o/[s]kip)?
@@ -25,7 +26,8 @@ Do you want to include the test case ([y]es/[n]o/[s]kip)?
     sdSkipTest
 
 proc chooseReimplementsSyncDecision(testCase: ExerciseTestCase): SyncDecision =
-  echo &"""The following test case is missing:
+  echo &"""
+The following test case is missing:
 {testCase.json.pretty()}
 
 It reimplements this test case:

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -7,10 +7,10 @@ type
     sdIncludeTest, sdExcludeTest, sdSkipTest, sdReplaceTest
 
 proc chooseRegularSyncDecision(testCase: ExerciseTestCase): SyncDecision =
-  echo &"""The following test case is missing:"
-{testCase.json.pretty()}:
+  echo &"""The following test case is missing:
+{testCase.json.pretty()}
 
-Do you want to include the test case ([y]es/[n]o/[s]kip)?:
+Do you want to include the test case ([y]es/[n]o/[s]kip)?
 """
 
   case stdin.readLine().toLowerAscii()
@@ -25,13 +25,13 @@ Do you want to include the test case ([y]es/[n]o/[s]kip)?:
     sdSkipTest
 
 proc chooseReimplementsSyncDecision(testCase: ExerciseTestCase): SyncDecision =
-  echo &"""The following test case is missing:"
-{testCase.json.pretty()}:
+  echo &"""The following test case is missing:
+{testCase.json.pretty()}
 
 It reimplements this test case:
-{testCase.reimplements.get().json.pretty()}:
+{testCase.reimplements.get().json.pretty()}
 
-Do you want to replace the existing test case ([y]es/[n]o/[s]kip)?:
+Do you want to replace the existing test case ([y]es/[n]o/[s]kip)?
 """
 
   case stdin.readLine().toLowerAscii()

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -6,6 +6,9 @@ type
   SyncDecision = enum
     sdIncludeTest, sdExcludeTest, sdSkipTest, sdReplaceTest
 
+proc writeBlankLines =
+  stderr.write "\n\n"
+
 proc chooseRegularSyncDecision(testCase: ExerciseTestCase): SyncDecision =
   stderr.write &"""
 The following test case is missing:
@@ -15,13 +18,17 @@ Do you want to include the test case ([y]es/[n]o/[s]kip)? """
 
   case stdin.readLine().toLowerAscii()
   of "y", "yes":
+    writeBlankLines()
     sdIncludeTest
   of "n", "no":
+    writeBlankLines()
     sdExcludeTest
   of "s", "skip":
+    writeBlankLines()
     sdSkipTest
   else:
     stderr.writeLine "Unknown response. Skipping test case..."
+    writeBlankLines()
     sdSkipTest
 
 proc chooseReimplementsSyncDecision(testCase: ExerciseTestCase): SyncDecision =
@@ -36,13 +43,17 @@ Do you want to replace the existing test case ([y]es/[n]o/[s]kip)? """
 
   case stdin.readLine().toLowerAscii()
   of "y", "yes":
+    writeBlankLines()
     sdReplaceTest
   of "n", "no":
+    writeBlankLines()
     sdExcludeTest
   of "s", "skip":
+    writeBlankLines()
     sdSkipTest
   else:
     stderr.writeLine "Unknown response. Skipping test case..."
+    writeBlankLines()
     sdSkipTest
 
 proc syncDecision(testCase: ExerciseTestCase, mode: Mode): SyncDecision =

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -7,12 +7,11 @@ type
     sdIncludeTest, sdExcludeTest, sdSkipTest, sdReplaceTest
 
 proc chooseRegularSyncDecision(testCase: ExerciseTestCase): SyncDecision =
-  echo &"""
+  stderr.write &"""
 The following test case is missing:
 {testCase.json.pretty()}
 
-Do you want to include the test case ([y]es/[n]o/[s]kip)?
-"""
+Do you want to include the test case ([y]es/[n]o/[s]kip)? """
 
   case stdin.readLine().toLowerAscii()
   of "y", "yes":
@@ -22,19 +21,18 @@ Do you want to include the test case ([y]es/[n]o/[s]kip)?
   of "s", "skip":
     sdSkipTest
   else:
-    echo "Unknown response. Skipping test case..."
+    stderr.writeLine "Unknown response. Skipping test case..."
     sdSkipTest
 
 proc chooseReimplementsSyncDecision(testCase: ExerciseTestCase): SyncDecision =
-  echo &"""
+  stderr.write &"""
 The following test case is missing:
 {testCase.json.pretty()}
 
 It reimplements this test case:
 {testCase.reimplements.get().json.pretty()}
 
-Do you want to replace the existing test case ([y]es/[n]o/[s]kip)?
-"""
+Do you want to replace the existing test case ([y]es/[n]o/[s]kip)? """
 
   case stdin.readLine().toLowerAscii()
   of "y", "yes":
@@ -44,7 +42,7 @@ Do you want to replace the existing test case ([y]es/[n]o/[s]kip)?
   of "s", "skip":
     sdSkipTest
   else:
-    echo "Unknown response. Skipping test case..."
+    stderr.writeLine "Unknown response. Skipping test case..."
     sdSkipTest
 
 proc syncDecision(testCase: ExerciseTestCase, mode: Mode): SyncDecision =


### PR DESCRIPTION
See the commit messages.

Thoughts?

In the future, this is an area where I'd like to add color for clarity (potentially with syntax highlighting for JSON) - I've opened #353.

### Before this PR
```
Syncing exercises...
Cloning the problem-specifications repo into /foo/.problem-specifications...
[warn] anagram: missing 1 test cases
The following test case is missing:"
{
  "uuid": "03eb9bbe-8906-4ea0-84fa-ffe711b52c8b",
  "reimplements": "b3cca662-f50a-489e-ae10-ab8290a09bdc",
  "comments": [
    "Reimplemented to be consistent about removing references to 'master'"
  ],
  "description": "detects two anagrams",
  "property": "findAnagrams",
  "input": {
    "subject": "solemn",
    "candidates": [
      "lemons",
      "cherry",
      "melons"
    ]
  },
  "expected": [
    "lemons",
    "melons"
  ]
}:

It reimplements this test case:
{
  "uuid": "b3cca662-f50a-489e-ae10-ab8290a09bdc",
  "description": "detects two anagrams",
  "property": "findAnagrams",
  "input": {
    "subject": "master",
    "candidates": [
      "stream",
      "pigeon",
      "maters"
    ]
  },
  "expected": [
    "stream",
    "maters"
  ]
}:

Do you want to replace the existing test case ([y]es/[n]o/[s]kip)?:

s
[warn] diffie-hellman: missing 1 test cases
The following test case is missing:"
{
  "uuid": "0d25f8d7-4897-4338-a033-2d3d7a9af688",
  "description": "can calculate public key when given a different private key",
  "comments": [
    "As this test is intended to test the immutability / purity           ",
    "of the underlying structure, when implemented, it should first get a ",
    "public key from different values, for example from the test with     ",
    "uuid (b4161d8e-53a1-4241-ae8f-48cc86527f22).                         "
  ],
  "property": "publicKey",
  "input": {
    "p": 23,
    "g": 5,
    "privateKey": 15
  },
  "expected": 19,
  "scenarios": [
    "immutable"
  ]
}:

Do you want to include the test case ([y]es/[n]o/[s]kip)?:
```

### With this PR
```
Syncing exercises...
Cloning the problem-specifications repo into /foo/.problem-specifications...
[warn] anagram: missing 1 test cases
The following test case is missing:
{
  "uuid": "03eb9bbe-8906-4ea0-84fa-ffe711b52c8b",
  "reimplements": "b3cca662-f50a-489e-ae10-ab8290a09bdc",
  "comments": [
    "Reimplemented to be consistent about removing references to 'master'"
  ],
  "description": "detects two anagrams",
  "property": "findAnagrams",
  "input": {
    "subject": "solemn",
    "candidates": [
      "lemons",
      "cherry",
      "melons"
    ]
  },
  "expected": [
    "lemons",
    "melons"
  ]
}

It reimplements this test case:
{
  "uuid": "b3cca662-f50a-489e-ae10-ab8290a09bdc",
  "description": "detects two anagrams",
  "property": "findAnagrams",
  "input": {
    "subject": "master",
    "candidates": [
      "stream",
      "pigeon",
      "maters"
    ]
  },
  "expected": [
    "stream",
    "maters"
  ]
}

Do you want to replace the existing test case ([y]es/[n]o/[s]kip)? s


[warn] diffie-hellman: missing 1 test cases
The following test case is missing:
{
  "uuid": "0d25f8d7-4897-4338-a033-2d3d7a9af688",
  "description": "can calculate public key when given a different private key",
  "comments": [
    "As this test is intended to test the immutability / purity           ",
    "of the underlying structure, when implemented, it should first get a ",
    "public key from different values, for example from the test with     ",
    "uuid (b4161d8e-53a1-4241-ae8f-48cc86527f22).                         "
  ],
  "property": "publicKey",
  "input": {
    "p": 23,
    "g": 5,
    "privateKey": 15
  },
  "expected": 19,
  "scenarios": [
    "immutable"
  ]
}

Do you want to include the test case ([y]es/[n]o/[s]kip)? 
```