### PR TITLE
sync: remove `--check` and add `--update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ comment = "excluded because we don't want to add error handling to the exercise"
 
 In this case, the track has chosen to implement two of the three available tests. If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
 
-The `configlet sync` command allows tracks to keep `tests.toml` files up to date. The command will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data. It will then prompt the user to choose whether to include or exclude missing tests, and update the `tests.toml` files accordingly. If you only want a quick check, you can use the `--check` option.
+The `sync` command allows tracks to keep `tests.toml` files up to date. A plain `configlet sync` performs no changes, and just compares the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data - if there are tests defined only in the latter, it prints a summary and exits with a non-zero exit code.
+
+To interactively update the `tests.toml` files, use `configlet sync --update`. For each missing test, this prompts the user to choose whether to include/exclude/skip it, and updates the corresponding `tests.toml` file accordingly.
 
 The `configlet sync` command replaces the functionality of the older `canonical_data_syncer` application.
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Commands:
 
 Options for sync:
   -e, --exercise <slug>        Only sync this exercise
-  -c, --check                  Terminates with a non-zero exit code if one or more tests are missing. Doesn't update the tests
   -m, --mode <mode>            What to do with missing test cases. Allowed values: c[hoose], i[nclude], e[xclude]
   -p, --prob-specs-dir <dir>   Use this `problem-specifications` directory, rather than cloning temporarily
   -o, --offline                Do not check that the directory specified by `-p, --prob-specs-dir` is up-to-date
+  -u, --update                 Prompt the user to include, exclude, or skip any missing tests
 
 Options for uuid:
   -n, --num <int>              Number of UUIDs to generate

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -27,10 +27,10 @@ type
       discard
     of actSync:
       exercise*: string
-      check*: bool
       mode*: Mode
       probSpecsDir*: string
       offline*: bool
+      update*: bool
     of actUuid:
       num*: int
     of actGenerate:
@@ -47,10 +47,10 @@ type
     optTrackDir = "trackDir"
     optVerbosity = "verbosity"
     optSyncExercise = "exercise"
-    optSyncCheck = "check"
     optSyncMode = "mode"
     optSyncProbSpecsDir = "probSpecsDir"
     optSyncOffline = "offline"
+    optSyncUpdate = "update"
     optUuidNum = "num"
 
 func genShortKeys: array[Opt, char] =
@@ -65,7 +65,7 @@ const
   repoRootDir = currentSourcePath().parentDir().parentDir()
   configletVersion = staticRead(repoRootDir / "configlet.version").strip()
   short = genShortKeys()
-  optsNoVal = {optHelp, optVersion, optSyncCheck, optSyncOffline}
+  optsNoVal = {optHelp, optVersion, optSyncOffline, optSyncUpdate}
 
 func generateNoVals: tuple[shortNoVal: set[char], longNoVal: seq[string]] =
   ## Returns the short and long keys for the options in `optsNoVal`.
@@ -137,13 +137,12 @@ func genHelpText: string =
     optTrackDir: "Specify a track directory to use instead of the current directory",
     optVerbosity: &"The verbosity of output. {allowedValues(Verbosity)}",
     optSyncExercise: "Only sync this exercise",
-    optSyncCheck: "Terminates with a non-zero exit code if one or more tests " &
-                  "are missing. Doesn't update the tests",
     optSyncMode: &"What to do with missing test cases. {allowedValues(Mode)}",
     optSyncProbSpecsDir: "Use this `problem-specifications` directory, " &
                          "rather than cloning temporarily",
     optSyncOffline: "Do not check that the directory specified by " &
                     &"`{list(optSyncProbSpecsDir)}` is up-to-date",
+    optSyncUpdate: "Prompt the user to include, exclude, or skip any missing tests",
     optUuidNum: "Number of UUIDs to generate",
   ]
 
@@ -356,14 +355,14 @@ proc handleOption(conf: var Conf; kind: CmdLineKind; key, val: string) =
       case opt
       of optSyncExercise:
         setActionOpt(exercise, val)
-      of optSyncCheck:
-        setActionOpt(check, true)
       of optSyncMode:
         setActionOpt(mode, parseVal[Mode](kind, key, val))
       of optSyncProbSpecsDir:
         setActionOpt(probSpecsDir, val)
       of optSyncOffline:
         setActionOpt(offline, true)
+      of optSyncUpdate:
+        setActionOpt(update, true)
       else:
         discard
     of actUuid:

--- a/src/configlet.nim
+++ b/src/configlet.nim
@@ -1,5 +1,5 @@
 import std/posix
-import "."/[cli, generate/generate, lint/lint, logger, sync/check, sync/sync, uuid/uuid]
+import "."/[cli, generate/generate, lint/lint, logger, sync/check, sync/update, uuid/uuid]
 
 proc main =
   onSignal(SIGTERM):
@@ -15,10 +15,10 @@ proc main =
   of actLint:
     lint(conf)
   of actSync:
-    if conf.action.check:
-      check(conf)
+    if conf.action.update:
+      update(conf)
     else:
-      sync(conf)
+      check(conf)
   of actUuid:
     uuid(conf.action.num)
   of actGenerate:

--- a/src/sync/update.nim
+++ b/src/sync/update.nim
@@ -114,7 +114,7 @@ proc syncIfNeeded(exercise: Exercise, conf: Conf): bool =
     logDetailed(&"[skip] {exercise.slug} does not have canonical data")
     true
 
-proc sync*(conf: Conf) =
+proc update*(conf: Conf) =
   logNormal("Syncing exercises...")
 
   var everyExerciseIsSynced = true


### PR DESCRIPTION
First step towards https://github.com/exercism/configlet/issues/298

---

To-do:
- [x] Amend this part of the README:

> It will then prompt the user to choose whether to include or exclude missing tests, and update the `tests.toml` files accordingly. If you only want a quick check, you can use the `--check` option.