### PR TITLE
tests: refactor to share code for exec and git

### DIFF
--- a/src/exec.nim
+++ b/src/exec.nim
@@ -42,7 +42,8 @@ proc git*(args: openArray[string]): ProcessResult =
   result = myExecCmdEx("git", args = args)
 
 proc cloneExercismRepo*(repoName, dest: string; isShallow = false) =
-  ## Clones the Exercism repo named `repoName` to the location `dest`.
+  ## Clones the Exercism repo named `repoName` to the location `dest`. Performs
+  ## a shallow clone if `isShallow` is `true`.
   ##
   ## Quits if unsuccessful.
   let url = &"https://github.com/exercism/{repoName}/"

--- a/src/exec.nim
+++ b/src/exec.nim
@@ -16,7 +16,7 @@ proc myExecCmdEx*(command: string; args: openArray[string] = [];
   ## This is a convenience wrapper around `startProcess`, and is minimally
   ## adapted from `osproc.execCmdEx` to use `args` (and avoid `poEvalCommand`).
   ##
-  ## Raises `OSError` if we cannot execute a file at `path`.
+  ## Raises `OSError` if the `command` is not found.
   var p = startProcess(command, args = args, options = options, env = env,
                        workingDir = workingDir)
   var outp = outputStream(p)

--- a/src/exec.nim
+++ b/src/exec.nim
@@ -73,3 +73,11 @@ proc gitCheckout*(dir, hash: string) =
   if exitCode != 0:
     stderr.writeLine output
     quit 1
+
+proc setupExercismRepo*(repoName, dest, hash: string; isShallow = false) =
+  ## If there is no directory at `dest`, clones the Exercism repo named
+  ## `repoName` to `dest`.
+  ##
+  ## Then checkout the given `hash` in `dest`.
+  cloneExercismRepo(repoName, dest, isShallow)
+  gitCheckout(dest, hash)

--- a/src/exec.nim
+++ b/src/exec.nim
@@ -1,0 +1,42 @@
+import std/[osproc, streams, strtabs]
+
+type
+  ProcessResult* = tuple
+    output: string
+    exitCode: int
+
+proc myExecCmdEx*(command: string; args: openArray[string] = [];
+    options: set[ProcessOption] = {poStdErrToStdOut, poUsePath};
+    env: StringTableRef = nil; workingDir = ""; input = ""): ProcessResult {.
+    gcsafe, tags: [ExecIOEffect, ReadIOEffect, RootEffect].} =
+  ## Runs the `command` with `args`, and returns the output and exit code.
+  ## The `options`, `env`, and `workingDir` parameters behave as for
+  ## `startProcess`. If `input.len > 0`, it is passed as stdin.
+  ##
+  ## This is a convenience wrapper around `startProcess`, and is minimally
+  ## adapted from `osproc.execCmdEx` to use `args` (and avoid `poEvalCommand`).
+  ##
+  ## Raises `OSError` if we cannot execute a file at `path`.
+  var p = startProcess(command, args = args, options = options, env = env,
+                       workingDir = workingDir)
+  var outp = outputStream(p)
+
+  if input.len > 0:
+    inputStream(p).write(input)
+  close inputStream(p)
+
+  result = ("", -1)
+  var line = newStringOfCap(120)
+  while true:
+    if outp.readLine(line):
+      result[0].add line
+      result[0].add "\n"
+    else:
+      result[1] = peekExitCode(p)
+      if result[1] != -1:
+        break
+  close(p)
+
+proc git*(args: openArray[string]): ProcessResult =
+  ## Runs `git` with `args`. Returns the output and exit code.
+  result = myExecCmdEx("git", args = args)

--- a/src/exec.nim
+++ b/src/exec.nim
@@ -5,7 +5,7 @@ type
     output: string
     exitCode: int
 
-proc exec*(command: string; args: openArray[string] = [];
+proc exec(command: string; args: openArray[string] = [];
     options: set[ProcessOption] = {poStdErrToStdOut, poUsePath};
     env: StringTableRef = nil; workingDir = ""; input = ""): ProcessResult {.
     gcsafe, tags: [ExecIOEffect, ReadIOEffect, RootEffect].} =
@@ -37,7 +37,7 @@ proc exec*(command: string; args: openArray[string] = [];
         break
   close(p)
 
-proc git*(args: openArray[string]): ProcessResult =
+proc git(args: openArray[string]): ProcessResult =
   ## Runs `git` with `args`. Returns the output and exit code.
   result = exec("git", args = args)
 
@@ -63,7 +63,7 @@ proc cloneExercismRepo*(repoName, dest: string; isShallow = false) =
       stderr.writeLine outp
       quit 1
 
-proc gitCheckout*(dir, hash: string) =
+proc gitCheckout(dir, hash: string) =
   ## Checkout `hash` in the git repo at `dir`, discarding changes to the working
   ## directory in `dir`.
   ##

--- a/src/exec.nim
+++ b/src/exec.nim
@@ -41,16 +41,16 @@ proc git(args: openArray[string]): ProcessResult =
   ## Runs `git` with `args`. Returns the output and exit code.
   result = exec("git", args = args)
 
-proc cloneExercismRepo*(repoName, dest: string; isShallow = false) =
+proc cloneExercismRepo*(repoName, dest: string; shallow = false) =
   ## If there is no directory at `dest`, clones the Exercism repo named
-  ## `repoName` to `dest`. Performs a shallow clone if `isShallow` is `true`.
+  ## `repoName` to `dest`. Performs a shallow clone if `shallow` is `true`.
   ##
   ## Quits if the directory does not already exist and the clone is
   ## unsuccessful.
   if not dirExists(dest):
     let url = &"https://github.com/exercism/{repoName}/"
     let args =
-      if isShallow:
+      if shallow:
         @["clone", "--depth", "1", "--", url, dest]
       else:
         @["clone", "--", url, dest]
@@ -74,10 +74,10 @@ proc gitCheckout(dir, hash: string) =
     stderr.writeLine output
     quit 1
 
-proc setupExercismRepo*(repoName, dest, hash: string; isShallow = false) =
+proc setupExercismRepo*(repoName, dest, hash: string; shallow = false) =
   ## If there is no directory at `dest`, clones the Exercism repo named
   ## `repoName` to `dest`.
   ##
   ## Then checkout the given `hash` in `dest`.
-  cloneExercismRepo(repoName, dest, isShallow)
+  cloneExercismRepo(repoName, dest, shallow)
   gitCheckout(dest, hash)

--- a/src/exec.nim
+++ b/src/exec.nim
@@ -5,7 +5,7 @@ type
     output: string
     exitCode: int
 
-proc myExecCmdEx*(command: string; args: openArray[string] = [];
+proc exec*(command: string; args: openArray[string] = [];
     options: set[ProcessOption] = {poStdErrToStdOut, poUsePath};
     env: StringTableRef = nil; workingDir = ""; input = ""): ProcessResult {.
     gcsafe, tags: [ExecIOEffect, ReadIOEffect, RootEffect].} =
@@ -39,7 +39,7 @@ proc myExecCmdEx*(command: string; args: openArray[string] = [];
 
 proc git*(args: openArray[string]): ProcessResult =
   ## Runs `git` with `args`. Returns the output and exit code.
-  result = myExecCmdEx("git", args = args)
+  result = exec("git", args = args)
 
 proc cloneExercismRepo*(repoName, dest: string; isShallow = false) =
   ## If there is no directory at `dest`, clones the Exercism repo named

--- a/src/exec.nim
+++ b/src/exec.nim
@@ -1,4 +1,4 @@
-import std/[osproc, streams, strtabs]
+import std/[osproc, streams, strformat, strtabs]
 
 type
   ProcessResult* = tuple
@@ -40,3 +40,22 @@ proc myExecCmdEx*(command: string; args: openArray[string] = [];
 proc git*(args: openArray[string]): ProcessResult =
   ## Runs `git` with `args`. Returns the output and exit code.
   result = myExecCmdEx("git", args = args)
+
+proc cloneExercismRepo*(repoName, dest: string; isShallow = false) =
+  ## Clones the Exercism repo named `repoName` to the location `dest`.
+  ##
+  ## Quits if unsuccessful.
+  let url = &"https://github.com/exercism/{repoName}/"
+  let args =
+    if isShallow:
+      @["clone", "--depth", "1", "--", url, dest]
+    else:
+      @["clone", "--", url, dest]
+  stderr.write &"Cloning {url}... "
+  let (outp, exitCode) = git(args)
+  if exitCode == 0:
+    stderr.writeLine "success"
+  else:
+    stderr.writeLine "failure"
+    stderr.writeLine outp
+    quit 1

--- a/src/exec.nim
+++ b/src/exec.nim
@@ -62,3 +62,14 @@ proc cloneExercismRepo*(repoName, dest: string; isShallow = false) =
       stderr.writeLine "failure"
       stderr.writeLine outp
       quit 1
+
+proc gitCheckout*(dir, hash: string) =
+  ## Checkout `hash` in the git repo at `dir`, discarding changes to the working
+  ## directory in `dir`.
+  ##
+  ## Quits if unsucessful.
+  let args = ["-C", dir, "checkout", "--force", hash]
+  let (output, exitCode) = git(args)
+  if exitCode != 0:
+    stderr.writeLine output
+    quit 1

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -27,17 +27,13 @@ proc testsForSync(binaryPath: string) =
     const psDir = testsDir / ".test_binary_problem_specifications"
     const trackDir = testsDir / ".test_binary_nim_track_repo"
 
-    # Setup: clone the problem-specifications repo
-    cloneExercismRepo("problem-specifications", psDir)
+    # Setup: clone the problem-specifications repo, and checkout a known state
+    setupExercismRepo("problem-specifications", psDir,
+                      "f17f457fdc0673369047250f652e93c7901755e1")
 
-    # Setup: clone a track repo
-    cloneExercismRepo("nim", trackDir)
-
-    # Setup: set the problem-specifications repo to a known state
-    gitCheckout(psDir, "f17f457fdc0673369047250f652e93c7901755e1")
-
-    # Setup: set the track repo to a known state
-    gitCheckout(trackDir, "6e909c9e5338cd567c20224069df00e031fb2efa")
+    # Setup: clone a track repo, and checkout a known state
+    setupExercismRepo("nim", trackDir,
+                      "6e909c9e5338cd567c20224069df00e031fb2efa")
 
     test "a `sync` without `--update` exits with 1 and prints the expected output":
       execAndCheck(1):
@@ -480,11 +476,9 @@ proc testsForGenerate(binaryPath: string) =
     let generateCmd = &"{binaryPath} -t {trackDir} generate"
     let diffCmd = &"git -C {trackDir} diff --exit-code"
 
-    # Setup: clone a track repo
-    cloneExercismRepo("elixir", trackDir)
-
-    # Setup: set the track repo to a known state
-    gitCheckout(trackDir, "f3974abf6e0d4a434dfe3494d58581d399c18edb")
+    # Setup: clone a track repo, and checkout a known state
+    setupExercismRepo("elixir", trackDir,
+                      "f3974abf6e0d4a434dfe3494d58581d399c18edb")
 
     test "`configlet generate` exits with 0 when there are no `.md.tpl` files":
       execAndCheck(0):

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -28,12 +28,10 @@ proc testsForSync(binaryPath: string) =
     const trackDir = testsDir / ".test_binary_nim_track_repo"
 
     # Setup: clone the problem-specifications repo
-    if not dirExists(psDir):
-      cloneExercismRepo("problem-specifications", psDir)
+    cloneExercismRepo("problem-specifications", psDir)
 
     # Setup: clone a track repo
-    if not dirExists(trackDir):
-      cloneExercismRepo("nim", trackDir)
+    cloneExercismRepo("nim", trackDir)
 
     # Setup: set the problem-specifications repo to a known state
     block:
@@ -487,8 +485,7 @@ proc testsForGenerate(binaryPath: string) =
     let diffCmd = &"git -C {trackDir} diff --exit-code"
 
     # Setup: clone a track repo
-    if not dirExists(trackDir):
-      cloneExercismRepo("elixir", trackDir)
+    cloneExercismRepo("elixir", trackDir)
 
     # Setup: set the track repo to a known state
     block:

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -34,14 +34,10 @@ proc testsForSync(binaryPath: string) =
     cloneExercismRepo("nim", trackDir)
 
     # Setup: set the problem-specifications repo to a known state
-    block:
-      execAndCheck(0):
-        execCmdEx(&"git -C {psDir} checkout --force f17f457fdc0673369047250f652e93c7901755e1")
+    gitCheckout(psDir, "f17f457fdc0673369047250f652e93c7901755e1")
 
     # Setup: set the track repo to a known state
-    block:
-      execAndCheck(0):
-        execCmdEx(&"git -C {trackDir} checkout --force 6e909c9e5338cd567c20224069df00e031fb2efa")
+    gitCheckout(trackDir, "6e909c9e5338cd567c20224069df00e031fb2efa")
 
     test "a `sync` without `--update` exits with 1 and prints the expected output":
       execAndCheck(1):
@@ -488,9 +484,7 @@ proc testsForGenerate(binaryPath: string) =
     cloneExercismRepo("elixir", trackDir)
 
     # Setup: set the track repo to a known state
-    block:
-      execAndCheck(0):
-        execCmdEx(&"git -C {trackDir} checkout --force f3974abf6e0d4a434dfe3494d58581d399c18edb")
+    gitCheckout(trackDir, "f3974abf6e0d4a434dfe3494d58581d399c18edb")
 
     test "`configlet generate` exits with 0 when there are no `.md.tpl` files":
       execAndCheck(0):

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -1,5 +1,5 @@
 import std/[os, osproc, strformat, strscans, strutils, unittest]
-import "."/lint/validators
+import "."/[exec, lint/validators]
 
 const
   testsDir = currentSourcePath().parentDir()
@@ -9,11 +9,14 @@ proc cloneExercismRepo(repoName, dest: string; isShallow = false) =
   ## Clones the Exercism repo named `repoName` to the location `dest`.
   ##
   ## Quits if unsuccessful.
-  let opts = if isShallow: "--depth 1" else: ""
   let url = &"https://github.com/exercism/{repoName}/"
-  let cmd = &"git clone {opts} {url} {dest}"
-  stderr.write &"Running `{cmd}`... "
-  let (outp, exitCode) = execCmdEx(cmd)
+  let args =
+    if isShallow:
+      @["clone", "--depth", "1", "--", url, dest]
+    else:
+      @["clone", "--", url, dest]
+  stderr.write &"Cloning {url}... "
+  let (outp, exitCode) = git(args)
   if exitCode == 0:
     stderr.writeLine "success"
   else:

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -5,25 +5,6 @@ const
   testsDir = currentSourcePath().parentDir()
   repoRootDir = testsDir.parentDir()
 
-proc cloneExercismRepo(repoName, dest: string; isShallow = false) =
-  ## Clones the Exercism repo named `repoName` to the location `dest`.
-  ##
-  ## Quits if unsuccessful.
-  let url = &"https://github.com/exercism/{repoName}/"
-  let args =
-    if isShallow:
-      @["clone", "--depth", "1", "--", url, dest]
-    else:
-      @["clone", "--", url, dest]
-  stderr.write &"Cloning {url}... "
-  let (outp, exitCode) = git(args)
-  if exitCode == 0:
-    stderr.writeLine "success"
-  else:
-    stderr.writeLine "failure"
-    stderr.writeLine outp
-    quit 1
-
 template execAndCheck(expectedExitCode: int; body: untyped) {.dirty.} =
   ## Runs `body`, and prints the output if the exit code is non-zero.
   ## `body` must have the same return type as `execCmdEx`.

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -23,7 +23,7 @@ proc main =
   for ps in ProblemSpecsDir:
     suite &"getCanonicalTests: {ps}":
       if ps == psExisting:
-        cloneExercismRepo("problem-specifications", existingDir, isShallow = true)
+        cloneExercismRepo("problem-specifications", existingDir, shallow = true)
 
       let probSpecsPath =
         case ps

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -1,6 +1,6 @@
 # This module contains tests for `src/probspecs.nim`
-import std/[json, os, osproc, strformat, tables, unittest]
-import "."/[cli, sync/probspecs]
+import std/[json, os, strformat, tables, unittest]
+import "."/[cli, exec, sync/probspecs]
 
 type
   ProblemSpecsDir = enum
@@ -23,12 +23,7 @@ proc main =
   for ps in ProblemSpecsDir:
     suite &"getCanonicalTests: {ps}":
       if ps == psExisting:
-        let cmd = "git clone --depth 1 --quiet " &
-                  "https://github.com/exercism/problem-specifications/ " &
-                  existingDir
-        test "can make our own clone for later use as an \"existing dir\"":
-          check:
-            execCmd(cmd) == 0
+        cloneExercismRepo("problem-specifications", existingDir, isShallow = true)
 
       let probSpecsPath =
         case ps

--- a/tests/test_tracks.nim
+++ b/tests/test_tracks.nim
@@ -5,7 +5,8 @@ import "."/[cli, exec, sync/tracks]
 proc main =
   suite "findPracticeExercises":
     const trackDir = ".test_tracks_nim_track_repo"
-    setupExercismRepo("nim", trackDir, "6e909c9e5338cd567c20224069df00e031fb2efa")
+    setupExercismRepo("nim", trackDir,
+                      "6e909c9e5338cd567c20224069df00e031fb2efa")
 
     let conf = Conf(
       action: initAction(actSync),

--- a/tests/test_tracks.nim
+++ b/tests/test_tracks.nim
@@ -1,20 +1,11 @@
 # This file implements tests for `src/tracks.nim`
-import std/[os, osproc, sequtils, sets, strformat, unittest]
-import "."/[cli, sync/tracks]
+import std/[os, sequtils, sets, strformat, unittest]
+import "."/[cli, exec, sync/tracks]
 
 proc main =
   suite "findPracticeExercises":
     const trackDir = ".test_tracks_nim_track_repo"
-    removeDir(trackDir)
-    let cmd = &"git clone --quiet https://github.com/exercism/nim.git {trackDir}"
-    if execCmd(cmd) != 0:
-      stderr.writeLine "Error: failed to clone the track repo"
-      quit(1)
-
-    const gitHash = "6e909c9e5338cd567c20224069df00e031fb2efa"
-    if execCmd(&"git -C {trackDir} checkout --quiet {gitHash}") != 0:
-      stderr.writeLine "Error: could not checkout a specific commit"
-      quit(1)
+    setupExercismRepo("nim", trackDir, "6e909c9e5338cd567c20224069df00e031fb2efa")
 
     let conf = Conf(
       action: initAction(actSync),


### PR DESCRIPTION
This PR is a follow-up of #379, where I wrote:

> I was going to push these changes (and much more upcoming) to #366, but it makes that PR (and eventual squashed commit) too large - it'll already be pretty big. So I want to merge a few PRs first - this won't slow things down more. I consider adding decent tests one of the biggest parts of #366, so in this case I want to not hate the initial state of the new tests.

> The next PR will improve the cloning process further, so we'll just have `setupExercismRepo` at the call site that does "clone if necessary, and checkout".

> I think I've finally figured out an ergonomic design for some exec/git helper commands, so they'll soon infect the rest of our codebase too.

See the individual commits.

The hard question: can we think of a better name than `myExecCmdEx`? I might use just `exec` instead - it's hard for a reader to confuse with [`nimscript.exec`](https://nim-lang.github.io/Nim/nimscript.html#exec%2Cstring) because that proc doesn't return anything.

A later PR will make `src/probspecs.nim` also use this shared code. And other things in `tests/test_binary.nim` too.