### PR TITLE
sync(exercises): remove duplicate `tests.toml` parsing

### DIFF
--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -133,6 +133,12 @@ proc toToml(exercise: Exercise, testsPath: string): string =
 # is regenerated, comments can be added via a `comment` key.
 """
 
+  let currContents =
+    if fileExists(testsPath):
+      parsetoml.parseFile(testsPath)
+    else:
+      nil
+
   for testCase in exercise.testCases:
     let uuid = testCase.uuid
     if uuid notin exercise.tests.missing:
@@ -148,8 +154,7 @@ proc toToml(exercise: Exercise, testsPath: string): string =
       if testCase.reimplements.isSome():
         result.add &"reimplements = \"{testCase.reimplements.get().uuid}\"\n"
 
-      if fileExists(testsPath):
-        let currContents = parsetoml.parseFile(testsPath)
+      if not currContents.isNil():
         if currContents.hasKey(uuid):
           # Preserve any other key/value pair
           for k, v in currContents[uuid].getTable():


### PR DESCRIPTION
Under some circumstances, we previously parsed `tests.toml` once per test case (!).