### PR TITLE
lint(track_config): add more checks of `prerequisites`, `concepts`, `practices`

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -310,19 +310,28 @@ proc checkExercisePCP(exercise: ConceptExercise | PracticeExercise;
                       b: var bool; path: Path) =
   ## Checks the `prerequisites` array and either the `concepts` or `practices`
   ## array of `exercise`, and sets `b` to `false` if a check fails.
+
+  let conceptsOrPractices =
+    when exercise is ConceptExercise:
+      exercise.concepts
+    else:
+      exercise.practices
+
+  const conceptsOrPracticesStr =
+    when exercise is ConceptExercise:
+      "concepts"
+    else:
+      "practices"
+
   let status = exercise.status
 
   case status
   of sMissing, sBeta, sActive:
     # Check either `concepts` or `practices`
-    when exercise is ConceptExercise:
-      if exercise.concepts.len == 0:
-        let msg = statusMsg(exercise, "an empty array of `concepts`")
-        b.setFalseAndPrint(msg, path)
-    else:
-      if exercise.practices.len == 0:
-        let msg = statusMsg(exercise, "an empty array of `practices`")
-        b.setFalseAndPrint(msg, path)
+    if conceptsOrPractices.len == 0:
+      let msg = statusMsg(exercise, &"an empty array of `{conceptsOrPracticesStr}`")
+      b.setFalseAndPrint(msg, path)
+
     # Check `prerequisites`
     when exercise is PracticeExercise:
       if exercise.prerequisites.len == 0:
@@ -331,14 +340,9 @@ proc checkExercisePCP(exercise: ConceptExercise | PracticeExercise;
 
   of sDeprecated:
     # Check either `concepts` or `practices`
-    when exercise is ConceptExercise:
-      if exercise.concepts.len > 0:
-        let msg = statusMsg(exercise, "a non-empty array of `concepts`")
-        b.setFalseAndPrint(msg, path)
-    else:
-      if exercise.practices.len > 0:
-        let msg = statusMsg(exercise, "a non-empty array of `practices`")
-        b.setFalseAndPrint(msg, path)
+    if conceptsOrPractices.len > 0:
+      let msg = statusMsg(exercise, &"a non-empty array of `{conceptsOrPracticesStr}`")
+      b.setFalseAndPrint(msg, path)
     # Check `prerequisites`
     if exercise.prerequisites.len > 0:
       let msg = statusMsg(exercise, "a non-empty array of `prerequisites`")

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -295,11 +295,11 @@ proc checkExercisePrerequisites(trackConfig: TrackConfig;
                    "`slug` in the top-level `concepts` array"
         b.setFalseAndPrint(msg, path)
 
-proc checkExerciseConceptsAndPrereqsLen(trackConfig: TrackConfig; b: var bool;
-                                        path: Path) =
-  ## Checks the `concepts` and `prerequisites` array of each Concept Exercise in
-  ## `trackConfig`, and sets `b` to `false` if a check fails.
-  for conceptExercise in trackConfig.exercises.`concept`:
+proc checkConceptExercises(conceptExercises: seq[ConceptExercise];
+                           b: var bool; path: Path) =
+  ## Checks the `concepts` and `prerequisites` array of each exercise in
+  ## `conceptExercises`, and sets `b` to `false` if a check fails.
+  for conceptExercise in conceptExercises:
     let status = conceptExercise.status
     case status
     of sMissing, sBeta, sActive:
@@ -319,11 +319,11 @@ proc checkExerciseConceptsAndPrereqsLen(trackConfig: TrackConfig; b: var bool;
     of sWip:
       discard
 
-proc checkExercisePracticesAndPrereqsLen(trackConfig: TrackConfig; b: var bool;
-                                         path: Path) =
-  ## Checks the `practices` and `prerequisites` array of each Practice Exercise in
-  ## `trackConfig`, and sets `b` to `false` if a check fails.
-  for practiceExercise in trackConfig.exercises.practice:
+proc checkPracticeExercises(practiceExercises: seq[PracticeExercise];
+                            b: var bool; path: Path) =
+  ## Checks the `practices` and `prerequisites` array of each exercise in
+  ## `practiceExercises`, and sets `b` to `false` if a check fails.
+  for practiceExercise in practiceExercises:
     let status = practiceExercise.status
     case status
     of sMissing, sBeta, sActive:
@@ -356,8 +356,8 @@ proc satisfiesSecondPass(s: string; path: Path): bool =
                                              path)
   checkExercisePrerequisites(trackConfig, conceptSlugs, conceptsTaught, result,
                              path)
-  checkExerciseConceptsAndPrereqsLen(trackConfig, result, path)
-  checkExercisePracticesAndPrereqsLen(trackConfig, result, path)
+  checkConceptExercises(trackConfig.exercises.`concept`, result, path)
+  checkPracticeExercises(trackConfig.exercises.practice, result, path)
 
 proc isValidTrackConfig(data: JsonNode; path: Path): bool =
   if isObject(data, jsonRoot, path):

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -303,8 +303,17 @@ proc statusMsg(exercise: ConceptExercise | PracticeExercise;
       "Concept Exercise"
     else:
       "Practice Exercise"
-  result = &"The {exerciseKind} {q exercise.slug} has a `status` " &
-           &"of {q $exercise.status}, but has {problem}"
+  let statusStr =
+    case exercise.status
+    of sMissing:
+      "is user-facing (because a missing `status` key implies `active`)"
+    of sDeprecated:
+      "has a `status` of `deprecated`"
+    else:
+      &"is user-facing (because its `status` key has the value {q $exercise.status})"
+
+  result = &"The {exerciseKind} {q exercise.slug} {statusStr}" &
+           &", but has {problem}"
 
 proc checkExercisePCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
                       b: var bool; path: Path) =

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -295,6 +295,17 @@ proc checkExercisePrerequisites(trackConfig: TrackConfig;
                    "`slug` in the top-level `concepts` array"
         b.setFalseAndPrint(msg, path)
 
+proc statusMsg(exercise: ConceptExercise | PracticeExercise;
+               problem: string): string =
+  ## Returns the error text for an `exercise` with the status-related `problem`.
+  const exerciseKind =
+    when exercise is ConceptExercise:
+      "Concept Exercise"
+    else:
+      "Practice Exercise"
+  result = &"The {exerciseKind} {q exercise.slug} has a `status` " &
+           &"of {q $exercise.status}, but has {problem}"
+
 proc checkConceptExercises(conceptExercises: seq[ConceptExercise];
                            b: var bool; path: Path) =
   ## Checks the `concepts` and `prerequisites` array of each exercise in
@@ -304,17 +315,14 @@ proc checkConceptExercises(conceptExercises: seq[ConceptExercise];
     case status
     of sMissing, sBeta, sActive:
       if conceptExercise.concepts.len == 0:
-        let msg = &"The Concept Exercise {q conceptExercise.slug} has a `status` " &
-                  &"of {q $status}, but has an empty array of `concepts`"
+        let msg = statusMsg(conceptExercise, "an empty array of `concepts`")
         b.setFalseAndPrint(msg, path)
     of sDeprecated:
       if conceptExercise.concepts.len > 0:
-        let msg = &"The Concept Exercise {q conceptExercise.slug} has a `status` " &
-                  &"of {q $status}, but has a non-empty array of `concepts`"
+        let msg = statusMsg(conceptExercise, "a non-empty array of `concepts`")
         b.setFalseAndPrint(msg, path)
       if conceptExercise.prerequisites.len > 0:
-        let msg = &"The Concept Exercise {q conceptExercise.slug} has a `status` " &
-                  &"of {q $status}, but has a non-empty array of `prerequisites`"
+        let msg = statusMsg(conceptExercise, "a non-empty array of `prerequisites`")
         b.setFalseAndPrint(msg, path)
     of sWip:
       discard
@@ -328,21 +336,17 @@ proc checkPracticeExercises(practiceExercises: seq[PracticeExercise];
     case status
     of sMissing, sBeta, sActive:
       if practiceExercise.practices.len == 0:
-        let msg = &"The Practice Exercise {q practiceExercise.slug} has a `status` " &
-                  &"of {q $status}, but has an empty array of `practices`"
+        let msg = statusMsg(practiceExercise, "an empty array of `practices`")
         b.setFalseAndPrint(msg, path)
       if practiceExercise.prerequisites.len == 0:
-        let msg = &"The Practice Exercise {q practiceExercise.slug} has a `status` " &
-                  &"of {q $status}, but has an empty array of `prerequisites`"
+        let msg = statusMsg(practiceExercise, "an empty array of `prerequisites`")
         b.setFalseAndPrint(msg, path)
     of sDeprecated:
       if practiceExercise.practices.len > 0:
-        let msg = &"The Practice Exercise {q practiceExercise.slug} has a `status` " &
-                  &"of {q $status}, but has a non-empty array of `practices`"
+        let msg = statusMsg(practiceExercise, "a non-empty array of `practices`")
         b.setFalseAndPrint(msg, path)
       if practiceExercise.prerequisites.len > 0:
-        let msg = &"The Practice Exercise {q practiceExercise.slug} has a `status` " &
-                  &"of {q $status}, but has a non-empty array of `prerequisites`"
+        let msg = statusMsg(practiceExercise, "a non-empty array of `prerequisites`")
         b.setFalseAndPrint(msg, path)
     of sWip:
       discard

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -315,8 +315,8 @@ proc statusMsg(exercise: ConceptExercise | PracticeExercise;
   result = &"The {exerciseKind} {q exercise.slug} {statusStr}" &
            &", but has {problem}"
 
-proc checkExercisePCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
-                      b: var bool; path: Path) =
+proc checkExercisesPCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
+                       b: var bool; path: Path) =
   ## Checks the `prerequisites` array and either the `concepts` or `practices`
   ## array (hence "PCP") of every exercise in `exercises`, and sets `b` to
   ## `false` if a check fails.
@@ -385,10 +385,6 @@ proc checkExercisePCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
             "Exercise is allowed to have that"
     b.setFalseAndPrint(msg, path)
 
-proc checkExercisesPCP(exercises: Exercises; b: var bool; path: Path) =
-  for exerciseKind in exercises.fields:
-    checkExercisePCP(exerciseKind, b, path)
-
 proc satisfiesSecondPass(s: string; path: Path): bool =
   let trackConfig = fromJson(s, TrackConfig)
   result = true
@@ -398,7 +394,8 @@ proc satisfiesSecondPass(s: string; path: Path): bool =
                                              path)
   checkExercisePrerequisites(trackConfig, conceptSlugs, conceptsTaught, result,
                              path)
-  checkExercisesPCP(trackConfig.exercises, result, path)
+  checkExercisesPCP(trackConfig.exercises.`concept`, result, path)
+  checkExercisesPCP(trackConfig.exercises.practice, result, path)
 
 proc isValidTrackConfig(data: JsonNode; path: Path): bool =
   if isObject(data, jsonRoot, path):

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -326,7 +326,8 @@ proc checkExercisesPCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
     else:
       "practices"
 
-  var conceptExercisesWithEmptyPrereqs = newSeq[string]()
+  when exercises is seq[ConceptExercise]:
+    var conceptExercisesWithEmptyPrereqs = newSeq[string]()
 
   for exercise in exercises:
     let conceptsOrPractices =
@@ -376,14 +377,15 @@ proc checkExercisesPCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
     of sWip:
       discard
 
-  if conceptExercisesWithEmptyPrereqs.len >= 2:
-    var msg = "The Concept Exercises "
-    for slug in conceptExercisesWithEmptyPrereqs:
-      msg.add &"{q slug}, "
-    msg.setLen(msg.len - 2)
-    msg.add " each have an empty array of `prerequisites`, but only 1 Concept " &
-            "Exercise is allowed to have that"
-    b.setFalseAndPrint(msg, path)
+  when exercises is seq[ConceptExercise]:
+    if conceptExercisesWithEmptyPrereqs.len >= 2:
+      var msg = "The Concept Exercises "
+      for slug in conceptExercisesWithEmptyPrereqs:
+        msg.add &"{q slug}, "
+      msg.setLen(msg.len - 2)
+      msg.add " each have an empty array of `prerequisites`, but only 1 Concept " &
+              "Exercise is allowed to have that"
+      b.setFalseAndPrint(msg, path)
 
 proc satisfiesSecondPass(s: string; path: Path): bool =
   let trackConfig = fromJson(s, TrackConfig)

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -318,8 +318,8 @@ proc statusMsg(exercise: ConceptExercise | PracticeExercise;
 proc checkExercisePCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
                       b: var bool; path: Path) =
   ## Checks the `prerequisites` array and either the `concepts` or `practices`
-  ## array of every exercise in `exercises`, and sets `b` to `false` if a check
-  ## fails.
+  ## array (hence "PCP") of every exercise in `exercises`, and sets `b` to
+  ## `false` if a check fails.
   const conceptsOrPracticesStr =
     when exercises is seq[ConceptExercise]:
       "concepts"

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -340,9 +340,11 @@ proc checkExercisePCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
     case status
     of sMissing, sBeta, sActive:
       # Check either `concepts` or `practices`
-      if conceptsOrPractices.len == 0:
-        let msg = statusMsg(exercise, &"an empty array of `{conceptsOrPracticesStr}`")
-        b.setFalseAndPrint(msg, path)
+      # TODO: enable the `practices` check when more tracks have populated them.
+      when exercise is ConceptExercise:
+        if conceptsOrPractices.len == 0:
+          let msg = statusMsg(exercise, &"an empty array of `{conceptsOrPracticesStr}`")
+          b.setFalseAndPrint(msg, path)
 
       # Check `prerequisites`
       when exercise is ConceptExercise:
@@ -354,9 +356,12 @@ proc checkExercisePCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
             let msg = statusMsg(exercise, "a non-empty array of `prerequisites`")
             b.setFalseAndPrint(msg, path)
         else:
-          if exercise.prerequisites.len == 0:
-            let msg = statusMsg(exercise, "an empty array of `prerequisites`")
-            b.setFalseAndPrint(msg, path)
+          # TODO: enable the Practice Exercise `prerequisites` check when more
+          # tracks have populated them.
+          if false:
+            if exercise.prerequisites.len == 0:
+              let msg = statusMsg(exercise, "an empty array of `prerequisites`")
+              b.setFalseAndPrint(msg, path)
 
     of sDeprecated:
       # Check either `concepts` or `practices`

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -384,7 +384,7 @@ proc checkExercisesPCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
       for slug in conceptExercisesWithEmptyPrereqs:
         msg.add &"{q slug}, "
       msg.setLen(msg.len - 2)
-      msg.add " each have an empty array of `prerequisites`, but only 1 Concept " &
+      msg.add " each have an empty array of `prerequisites`, but only one Concept " &
               "Exercise is allowed to have that"
       b.setFalseAndPrint(msg, path)
 

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -334,9 +334,14 @@ proc checkExercisePCP(exercise: ConceptExercise | PracticeExercise;
 
     # Check `prerequisites`
     when exercise is PracticeExercise:
-      if exercise.prerequisites.len == 0:
-        let msg = statusMsg(exercise, "an empty array of `prerequisites`")
-        b.setFalseAndPrint(msg, path)
+      if exercise.slug == "hello-world":
+        if exercise.prerequisites.len > 0:
+          let msg = statusMsg(exercise, "a non-empty array of `prerequisites`")
+          b.setFalseAndPrint(msg, path)
+      else:
+        if exercise.prerequisites.len == 0:
+          let msg = statusMsg(exercise, "an empty array of `prerequisites`")
+          b.setFalseAndPrint(msg, path)
 
   of sDeprecated:
     # Check either `concepts` or `practices`

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -354,7 +354,8 @@ proc checkExercisesPCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
       else:
         if exercise.slug == "hello-world":
           if exercise.prerequisites.len > 0:
-            let msg = statusMsg(exercise, "a non-empty array of `prerequisites`")
+            let msg = "The Practice Exercise `hello-world` must have an " &
+                      "empty array of `prerequisites`"
             b.setFalseAndPrint(msg, path)
         else:
           # TODO: enable the Practice Exercise `prerequisites` check when more


### PR DESCRIPTION
With this commit, `configlet lint` now checks that a track-level
`config.json` file follows the below rules for Concept Exercises:

- The `exercises.concept[].concepts` value must be a non-empty array of
  strings if `exercises.concept[].status` is not equal to `deprecated`
- The `exercises.concept[].concepts` value must be an empty array if
  `exercises.concept[].status` is equal to `deprecated`
- The `exercises.concept[].prerequisites` value must be a non-empty
  array of strings if `exercises.concept[].status` is not equal to
  `deprecated`, except for exactly one exercise which is allowed to have
  an empty array as its value
- The `exercises.concept[].prerequisites` value must be an empty array
  if `exercises.concept[].status` is equal to `deprecated`

and these rules for Practice Exercises:

- The `exercises.practice[].practices` value must be an empty array if
  `exercises.practice[].status` is equal to `deprecated`
- The `exercises.practice[].prerequisites` value must be an empty array
  if `exercises.practice[].status` is equal to `deprecated`
- The `exercises.practice[].prerequisites` value must be an empty array
  if `exercises.practice[].slug` is equal to `hello-world`

This commit also adds support for the below checks of
Practice Exercises. However, because there would currently be too many
linting errors, this commit leaves these checks disabled for now:

- The `exercises.practice[].practices` value must be a non-empty array
  of strings if `exercises.practice[].status` is not equal to
  `deprecated`
- The `exercises.practice[].prerequisites` value must be a non-empty
  array of strings if `exercises.practice[].status` is not equal to
  `deprecated`

Closes: #386

---

~This PR currently includes the commit from #414. We will merge that one PR first, then rebase this PR on top.~ Edit: done.

At the time of writing (`2021-09-06T18:27:00Z`), this PR causes the below diff to the output of `configlet lint`, per track:

#### elixir
https://github.com/exercism/elixir/blob/d5f3834445ca/config.json#L1153-L1338
```diff
+The Practice Exercise `binary` has a `status` of `deprecated`, but has a non-empty array of `practices`:
+./config.json
+
+The Practice Exercise `binary` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `hexadecimal` has a `status` of `deprecated`, but has a non-empty array of `practices`:
+./config.json
+
+The Practice Exercise `hexadecimal` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### python
https://github.com/exercism/python/blob/6afbd74d3bce/config.json#L1971-L2190
```diff
+The Practice Exercise `accumulate` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `binary` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `error-handling` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `hexadecimal` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `nucleotide-count` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `octal` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `parallel-letter-frequency` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `pascals-triangle` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `point-mutations` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `proverb` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `strain` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+The Practice Exercise `trinary` has a `status` of `deprecated`, but has a non-empty array of `prerequisites`:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### zig
https://github.com/exercism/zig/blob/3d166c4e2a7a/config.json#L21-L36
```diff
+The Practice Exercise `hello-world` is user-facing (because a missing `status` key implies `active`), but has a non-empty array of `prerequisites`:
+./config.json
+

```