### PR TITLE
lint(track_config): add more checks of exercise slugs

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -389,22 +389,22 @@ proc checkExercisesPCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
               "Exercise is allowed to have that"
       b.setFalseAndPrint(msg, path)
 
-proc checkExerciseSlugsAndForegone(trackConfig: TrackConfig; b: var bool;
+proc checkExerciseSlugsAndForegone(exercises: Exercises; b: var bool;
                                    path: Path) =
   ## Sets `b` to `false` if the below conditions are not satisfied:
-  ## - Each slug of a Concept Exercise or a Practice Exercise in `trackConfig`
+  ## - Each slug of a Concept Exercise or a Practice Exercise in `exercises`
   ##   only exists once on the track.
   ## - There is exactly one Practice Exercise with the slug `hello-world`.
   ## - The `foregone` array does not contain a slug of an implemented exercise.
-  var conceptExerciseSlugs = initHashSet[string](trackConfig.exercises.`concept`.len)
-  for conceptExercise in trackConfig.exercises.`concept`:
+  var conceptExerciseSlugs = initHashSet[string](exercises.`concept`.len)
+  for conceptExercise in exercises.`concept`:
     let slug = conceptExercise.slug
     if conceptExerciseSlugs.containsOrIncl slug:
       let msg = &"There is more than one Concept Exercise with the slug {q slug}"
       b.setFalseAndPrint(msg, path)
 
-  var practiceExerciseSlugs = initHashSet[string](trackConfig.exercises.practice.len)
-  for practiceExercise in trackConfig.exercises.practice:
+  var practiceExerciseSlugs = initHashSet[string](exercises.practice.len)
+  for practiceExercise in exercises.practice:
     let slug = practiceExercise.slug
     if practiceExerciseSlugs.containsOrIncl slug:
       let msg = &"There is more than one Practice Exercise with the slug {q slug}"
@@ -420,7 +420,7 @@ proc checkExerciseSlugsAndForegone(trackConfig: TrackConfig; b: var bool;
     let msg = &"There must be a Practice Exercise with the slug `hello-world`"
     b.setFalseAndPrint(msg, path)
 
-  for slug in trackConfig.exercises.foregone:
+  for slug in exercises.foregone:
     if slug in conceptExerciseSlugs or slug in practiceExerciseSlugs:
       let msg = &"The `exercises.foregone` array contains the slug {q slug}, " &
                  "but there is an implemented exercise with that slug"
@@ -437,7 +437,7 @@ proc satisfiesSecondPass(s: string; path: Path): bool =
                              path)
   checkExercisesPCP(trackConfig.exercises.`concept`, result, path)
   checkExercisesPCP(trackConfig.exercises.practice, result, path)
-  checkExerciseSlugsAndForegone(trackConfig, result, path)
+  checkExerciseSlugsAndForegone(trackConfig.exercises, result, path)
 
 proc isValidTrackConfig(data: JsonNode; path: Path): bool =
   if isObject(data, jsonRoot, path):

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -396,14 +396,14 @@ proc checkExerciseSlugsAndForegone(trackConfig: TrackConfig; b: var bool;
   ##   only exists once on the track.
   ## - There is exactly one Practice Exercise with the slug `hello-world`.
   ## - The `foregone` array does not contain a slug of an implemented exercise.
-  var conceptExerciseSlugs = initHashSet[string](200)
+  var conceptExerciseSlugs = initHashSet[string](trackConfig.exercises.`concept`.len)
   for conceptExercise in trackConfig.exercises.`concept`:
     let slug = conceptExercise.slug
     if conceptExerciseSlugs.containsOrIncl slug:
       let msg = &"There is more than one Concept Exercise with the slug {q slug}"
       b.setFalseAndPrint(msg, path)
 
-  var practiceExerciseSlugs = initHashSet[string](200)
+  var practiceExerciseSlugs = initHashSet[string](trackConfig.exercises.practice.len)
   for practiceExercise in trackConfig.exercises.practice:
     let slug = practiceExercise.slug
     if practiceExerciseSlugs.containsOrIncl slug:


### PR DESCRIPTION
With this PR, `configlet lint` now checks that a track-level
`config.json` file follows the below rules:

- The `exercises.concept[].slug` value must be unique in
  `exercises.concept[].slug`  and may not exist in
  `exercises.practice[].slug`
- The `exercises.practice[].slug` value must be unique in
  `exercises.practice[].slug` and may not exist in
  `exercises.concept[].slug`
- There must be exactly one `exercises.practice[].slug` value that is
  the string `hello-world`
- The `exercises.foregone` values must not match any of the concept or
  practice exercise slugs

---

At the time of writing (`2021-09-07T13:37:00Z`), this PR produces the following diff to the output of `configlet lint`, per track:

#### julia
https://github.com/exercism/julia/blob/0a134640aeed/config.json#L102-L296
```diff
+The slug `leap` is used for both a Concept Exercise and a Practice Exercise, but must only appear once on the track:
+./config.json
+

```

Looks like Sascha has a PR for it: https://github.com/exercism/julia/pull/365