### PR TITLE
lint: check `source` and `source_url`

### DIFF
--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -18,6 +18,9 @@ proc isValidConceptExerciseConfig(data: JsonNode;
   if isObject(data, jsonRoot, path):
     let checks = [
       hasString(data, "blurb", path, maxLen = 350),
+      hasString(data, "source", path, isRequired = false),
+      hasString(data, "source_url", path, isRequired = false,
+                checkIsUrlLike = true),
       hasArrayOfStrings(data, "authors", path, uniqueValues = true),
       hasArrayOfStrings(data, "contributors", path, isRequired = false,
                         uniqueValues = true),

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -18,6 +18,9 @@ proc isValidPracticeExerciseConfig(data: JsonNode;
   if isObject(data, jsonRoot, path):
     let checks = [
       hasString(data, "blurb", path, maxLen = 350),
+      hasString(data, "source", path, isRequired = false),
+      hasString(data, "source_url", path, isRequired = false,
+                checkIsUrlLike = true),
       hasArrayOfStrings(data, "authors", path, isRequired = false,
                         uniqueValues = true),
       hasArrayOfStrings(data, "contributors", path, isRequired = false,


### PR DESCRIPTION
To-do:
- [x] Merge #404

---

With this commit, `configlet lint` now checks that the `config.json`
file for a Concept Exercise or a Practice Exercise follows these rules:

- The `source` key is optional
- The `source` value must be a non-blank string
- The `source_url` key is optional
- The `source_url` value must be a URL

---

This PR will address the `source` and `source_url` changes from https://github.com/exercism/docs/commit/12edc0eecbed4dd9e54300cb6eac286059a9ceb8

Do we want to complain when the value of an optional key is the empty string?

~The error message below doesn't mention `source_url`. I'll try to fix it.~ (Done in #404)

---

This PR currently produces the below diff to the output of `configlet lint`, per track:

#### babashka
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+

```

#### bash
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### c
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### clojure
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### common-lisp
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### cpp
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### csharp
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### dart
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### delphi
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### elixir
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### elm
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### erlang
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### fsharp
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### go
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+

```

#### haskell
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### haxe
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/darts/.meta/config.json
+
+The value of `source` is a zero-length string:
+./exercises/practice/forth/.meta/config.json
+
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/forth/.meta/config.json
+

```

#### java
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### javascript
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### julia
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+

```

#### kotlin
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### lfe
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### lua
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### perl5
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### pharo-smalltalk
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### php
```diff
+The value of `source` is a zero-length string:
+./exercises/practice/mask-credit-card/.meta/config.json
+
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/mask-credit-card/.meta/config.json
+
+The value of `source` is a zero-length string:
+./exercises/practice/ordinal-number/.meta/config.json
+
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### python
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### ruby
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### rust
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### scala
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### swift
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### tcl
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### typescript
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### wren
```diff
+The `source_url` value is the empty string, but it must be a valid URL:
+./exercises/practice/robot-simulator/.meta/config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```
