### PR TITLE
tests(binary): improve cloning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@
 
 # Ignore temporary repos
 .problem-specifications/
+tests/.test_binary_elixir_track_repo/
 tests/.test_binary_nim_track_repo/
 tests/.test_binary_problem_specifications/

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@
 
 # Ignore temporary repos
 .problem-specifications/
-.test_binary_problem_specifications/
-.test_binary_nim_track_repo/
+tests/.test_binary_nim_track_repo/
+tests/.test_binary_problem_specifications/

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -7,13 +7,17 @@ const
     else: ""
   binaryName = "configlet" & binaryExt
 
-proc cloneExercismRepo(repoName, dest: string; isShallow = false): tuple[
-    output: string; exitCode: int] =
-  # Clones the Exercism repo named `repoName` to the location `dest`.
+proc cloneExercismRepo(repoName, dest: string; isShallow = false) =
+  ## Clones the Exercism repo named `repoName` to the location `dest`.
+  ##
+  ## Quits if unsuccessful.
   let opts = if isShallow: "--depth 1" else: ""
   let url = &"https://github.com/exercism/{repoName}/"
   let cmd = &"git clone {opts} {url} {dest}"
-  result = execCmdEx(cmd)
+  let (outp, exitCode) = execCmdEx(cmd)
+  if exitCode != 0:
+    stderr.writeLine outp
+    quit 1
 
 template execAndCheck(expectedExitCode: int; body: untyped) {.dirty.} =
   ## Runs `body`, and prints the output if the exit code is non-zero.
@@ -39,15 +43,11 @@ proc testsForSync(binaryPath: string) =
 
     # Setup: clone the problem-specifications repo
     if not dirExists(psDir):
-      block:
-        execAndCheck(0):
-          cloneExercismRepo("problem-specifications", psDir)
+      cloneExercismRepo("problem-specifications", psDir)
 
     # Setup: clone a track repo
     if not dirExists(trackDir):
-      block:
-        execAndCheck(0):
-          cloneExercismRepo("nim", trackDir)
+      cloneExercismRepo("nim", trackDir)
 
     # Setup: set the problem-specifications repo to a known state
     block:
@@ -502,9 +502,7 @@ proc testsForGenerate(binaryPath: string) =
 
     # Setup: clone a track repo
     if not dirExists(trackDir):
-      block:
-        execAndCheck(0):
-          cloneExercismRepo("elixir", trackDir)
+      cloneExercismRepo("elixir", trackDir)
 
     # Setup: set the track repo to a known state
     block:

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -559,11 +559,12 @@ proc testsForGenerate(binaryPath: string) =
         execCmdEx(diffCmd)
 
 proc main =
-  const repoRootDir = currentSourcePath.parentDir().parentDir()
-  let binaryPath = repoRootDir / binaryName
-  const helpStart = &"Usage:\n  {binaryName} [global-options] <command> [command-options]"
+  const
+    repoRootDir = currentSourcePath.parentDir().parentDir()
+    binaryPath = repoRootDir / binaryName
+    helpStart = &"Usage:\n  {binaryName} [global-options] <command> [command-options]"
+    cmdBase = "nimble --verbose build"
 
-  const cmdBase = "nimble --verbose build"
   let cmd = if existsEnv("CI"): &"{cmdBase} -d:release" else: cmdBase
   stderr.write(&"Running `{cmd}`... ")
   let (buildOutput, buildExitCode) = execCmdEx(cmd, workingDir = repoRootDir)

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -2,10 +2,8 @@ import std/[os, osproc, strformat, strscans, strutils, unittest]
 import "."/lint/validators
 
 const
-  binaryExt =
-    when defined(windows): ".exe"
-    else: ""
-  binaryName = "configlet" & binaryExt
+  testsDir = currentSourcePath().parentDir()
+  repoRootDir = testsDir.parentDir()
 
 proc cloneExercismRepo(repoName, dest: string; isShallow = false) =
   ## Clones the Exercism repo named `repoName` to the location `dest`.
@@ -42,8 +40,8 @@ func conciseDiff(s: string): string =
 
 proc testsForSync(binaryPath: string) =
   suite "sync":
-    const psDir = ".test_binary_problem_specifications"
-    const trackDir = ".test_binary_nim_track_repo"
+    const psDir = testsDir / ".test_binary_problem_specifications"
+    const trackDir = testsDir / ".test_binary_nim_track_repo"
 
     # Setup: clone the problem-specifications repo
     if not dirExists(psDir):
@@ -500,7 +498,7 @@ proc prepareIntroductionFiles(trackDir, header, placeholder: string;
 
 proc testsForGenerate(binaryPath: string) =
   suite "generate":
-    const trackDir = ".test_binary_elixir_track_repo"
+    const trackDir = testsDir / ".test_binary_elixir_track_repo"
     let generateCmd = &"{binaryPath} -t {trackDir} generate"
     let diffCmd = &"git -C {trackDir} diff --exit-code"
 
@@ -560,7 +558,10 @@ proc testsForGenerate(binaryPath: string) =
 
 proc main =
   const
-    repoRootDir = currentSourcePath.parentDir().parentDir()
+    binaryExt =
+      when defined(windows): ".exe"
+      else: ""
+    binaryName = &"configlet{binaryExt}"
     binaryPath = repoRootDir / binaryName
     helpStart = &"Usage:\n  {binaryName} [global-options] <command> [command-options]"
     cmdBase = "nimble --verbose build"

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -36,28 +36,28 @@ proc testsForSync(binaryPath: string) =
   suite "sync":
     const psDir = ".test_binary_problem_specifications"
     const trackDir = ".test_binary_nim_track_repo"
-    removeDir(psDir)
-    removeDir(trackDir)
 
     # Setup: clone the problem-specifications repo
-    block:
-      execAndCheck(0):
-        cloneExercismRepo("problem-specifications", psDir)
+    if not dirExists(psDir):
+      block:
+        execAndCheck(0):
+          cloneExercismRepo("problem-specifications", psDir)
 
     # Setup: clone a track repo
-    block:
-      execAndCheck(0):
-        cloneExercismRepo("nim", trackDir)
+    if not dirExists(trackDir):
+      block:
+        execAndCheck(0):
+          cloneExercismRepo("nim", trackDir)
 
     # Setup: set the problem-specifications repo to a known state
     block:
       execAndCheck(0):
-        execCmdEx(&"git -C {psDir} checkout f17f457fdc0673369047250f652e93c7901755e1")
+        execCmdEx(&"git -C {psDir} checkout --force f17f457fdc0673369047250f652e93c7901755e1")
 
     # Setup: set the track repo to a known state
     block:
       execAndCheck(0):
-        execCmdEx(&"git -C {trackDir} checkout 6e909c9e5338cd567c20224069df00e031fb2efa")
+        execCmdEx(&"git -C {trackDir} checkout --force 6e909c9e5338cd567c20224069df00e031fb2efa")
 
     test "a `sync` without `--update` exits with 1 and prints the expected output":
       execAndCheck(1):
@@ -500,17 +500,16 @@ proc testsForGenerate(binaryPath: string) =
     let generateCmd = &"{binaryPath} -t {trackDir} generate"
     let diffCmd = &"git -C {trackDir} diff --exit-code"
 
-    removeDir(trackDir)
-
     # Setup: clone a track repo
-    block:
-      execAndCheck(0):
-        cloneExercismRepo("elixir", trackDir)
+    if not dirExists(trackDir):
+      block:
+        execAndCheck(0):
+          cloneExercismRepo("elixir", trackDir)
 
     # Setup: set the track repo to a known state
     block:
       execAndCheck(0):
-        execCmdEx(&"git -C {trackDir} checkout f3974abf6e0d4a434dfe3494d58581d399c18edb")
+        execCmdEx(&"git -C {trackDir} checkout --force f3974abf6e0d4a434dfe3494d58581d399c18edb")
 
     test "`configlet generate` exits with 0 when there are no `.md.tpl` files":
       execAndCheck(0):

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -14,8 +14,12 @@ proc cloneExercismRepo(repoName, dest: string; isShallow = false) =
   let opts = if isShallow: "--depth 1" else: ""
   let url = &"https://github.com/exercism/{repoName}/"
   let cmd = &"git clone {opts} {url} {dest}"
+  stderr.write &"Running `{cmd}`... "
   let (outp, exitCode) = execCmdEx(cmd)
-  if exitCode != 0:
+  if exitCode == 0:
+    stderr.writeLine "success"
+  else:
+    stderr.writeLine "failure"
     stderr.writeLine outp
     quit 1
 


### PR DESCRIPTION
This PR makes re-running the end-to-end tests much saner/faster. Without this change (or commenting-out the `git clone` lines), it's painful to add tests.

See the commit messages.

I was going to push these changes (and much more upcoming) to #366, but it makes that PR (and eventual squashed commit) too large - it'll already be pretty big. So I want to merge a few PRs first - this won't slow things down more. I consider adding decent tests one of the biggest parts of #366, so in this case I want to not hate the initial state of the new tests.

The next PR will improve the cloning process further, so we'll just have `setupExercismRepo` at the call site that does "clone if necessary, and checkout".

I think I've finally figured out an ergonomic design for some exec/git helper commands, so they'll soon infect the rest of our codebase too.