### PR TITLE
tests(binary): support skipping build

### DIFF
--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -534,13 +534,14 @@ proc main =
     binaryPath = repoRootDir / binaryName
     helpStart = &"Usage:\n  {binaryName} [global-options] <command> [command-options]"
 
-  let args =
-    if existsEnv("CI"):
-      @["--verbose", "build", "-d:release"]
-    else:
-      @["--verbose", "build"]
-  discard execAndCheck(0, "nimble", args, workingDir = repoRootDir,
-                       verbose = true)
+  if not defined(skipBuild):
+    let args =
+      if existsEnv("CI"):
+        @["--verbose", "build", "-d:release"]
+      else:
+        @["--verbose", "build"]
+    discard execAndCheck(0, "nimble", args, workingDir = repoRootDir,
+                         verbose = true)
 
   suite "help as an argument":
     test "help":


### PR DESCRIPTION
Tiny PR. This gives a configlet developer a shortcut (`nim r -d:skipBuild test_binary`) for re-running the end-to-end tests after making changes to them alone.

This is fine as a compile-time flag, rather than a run-time flag.