### PR TITLE
lint(practice_exercises): check `test_runner`

### DIFF
--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -24,6 +24,7 @@ proc isValidPracticeExerciseConfig(data: JsonNode;
                         uniqueValues = true),
       hasValidFiles(data, path, exerciseDir),
       hasString(data, "language_versions", path, isRequired = false),
+      hasBoolean(data, "test_runner", path, isRequired = false),
     ]
     result = allTrue(checks)
 


### PR DESCRIPTION
With this commit, `configlet lint` now checks that the `config.json`
file for a Practice Exercise follows these rules:

- The `test_runner` key is optional
- The `test_runner` value must be a boolean

---

This PR addresses the `test_runner` changes from https://github.com/exercism/docs/commit/12edc0eecbed4dd9e54300cb6eac286059a9ceb8

This PR currently keeps the output of `configlet lint` the same on every track.