### PR TITLE
tests(binary): add more tests for sync

### DIFF
--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -94,6 +94,29 @@ proc testsForSync(binaryPath: string) =
         [warn] some exercises are missing test cases
       """.dedent(8) # Not `unindent`. We want to preserve the indentation of the list items.
 
+    test "a single-exercise `sync` without `--update` exits with 1 and prints the expected output":
+      execAndCheck(1):
+        execCmdEx(&"{binaryPath} -t {trackDir} sync -o -p {psDir} -e anagram")
+
+      check outp == """
+        Checking exercises...
+        [warn] anagram: missing 1 test case
+               - detects two anagrams (03eb9bbe-8906-4ea0-84fa-ffe711b52c8b)
+        [warn] some exercises are missing test cases
+      """.dedent(8)
+
+    test "when passing multiple exercises, only the final exercise is acted upon":
+      # TODO: We should instead support multiple exercises being passed.
+      execAndCheck(1):
+        execCmdEx(&"{binaryPath} -t {trackDir} sync -o -p {psDir} -e grade-school -e isogram")
+
+      check outp == """
+        Checking exercises...
+        [warn] isogram: missing 1 test case
+               - word with duplicated character and with two hyphens (0d0b8644-0a1e-4a31-a432-2b3ee270d847)
+        [warn] some exercises are missing test cases
+      """.dedent(8)
+
     test "`sync --update --mode=include` exits with 0 and includes the expected test cases":
       execAndCheck(0):
         execCmdEx(&"{binaryPath} -t {trackDir} sync --update -mi -o -p {psDir}")

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -117,6 +117,50 @@ proc testsForSync(binaryPath: string) =
         [warn] some exercises are missing test cases
       """.dedent(8)
 
+    test "single-exercise `sync --update --mode=include` exits with 0 and includes the expected test cases":
+      execAndCheck(0):
+        execCmdEx(&"{binaryPath} -t {trackDir} sync --update -mi -o -p {psDir} -e anagram")
+
+      check outp == """
+        Syncing exercises...
+        [info] anagram: included 1 missing test case
+        All exercises are synced!
+      """.unindent()
+
+    const diffOpts = "--no-ext-diff --text --unified=0 --no-prefix --color=never"
+    const diffCmd = &"""git --no-pager -C {trackDir} diff {diffOpts}"""
+
+    test "`git diff` shows the expected diff":
+      execAndCheck(0):
+        execCmdEx(diffCmd)
+
+      const expectedAnagramDiffInclude = """
+        --- exercises/practice/anagram/.meta/tests.toml
+        +++ exercises/practice/anagram/.meta/tests.toml
+        -# This is an auto-generated file. Regular comments will be removed when this
+        -# file is regenerated. Regenerating will not touch any manually added keys,
+        -# so comments can be added in a "comment" key.
+        +# This is an auto-generated file.
+        +#
+        +# Regenerating this file via `configlet sync` will:
+        +# - Recreate every `description` key/value pair
+        +# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+        +# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+        +# - Preserve any other key/value pair
+        +#
+        +# As user-added comments (using the # character) will be removed when this file
+        +# is regenerated, comments can be added via a `comment` key.
+        +[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+        +description = "detects two anagrams"
+        +reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
+        +
+      """.unindent()
+
+      check outp.conciseDiff() == expectedAnagramDiffInclude
+
+    let anagramTestsTomlPath = joinPath("exercises", "practice", "anagram", ".meta", "tests.toml")
+    check execCmdEx(&"git -C {trackDir} restore {anagramTestsTomlPath}")[1] == 0
+
     test "`sync --update --mode=include` exits with 0 and includes the expected test cases":
       execAndCheck(0):
         execCmdEx(&"{binaryPath} -t {trackDir} sync --update -mi -o -p {psDir}")
@@ -444,8 +488,6 @@ proc testsForSync(binaryPath: string) =
       +description = "callbacks should not be called if dependencies change but output value doesn't change"
     """.unindent()
 
-    const diffOpts = "--no-ext-diff --text --unified=0 --no-prefix --color=never"
-    const diffCmd = &"""git --no-pager -C {trackDir} diff {diffOpts}"""
     test "`git diff` shows the expected diff":
       execAndCheck(0):
         execCmdEx(diffCmd)


### PR DESCRIPTION
Let's add our first tests for `--exercise` and the interactive mode, with a user typing `y`/`n`.

I'll refactor this later to be less terrible.