### PR TITLE
lint(validators): improve error message for bad URL

### DIFF
--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -199,7 +199,8 @@ proc isString*(data: JsonNode; key: string; path: Path; context: string;
         result.setFalseAndPrint(msgStart & msgEnd, path)
     elif checkIsUrlLike:
       if not isUrlLike(s):
-        result.setFalseAndPrint(&"Not a valid URL: {q s}", path)
+        let msg = &"The {q key} value is {q s}, but it must be a valid URL"
+        result.setFalseAndPrint(msg, path)
     elif s.len > 0:
       if not isEmptyOrWhitespace(s):
         if checkIsKebab:


### PR DESCRIPTION
Example before this commit:
```
Not a valid URL: the empty string:
./concepts/basics/links.json
```

With this commit:
```
The `url` value is the empty string, but it must be a valid URL:
./concepts/basics/links.json
```

---

This PR is to address my comment in #400:
> The error message below doesn't mention `source_url`. I'll try to fix it.