### PR TITLE
lint(track_config): fix handling of missing `status`

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -199,6 +199,7 @@ proc hasValidKeyFeatures(data: JsonNode; path: Path): bool =
 
 type
   Status = enum
+    sMissing = "missing"
     sWip = "wip"
     sBeta = "beta"
     sActive = "active"
@@ -237,7 +238,7 @@ iterator visibleConceptExercises(trackConfig: TrackConfig): ConceptExercise =
   ## Yields every concept exercise in `trackConfig` that has a `status` of
   ## "beta" or "active".
   for conceptExercise in trackConfig.exercises.`concept`:
-    if conceptExercise.status in [sBeta, sActive]:
+    if conceptExercise.status in [sMissing, sBeta, sActive]:
       yield conceptExercise
 
 proc checkExerciseConcepts(trackConfig: TrackConfig;


### PR DESCRIPTION
A Concept Exercise in the track-level `config.json` file may have a
`status` property. If that property is missing, the implied value is
`active`, and so the Concept Exercise appears on the website.

With this commit, `configlet lint` no longer skips some checks of a
Concept Exercise when its `status` property is missing.