### PR TITLE
lint(track_config): add missing key feature icons

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -159,6 +159,7 @@ const keyFeatureIcons = [
   "dynamically-typed",
   "easy",
   "embeddable",
+  "evolving",
   "expressive",
   "extensible",
   "fast",
@@ -167,6 +168,7 @@ const keyFeatureIcons = [
   "garbage-collected",
   "general-purpose",
   "homoiconic",
+  "immutable",
   "interactive",
   "interop",
   "multi-paradigm",
@@ -176,8 +178,10 @@ const keyFeatureIcons = [
   "safe",
   "scientific",
   "small",
+  "stable",
   "statically-typed",
   "tooling",
+  "web",
   "widely-used",
 ].toHashSet()
 


### PR DESCRIPTION
This commit adds four missing key feature icons:
- `evolving`
- `immutable`
- `stable`
- `web`

See also:
- https://github.com/exercism/docs/pull/187, which adds these icons to
  the list of key feature icons
