### PR TITLE
lint(track_config): check `prerequisites` and `concepts`

### DIFF
--- a/configlet.nimble
+++ b/configlet.nimble
@@ -11,6 +11,7 @@ requires "nim >= 1.4.8"
 requires "parsetoml"
 requires "cligen"
 requires "uuids >= 0.1.11"
+requires "jsony >= 1.0.4"
 
 task test, "Runs the test suite":
   exec "nim r ./tests/all_tests.nim"


### PR DESCRIPTION
With this commit, `configlet lint` now checks the below rules for a
track-level `config.json` file:
- The `exercises.concept[].prerequisites` values must match any other
  concept exercise's `concepts` property values
- The `exercises.concept[].prerequisites` values must not match any of
  the values in the exercise's `exercises.concept[].concepts` property

---

Quick hack for https://github.com/exercism/exercism/issues/5770

Ping @iHiD 

See also:
- https://github.com/exercism/rust/issues/1303

---

At the time of writing, this PR produces exactly the following diff to the output of `configlet lint`, per track:

#### go
```diff
+The Concept Exercise `savings-account` has `comments` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `elons-toys` has `pointers` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `card-tricks` has `iteration` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `chessboard` has `iteration` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `zero-zilch-nada` has `types` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+

```

#### java
```diff
+The Concept Exercise `elons-toy-car` has `conditionals` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `remote-control-competition` has `lists` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `football-match-reports` has `variables` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `football-match-reports` has `methods` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### javascript
```diff
+The Concept Exercise `elyses-looping-enchantments` has `arrow-functions` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `translation-service` has `array-transformations` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `translation-service` has `recursion` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `factory-sensors` has `classes` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### python
```diff
+The Concept Exercise `meltdown-mitigation` has `booleans` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### rust
```diff
+The Concept Exercise `magazine-cutout` has `hashmaps` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `magazine-cutout` has `intro-types` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `health-statistics` has `string-use` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `short-fibonacci` has `numbers` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `rpn-calculator` has `numbers` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `rpn-calculator` has `match-basics` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `rpn-calculator` has `mutability` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `rpn-calculator` has `loops` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `csv-builder` has `string-slices` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `csv-builder` has `string` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### swift
```diff
+The Concept Exercise `lasagna-master` has `conditionals` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `magician-in-training` has `conditionals` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `pizza-slices` has `conditionals` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+The Concept Exercise `santas-helper` has `strings` in its `prerequisites`, which is not in the `concepts` array of any other user-facing Concept Exercise:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```