### PR TITLE
lint(track_config): tidy up second pass

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -426,8 +426,8 @@ proc checkExerciseSlugsAndForegone(exercises: Exercises; b: var bool;
                  "but there is an implemented exercise with that slug"
       b.setFalseAndPrint(msg, path)
 
-proc satisfiesSecondPass(s: string; path: Path): bool =
-  let trackConfig = fromJson(s, TrackConfig)
+proc satisfiesSecondPass(trackConfigContents: string; path: Path): bool =
+  let trackConfig = fromJson(trackConfigContents, TrackConfig)
   result = true
 
   let conceptSlugs = getConceptSlugs(trackConfig)

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -205,6 +205,8 @@ type
     sActive = "active"
     sDeprecated = "deprecated"
 
+  # We can use a `HashSet` for `concepts`, `prerequisites` and `practices`
+  # because the first pass has already checked that each has unique values.
   ConceptExercise = object
     slug: string
     # name: string
@@ -427,6 +429,15 @@ proc checkExerciseSlugsAndForegone(exercises: Exercises; b: var bool;
       b.setFalseAndPrint(msg, path)
 
 proc satisfiesSecondPass(trackConfigContents: string; path: Path): bool =
+  ## Returns `true` if `trackConfigContents` satisfies some checks.
+  ##
+  ## Each check in this second pass is generally more complex, and typically
+  ## involves determining the validity of values in one key, depending on
+  ## another key.
+  ##
+  ## To make these checks easier, this proc uses `jsony` to deserialize to a
+  ## strongly typed `TrackConfig` object. Note that `jsony` is non-strict in
+  ## several ways, so we do a first pass that verifies the key names and types.
   let trackConfig = fromJson(trackConfigContents, TrackConfig)
   result = true
 
@@ -465,6 +476,7 @@ proc isTrackConfigValid*(trackDir: Path): bool =
     if not isValidTrackConfig(j, trackConfigPath):
       result = false
 
+  # Perform the second pass only if the track passes every previous check.
   if result:
     let trackConfigContents = readFile(trackConfigPath)
     result = satisfiesSecondPass(trackConfigContents, trackConfigPath)

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -252,10 +252,10 @@ proc toLineAndCol(s: string; offset: Natural): tuple[line: int; col: int] =
     inc result.col
 
 proc tidyJsonyErrorMsg(trackConfigContents: string): string =
-  let jsonyMsg = getCurrentExceptionMsg()
   result = "JSON parsing error during the second linting pass:\nconfig.json"
-  var offset = -1
+  let jsonyMsg = getCurrentExceptionMsg()
   var jsonyMsgStart = ""
+  var offset = -1
   result.add(
     if jsonyMsg.scanf("$* At offset: $i", jsonyMsgStart, offset):
       let (line, col) = toLineAndCol(trackConfigContents, offset)

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -258,7 +258,7 @@ proc tidyJsonyErrorMsg(trackConfigContents: string): string =
   var offset = -1
   # See https://github.com/treeform/jsony/blob/33c3daa/src/jsony.nim#L25-L27
   result.add(
-    if jsonyMsg.scanf("$* At offset: $i", jsonyMsgStart, offset):
+    if jsonyMsg.scanf("$* At offset: $i$.", jsonyMsgStart, offset):
       let (line, col) = toLineAndCol(trackConfigContents, offset)
       &"({line}, {col}): {jsonyMsgStart}"
     else:

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -256,6 +256,7 @@ proc tidyJsonyErrorMsg(trackConfigContents: string): string =
   let jsonyMsg = getCurrentExceptionMsg()
   var jsonyMsgStart = ""
   var offset = -1
+  # See https://github.com/treeform/jsony/blob/33c3daa/src/jsony.nim#L25-L27
   result.add(
     if jsonyMsg.scanf("$* At offset: $i", jsonyMsgStart, offset):
       let (line, col) = toLineAndCol(trackConfigContents, offset)

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -252,7 +252,7 @@ proc toLineAndCol(s: string; offset: Natural): tuple[line: int; col: int] =
     inc result.col
 
 proc tidyJsonyErrorMsg(trackConfigContents: string): string =
-  result = "JSON parsing error during the second linting pass:\nconfig.json"
+  result = "JSON parsing error:\nconfig.json"
   let jsonyMsg = getCurrentExceptionMsg()
   var jsonyMsgStart = ""
   var offset = -1

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -254,15 +254,14 @@ proc toLineAndCol(s: string; offset: Natural): tuple[line: int; col: int] =
 proc tidyJsonyErrorMsg(trackConfigContents: string): string =
   let jsonyMsg = getCurrentExceptionMsg()
   result = "JSON parsing error during the second linting pass:\nconfig.json"
+  var offset = -1
+  var jsonyMsgStart = ""
   result.add(
-    block:
-      var offset = -1
-      var jsonyMsgStart = ""
-      if jsonyMsg.scanf("$* At offset: $i", jsonyMsgStart, offset):
-        let (line, col) = toLineAndCol(trackConfigContents, offset)
-        &"({line}, {col}): {jsonyMsgStart}"
-      else:
-        &": {jsonyMsg}"
+    if jsonyMsg.scanf("$* At offset: $i", jsonyMsgStart, offset):
+      let (line, col) = toLineAndCol(trackConfigContents, offset)
+      &"({line}, {col}): {jsonyMsgStart}"
+    else:
+      &": {jsonyMsg}"
   )
 
 proc toTrackConfig(trackConfigContents: string): TrackConfig =


### PR DESCRIPTION
This PR:
- adds some comments that try to explain the approach for the second linting pass
- tries to improve an error message that a user shouldn't encounter.

Reproducing the latter commit message below.

---

Before this commit, an error during jsony's deserialization would look
something like:

```
jsony.nim(46)            parseHook
Error: unhandled exception: Expected " but got 1 instead. At offset: 73830 [JsonError]
```

With this commit, it instead looks like:

```
  Error: JSON parsing error during the second linting pass:
  config.json(3156, 10): Expected " but got 1 instead.
```

That is, we:
- Handle the exception
- Better explain what happened
- Mention the JSON file being parsed, rather than `jsony.nim`
- Provide the line and column number, rather than the offset, where the
  parsing error occurred

However, we hope that a user shouldn't encounter these errors, which
should only occur when a value's type in the `config.json` file doesn't
match that in the `TrackConfig` object. The current approach tries to
validate the types in the first pass, and only perform the second pass
when the types are correct.

Currently `showError` also prints the help message. We'll add a better
error proc in the future (maybe in `helpers.nim`, not `cli.nim`).