### PR TITLE
.gitignore, config, nimble: use lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,7 @@
 # Ignore temporary repos
 tests/.test_elixir_track_repo/
 tests/.test_nim_track_repo/
+
+# Ignore user-specific Nimble files
 nimble.develop
 nimble.paths

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 # Ignore temporary repos
 tests/.test_elixir_track_repo/
 tests/.test_nim_track_repo/
+nimble.develop
+nimble.paths

--- a/config.nims
+++ b/config.nims
@@ -28,8 +28,9 @@ if defined(release):
     elif defined(clang):
       switch("clang.exe", "musl-clang")
       switch("clang.linkerexe", "musl-clang")
-# begin Nimble config (version 2)
+
+# Tell Nim the paths to Nimble packages. We need this because we ran `nimble lock`.
+# The below lines are added by `nimble setup`.
 --noNimblePath
 when withDir(thisDir(), system.fileExists("nimble.paths")):
   include "nimble.paths"
-# end Nimble config

--- a/config.nims
+++ b/config.nims
@@ -28,3 +28,8 @@ if defined(release):
     elif defined(clang):
       switch("clang.exe", "musl-clang")
       switch("clang.linkerexe", "musl-clang")
+# begin Nimble config (version 2)
+--noNimblePath
+when withDir(thisDir(), system.fileExists("nimble.paths")):
+  include "nimble.paths"
+# end Nimble config

--- a/config.nims
+++ b/config.nims
@@ -31,6 +31,8 @@ if defined(release):
 
 # Tell Nim the paths to Nimble packages. We need this because we ran `nimble lock`.
 # The below lines are added by `nimble setup`.
+# begin Nimble config (version 2)
 --noNimblePath
 when withDir(thisDir(), system.fileExists("nimble.paths")):
   include "nimble.paths"
+# end Nimble config

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -17,9 +17,9 @@ bin           = @["configlet"]
 
 # Dependencies
 requires "nim >= 2.0.0"
-requires "jsony#ea811bec7fa50f5abd3088ba94cda74285e93f18"       # 1.1.5  (2023-02-09)
-requires "parsetoml#6e5e16179fa2db60f2f37d8b1af4128aaa9c8aaf"   # 0.7.1  (2023-08-06)
-requires "supersnappy#e4df8cb5468dd96fc5a4764028e20c8a3942f16a" # 2.1.3  (2022-06-12)
+requires "jsony"
+requires "parsetoml"
+requires "supersnappy"
 
 task test, "Runs the test suite":
   exec "nim r ./tests/all_tests.nim"

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -22,4 +22,6 @@ requires "parsetoml"
 requires "supersnappy"
 
 task test, "Runs the test suite":
+  if not fileExists("nimble.paths"):
+    exec "nimble setup"
   exec "nim r ./tests/all_tests.nim"

--- a/nimble.lock
+++ b/nimble.lock
@@ -1,0 +1,36 @@
+{
+  "version": 2,
+  "packages": {
+    "supersnappy": {
+      "version": "2.1.3",
+      "vcsRevision": "e4df8cb5468dd96fc5a4764028e20c8a3942f16a",
+      "url": "https://github.com/guzba/supersnappy",
+      "downloadMethod": "git",
+      "dependencies": [],
+      "checksums": {
+        "sha1": "36a05ee6befe3764ed8e2a6fb5d0882c2fd090f8"
+      }
+    },
+    "jsony": {
+      "version": "1.1.5",
+      "vcsRevision": "ea811bec7fa50f5abd3088ba94cda74285e93f18",
+      "url": "https://github.com/treeform/jsony",
+      "downloadMethod": "git",
+      "dependencies": [],
+      "checksums": {
+        "sha1": "6aeb83e7481ca8686396a568096054bc668294df"
+      }
+    },
+    "parsetoml": {
+      "version": "0.7.1",
+      "vcsRevision": "6e5e16179fa2db60f2f37d8b1af4128aaa9c8aaf",
+      "url": "https://github.com/NimParsers/parsetoml.git",
+      "downloadMethod": "git",
+      "dependencies": [],
+      "checksums": {
+        "sha1": "586fe63467a674008c4445ed1b8ac882177d7103"
+      }
+    }
+  },
+  "tasks": {}
+}


### PR DESCRIPTION
Before this commit, configlet pinned the version of each Nimble dependency by using the .nimble file. This was the best approach until recently, and was good enough for creating configlet releases, but it [wasn't robust][1] - Nimble wasn't designed to produce reproducible builds with that mechanism. For example, Nimble didn't check the hash of a package at build time to ensure that it was unmodified.

Now that we've [updated to Nim 2.0][2] and [vendored the parseopt3 dependency][3], let's use Nimble's new lock file mechanism. This should be robust.

Run `nimble lock` and `nimble setup`, and remove versions from the nimble file.

From the [docs for `nimble lock`][4]:

>The `nimble lock` command will generate or update a package lock file named `nimble.lock`. This file is used for pinning the exact versions of the dependencies of the package. The file is intended to be committed and used by other developers to ensure that exactly the same version of the dependencies is used by all developers.
>
>[...]
>
>If a lock file `nimble.lock`` exists, then on performing all Nimble commands which require searching for dependencies and downloading them in the case they are missing (like `build`, `install`, `develop`), it is read and its content is used to download the same version of the project dependencies by using the URL, download method and VCS revision written in it. The checksum of the downloaded package is compared against the one written in the lock file. In the case the two checksums are not equal then it will be printed error message and the operation will be aborted. Reverse dependencies are added for installed locked dependencies just like for any other package being locally installed.

and the [docs for `nimble setup`][5]:

>The `nimble setup` command creates a `nimble.paths` file containing file system paths to the dependencies. It also includes the paths file in the `config.nims` file (by creating it if it does not already exist) to make them available for the compiler. `nimble.paths` file is user-specific and MUST NOT be committed. The command also adds `nimble.develop` and `nimble.paths` files to the `.gitignore` file.`

Closes: #467

[1]: d6d728372477 ("build: pin versions of Nimble packages", 2021-11-25)
[2]: fa7d0bba04aa (".github, config, json, nimble: bump Nim from 1.6.12 to 2.0.0", 2023-08-08)
[3]: 7471af3add00 ("nimble, patches, cli: vendor parseopt3 dependency", 2023-08-08)
[4]: https://github.com/nim-lang/nimble/blob/412af022a441/readme.markdown#nimble-lock
[5]: https://github.com/nim-lang/nimble/blob/412af022a441/readme.markdown#nimble-setup

---

To-do:

- [x] Wait for a Nim release that adds support for the Nimble that supports lock files.
- [x] Either wait for Nim to **ship** with a Nimble that supports lock files, or manually install such a Nimble version in our CI workflows. Edit: Nim 2.0.0 should ship with a Nimble that supports lock files.
- [x] Bump package versions
- [x] Merge #723
- [x] Resolve problem with importing nimble packages when lock file present, when not using `nimble build`.
- [x] Consider if there's a better place to run `nimble setup`

Refs: d6d728372477702e70b0c5c338a0b054a1ed134e
Closes: #467