### PR TITLE
lint(track_config): further check exercise concepts

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -228,7 +228,11 @@ proc hasValidPrerequisites(s: string; path: Path): bool =
   for conceptExercise in trackConfig.exercises.`concept`:
     if conceptExercise.status in [sBeta, sActive]:
       for conceptTaught in conceptExercise.concepts:
-        conceptsTaught.incl conceptTaught
+        if conceptsTaught.containsOrIncl(conceptTaught):
+          let msg = &"The Concept Exercise {q conceptExercise.slug} has " &
+                    &"{q conceptTaught} in its `concepts`, but that concept " &
+                     "appears in the `concepts` of another Concept Exercise"
+          result.setFalseAndPrint(msg, path)
 
   # Require that every prerequisite is taught by different Concept Exercise
   for conceptExercise in trackConfig.exercises.`concept`:

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -233,8 +233,7 @@ func getConceptSlugs(trackConfig: TrackConfig): HashSet[string] =
   for con in trackConfig.concepts:
     result.incl con.slug
 
-proc hasValidPrerequisites(s: string; path: Path): bool =
-  # TODO: Add the missing checks to this proc.
+proc satisfiesSecondPass(s: string; path: Path): bool =
   let trackConfig = fromJson(s, TrackConfig)
   result = true
 
@@ -305,4 +304,4 @@ proc isTrackConfigValid*(trackDir: Path): bool =
 
   if result:
     let trackConfigContents = readFile(trackConfigPath)
-    result = hasValidPrerequisites(trackConfigContents, trackConfigPath)
+    result = satisfiesSecondPass(trackConfigContents, trackConfigPath)

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -250,6 +250,11 @@ proc hasValidPrerequisites(s: string; path: Path): bool =
                     &"{q conceptTaught} in its `concepts`, but that concept " &
                      "appears in the `concepts` of another Concept Exercise"
           result.setFalseAndPrint(msg, path)
+        if conceptTaught notin conceptSlugs:
+          let msg = &"The Concept Exercise {q conceptExercise.slug} has " &
+                    &"{q conceptTaught} in its `concepts`, which is not a " &
+                     "`slug` in the top-level `concepts` array"
+          result.setFalseAndPrint(msg, path)
 
   # Require that every prerequisite is taught by different Concept Exercise
   for conceptExercise in trackConfig.exercises.`concept`:

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -240,11 +240,12 @@ proc hasValidPrerequisites(s: string; path: Path): bool =
 
   let conceptSlugs = getConceptSlugs(trackConfig)
 
-  # Find the concepts that are taught by a user-facing Concept Exercise
+  # Check the `concepts` array of each user-facing Concept Exercise
   var conceptsTaught = initHashSet[string]()
   for conceptExercise in trackConfig.exercises.`concept`:
     if conceptExercise.status in [sBeta, sActive]:
       for conceptTaught in conceptExercise.concepts:
+        # Build a set of every concept taught by a user-facing Concept Exercise
         if conceptsTaught.containsOrIncl(conceptTaught):
           let msg = &"The Concept Exercise {q conceptExercise.slug} has " &
                     &"{q conceptTaught} in its `concepts`, but that concept " &
@@ -256,7 +257,7 @@ proc hasValidPrerequisites(s: string; path: Path): bool =
                      "`slug` in the top-level `concepts` array"
           result.setFalseAndPrint(msg, path)
 
-  # Require that every prerequisite is taught by different Concept Exercise
+  # Check the `prerequisites` array of each user-facing Concept Exercise
   for conceptExercise in trackConfig.exercises.`concept`:
     if conceptExercise.status in [sBeta, sActive]:
       for prereq in conceptExercise.prerequisites:


### PR DESCRIPTION
With this commit, `configlet lint` now checks that a track-level
`config.json` file follows the below rules:

- The `exercises.concept[].concepts` values must not be in any other
  concept exercise's `concepts` property
- The `exercises.concept[].concepts` values must match the
  `concepts.slug` property of one of the concepts
- The `exercises.concept[].prerequisites` values must match the
  `concepts.slug` property of one of the concepts

These rules currently apply to user-facing Concept Exercises only, which
are those with `status` of `active` or `beta`.

Refs: #386

---

Ping @iHiD - would you like another fast release for this one? Please sanity-check the below diff.

At the time of writing (`2021-09-05T18:14:00Z`), this PR produces the below diff to the output of `configlet lint`, per track:

#### go
https://github.com/exercism/go/blob/a167c7853aed/config.json
```diff
+The Concept Exercise `chessboard` has `range-iteration` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `elons-toys` has `pointers` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `zero-zilch-nada` has `types` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+

```

#### java
https://github.com/exercism/java/blob/30ff7755c73e/config.json
```diff
+The Concept Exercise `bird-watcher` has `foreach-loops` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `bird-watcher` has `for-loops` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `football-match-reports` has `switch-statement` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `football-match-reports` has `variables` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `football-match-reports` has `methods` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+

```

#### rust
https://github.com/exercism/rust/blob/60147eb56efd/config.json
```diff
+The Concept Exercise `low-power-embedded-game` has `tuples` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `short-fibonacci` has `vec-macro` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `rpn-calculator` has `vec-stack` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `csv-builder` has `string-vs-str` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `magazine-cutout` has `hashmaps` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `magazine-cutout` has `intro-types` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `health-statistics` has `string-use` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `short-fibonacci` has `numbers` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `rpn-calculator` has `numbers` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `rpn-calculator` has `match-basics` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `rpn-calculator` has `mutability` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `rpn-calculator` has `loops` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `csv-builder` has `string` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+

```

#### swift
https://github.com/exercism/swift/blob/e476a4a070dd/config.json
```diff
+The Concept Exercise `bomb-defuser` has `shorthand-arguments` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `bomb-defuser` has `closures` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `bomb-defuser` has `trailing-closures` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `bomb-defuser` has `capturing` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `high-score-board` has `dictionaries` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `master-mixologist` has `while-loops` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `master-mixologist` has `control-transfer` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `master-mixologist` has `repeat-while` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `master-mixologist` has `loops` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `master-mixologist` has `for-loops` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `secret-agent` has `escaping-functions` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `vehicle-purchase` has `ternary-operator` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `windowing-system` has `value-and-reference-types` in its `concepts`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+
+The Concept Exercise `bomb-defuser` has `loops` in its `prerequisites`, which is not a `slug` in the top-level `concepts` array:
+./config.json
+

```