### PR TITLE
lint(track_config): add checks for Practice Exercise `practices` and `prerequisites`

### DIFF
--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -45,6 +45,7 @@ proc warn*(msg: string, extra = "") =
   if colorStdout:
     stdout.styledWriteLine(fgYellow, msg)
   else:
+    stdout.write "Warning: "
     stdout.writeLine(msg)
   if extra.len > 0:
     stdout.writeLine(extra)

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -37,6 +37,16 @@ proc setFalseAndPrint*(b: var bool; description: string; path: Path) =
   stdout.writeLine(path.string)
   stdout.write "\n"
 
+proc warn*(description: string; path: Path) =
+  ## Writes a message to stdout containing `description` and `path`.
+  let descriptionPrefix = description & ":"
+  if colorStdout:
+    stdout.styledWriteLine(fgYellow, descriptionPrefix)
+  else:
+    stdout.writeLine(descriptionPrefix)
+  stdout.writeLine(path.string)
+  stdout.write "\n"
+
 proc `$`*(path: Path): string {.borrow.}
 proc `/`*(head: Path; tail: string): Path {.borrow.}
 

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -1,4 +1,4 @@
-import std/[algorithm, os, terminal]
+import std/[algorithm, os, strformat, terminal]
 import "."/cli
 
 template withDir*(dir: string; body: untyped): untyped =
@@ -37,15 +37,24 @@ proc setFalseAndPrint*(b: var bool; description: string; path: Path) =
   stdout.writeLine(path.string)
   stdout.write "\n"
 
+var printedWarning* = false
+
+proc warn*(msg: string, extra = "") =
+  ## Writes `msg` to stdout, in color when appropriate. If `extra` is provided,
+  ## it is written on its own line, without color.
+  if colorStdout:
+    stdout.styledWriteLine(fgYellow, msg)
+  else:
+    stdout.writeLine(msg)
+  if extra.len > 0:
+    stdout.writeLine(extra)
+  stdout.write "\n"
+  printedWarning = true
+
 proc warn*(description: string; path: Path) =
   ## Writes a message to stdout containing `description` and `path`.
-  let descriptionPrefix = description & ":"
-  if colorStdout:
-    stdout.styledWriteLine(fgYellow, descriptionPrefix)
-  else:
-    stdout.writeLine(descriptionPrefix)
-  stdout.writeLine(path.string)
-  stdout.write "\n"
+  let msg = &"{description}:"
+  warn(msg, path.string)
 
 proc `$`*(path: Path): string {.borrow.}
 proc `/`*(head: Path; tail: string): Path {.borrow.}

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -39,7 +39,7 @@ proc setFalseAndPrint*(b: var bool; description: string; path: Path) =
 
 var printedWarning* = false
 
-proc warn*(msg: string, extra = "") =
+proc warn*(msg: string; extra = ""; doubleFinalNewline = true) =
   ## Writes `msg` to stdout, in color when appropriate. If `extra` is provided,
   ## it is written on its own line, without color.
   if colorStdout:
@@ -49,7 +49,8 @@ proc warn*(msg: string, extra = "") =
     stdout.writeLine(msg)
   if extra.len > 0:
     stdout.writeLine(extra)
-  stdout.write "\n"
+  if doubleFinalNewline:
+    stdout.write "\n"
   printedWarning = true
 
 proc warn*(description: string; path: Path) =

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -55,6 +55,7 @@ For more information on resolving the problems, please see the documentation:
   if printedWarning:
     echo ""
     const msg = """
-      Configlet produced at least one warning - these will become errors in the future.
-      For more information, please see the documentation""".unindent()
+      Configlet produced at least one warning.
+      These warnings will become errors in a future configlet release (at the end of October 2021).
+      For more information, please see the documentation:""".unindent()
     warn(msg, url, doubleFinalNewline = false)

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -1,3 +1,4 @@
+import std/[strformat, strutils]
 import ".."/[cli, helpers]
 import "."/[concept_exercises, concepts, docs, practice_exercises,
             track_config, validators]
@@ -27,6 +28,8 @@ proc lint*(conf: Conf) =
 
   let trackDir = Path(conf.trackDir)
 
+  const url = "https://github.com/exercism/docs/blob/main/building/configlet/lint.md"
+
   if allChecksPass(trackDir):
     echo """
 Basic linting finished successfully:
@@ -43,8 +46,15 @@ Basic linting finished successfully:
 - Required track docs are present
 - Required shared exercise docs are present"""
   else:
-    echo """
+    echo &"""
 Configlet detected at least one problem.
 For more information on resolving the problems, please see the documentation:
-https://github.com/exercism/docs/blob/main/building/configlet/lint.md"""
+{url}"""
     quit(1)
+
+  if printedWarning:
+    const msg = """
+
+      Configlet produced at least one warning - these will become errors in the future.
+      For more information, please see the documentation""".unindent()
+    warn(msg, url)

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -53,8 +53,8 @@ For more information on resolving the problems, please see the documentation:
     quit(1)
 
   if printedWarning:
+    echo ""
     const msg = """
-
       Configlet produced at least one warning - these will become errors in the future.
       For more information, please see the documentation""".unindent()
-    warn(msg, url)
+    warn(msg, url, doubleFinalNewline = false)

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -309,14 +309,22 @@ proc checkExercisePractices(trackConfig: TrackConfig;
         let msg = &"The Practice Exercise {q practiceExercise.slug} has " &
                   &"{q conceptPracticed} in its `practices` array, which is " &
                    "not a `slug` in the top-level `concepts` array"
-        b.setFalseAndPrint(msg, path)
+        # TODO: Eventually make this an error, not a warning.
+        if true:
+          warn(msg, path)
+        else:
+          b.setFalseAndPrint(msg, path)
 
   for conceptPracticed, count in countConceptsPracticed.pairs:
     if count > 10:
       let msg = &"The Concept {q conceptPracticed} appears {count} times in " &
                  "the `practices` arrays of user-facing Practice Exercises, " &
                  "but can only appear at most 10 times"
-      b.setFalseAndPrint(msg, path)
+      # TODO: Eventually make this an error, not a warning.
+      if true:
+        warn(msg, path)
+      else:
+        b.setFalseAndPrint(msg, path)
 
 iterator visibleConceptExercises(trackConfig: TrackConfig): ConceptExercise =
   ## Yields every Concept Exercise in `trackConfig` that appears on the website.
@@ -382,13 +390,21 @@ proc checkPracticeExercisePrerequisites(trackConfig: TrackConfig;
           let msg = &"The Practice Exercise {q practiceExercise.slug} has " &
                     &"{q preReq} in its `prerequisites`, which is not in the " &
                      "`concepts` array of any user-facing Concept Exercise"
-          b.setFalseAndPrint(msg, path)
+          # TODO: Eventually make this an error, not a warning.
+          if true:
+            warn(msg, path)
+          else:
+            b.setFalseAndPrint(msg, path)
 
         if prereq notin conceptSlugs:
           let msg = &"The Practice Exercise {q practiceExercise.slug} has " &
                     &"{q preReq} in its `prerequisites`, which is not a " &
                      "`slug` in the top-level `concepts` array"
-          b.setFalseAndPrint(msg, path)
+          # TODO: Eventually make this an error, not a warning.
+          if true:
+            warn(msg, path)
+          else:
+            b.setFalseAndPrint(msg, path)
     of sWip, sDeprecated:
       discard
 

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -324,7 +324,7 @@ proc checkPractices(practiceExercises: seq[PracticeExercise];
 
   if practicesNotInTopLevelConcepts.len > 0:
     let msg = "The following concepts exist in the `practices` array " &
-              &"of a Practice Exercise in `{path}`, but do not exist in the " &
+              &"of a Practice Exercise in {q $path}, but do not exist in the " &
                "top-level `concepts` array"
     let slugs = joinWithNewlines(practicesNotInTopLevelConcepts)
     warn(msg, slugs)
@@ -424,14 +424,14 @@ proc checkPrerequisites(practiceExercises: seq[PracticeExercise];
 
   if prereqsNotTaught.len > 0:
     let msg = "The following concepts exist in the `prerequisites` array " &
-              &"of a Practice Exercise in `{path}`, but are not in the " &
+              &"of a Practice Exercise in {q $path}, but are not in the " &
                "`concepts` array of any user-facing Concept Exercise"
     let slugs = joinWithNewlines(prereqsNotTaught)
     warn(msg, slugs)
 
   if prereqsNotInTopLevelConcepts.len > 0:
     let msg = "The following concepts exist in the `prerequisites` array " &
-              &"of a Practice Exercise in `{path}`, but do not exist in the " &
+              &"of a Practice Exercise in {q $path}, but do not exist in the " &
                "top-level `concepts` array"
     let slugs = joinWithNewlines(prereqsNotInTopLevelConcepts)
     warn(msg, slugs)

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -295,6 +295,13 @@ func getConceptSlugs(trackConfig: TrackConfig): HashSet[string] =
   for con in trackConfig.concepts:
     result.incl con.slug
 
+func joinWithNewlines[A](s: SomeSet[A]): string =
+  result = ""
+  for item in s:
+    result.add item
+    result.add "\n"
+  result.setLen(result.len - 1)
+
 proc checkExercisePractices(trackConfig: TrackConfig;
                             conceptSlugs: HashSet[string]; b: var bool;
                             path: Path) =
@@ -319,11 +326,7 @@ proc checkExercisePractices(trackConfig: TrackConfig;
     let msg = "The following concepts exist in the `practices` array " &
               &"of a Practice Exercise in `{path}`, but do not exist in the " &
                "top-level `concepts` array"
-    var slugs = ""
-    for slug in practicesNotInTopLevelConcepts:
-      slugs.add slug
-      slugs.add "\n"
-    slugs.setLen(slugs.len - 1)
+    let slugs = joinWithNewlines(practicesNotInTopLevelConcepts)
     warn(msg, slugs)
 
   for conceptPracticed, count in countConceptsPracticed.pairs:
@@ -423,22 +426,14 @@ proc checkPracticeExercisePrerequisites(trackConfig: TrackConfig;
     let msg = "The following concepts exist in the `prerequisites` array " &
               &"of a Practice Exercise in `{path}`, but are not in the " &
                "`concepts` array of any user-facing Concept Exercise"
-    var slugs = ""
-    for slug in prereqsNotTaught:
-      slugs.add slug
-      slugs.add "\n"
-    slugs.setLen(slugs.len - 1)
+    let slugs = joinWithNewlines(prereqsNotTaught)
     warn(msg, slugs)
 
   if prereqsNotInTopLevelConcepts.len > 0:
     let msg = "The following concepts exist in the `prerequisites` array " &
               &"of a Practice Exercise in `{path}`, but do not exist in the " &
                "top-level `concepts` array"
-    var slugs = ""
-    for slug in prereqsNotInTopLevelConcepts:
-      slugs.add slug
-      slugs.add "\n"
-    slugs.setLen(slugs.len - 1)
+    let slugs = joinWithNewlines(prereqsNotInTopLevelConcepts)
     warn(msg, slugs)
 
 proc statusMsg(exercise: ConceptExercise | PracticeExercise;

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -318,8 +318,8 @@ proc checkPractices(practiceExercises: seq[PracticeExercise];
         # TODO: Eventually make this an error, not a warning.
         if false:
           let msg = &"The Practice Exercise {q practiceExercise.slug} has " &
-                    &"{q conceptPracticed} in its `practices` array, which is " &
-                     "not a `slug` in the top-level `concepts` array"
+                    &"{q conceptPracticed} in its `practices` array, which " &
+                     "is not a `slug` in the top-level `concepts` array"
           b.setFalseAndPrint(msg, path)
 
   if practicesNotInTopLevelConcepts.len > 0:
@@ -408,8 +408,8 @@ proc checkPrerequisites(practiceExercises: seq[PracticeExercise];
           # TODO: Eventually make this an error, not a warning.
           if false:
             let msg = &"The Practice Exercise {q practiceExercise.slug} has " &
-                      &"{q preReq} in its `prerequisites`, which is not in the " &
-                       "`concepts` array of any user-facing Concept Exercise"
+                      &"{q preReq} in its `prerequisites`, which is not in " &
+                       "the `concepts` array of any user-facing Concept Exercise"
             b.setFalseAndPrint(msg, path)
         if prereq notin conceptSlugs:
           prereqsNotInTopLevelConcepts.incl prereq

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -301,19 +301,30 @@ proc checkExercisePractices(trackConfig: TrackConfig;
   ## Checks the `practices` array of each user-facing Practice Exercise in
   ## `trackConfig`, and sets `b` to `false` if a check fails.
   var countConceptsPracticed = initCountTable[string]()
+  var practicesNotInTopLevelConcepts = initOrderedSet[string]()
 
   for practiceExercise in trackConfig.exercises.practice:
     for conceptPracticed in practiceExercise.practices:
       countConceptsPracticed.inc conceptPracticed
       if conceptPracticed notin conceptSlugs:
-        let msg = &"The Practice Exercise {q practiceExercise.slug} has " &
-                  &"{q conceptPracticed} in its `practices` array, which is " &
-                   "not a `slug` in the top-level `concepts` array"
+        practicesNotInTopLevelConcepts.incl conceptPracticed
         # TODO: Eventually make this an error, not a warning.
-        if true:
-          warn(msg, path)
-        else:
+        if false:
+          let msg = &"The Practice Exercise {q practiceExercise.slug} has " &
+                    &"{q conceptPracticed} in its `practices` array, which is " &
+                     "not a `slug` in the top-level `concepts` array"
           b.setFalseAndPrint(msg, path)
+
+  if practicesNotInTopLevelConcepts.len > 0:
+    let msg = "The following concepts exist in the `practices` array " &
+              &"of a Practice Exercise in `{path}`, but do not exist in the " &
+               "top-level `concepts` array"
+    var slugs = ""
+    for slug in practicesNotInTopLevelConcepts:
+      slugs.add slug
+      slugs.add "\n"
+    slugs.setLen(slugs.len - 1)
+    warn(msg, slugs)
 
   for conceptPracticed, count in countConceptsPracticed.pairs:
     if count > 10:

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -302,15 +302,15 @@ func joinWithNewlines[A](s: SomeSet[A]): string =
     result.add "\n"
   result.setLen(result.len - 1)
 
-proc checkExercisePractices(trackConfig: TrackConfig;
-                            conceptSlugs: HashSet[string]; b: var bool;
-                            path: Path) =
-  ## Checks the `practices` array of each user-facing Practice Exercise in
-  ## `trackConfig`, and sets `b` to `false` if a check fails.
+proc checkPractices(practiceExercises: seq[PracticeExercise];
+                    conceptSlugs: HashSet[string]; b: var bool;
+                    path: Path) =
+  ## Checks the `practices` of each user-facing Practice Exercise in
+  ## `practiceExercises`, and sets `b` to `false` if a check fails.
   var countConceptsPracticed = initCountTable[string]()
   var practicesNotInTopLevelConcepts = initOrderedSet[string]()
 
-  for practiceExercise in trackConfig.exercises.practice:
+  for practiceExercise in practiceExercises:
     for conceptPracticed in practiceExercise.practices:
       countConceptsPracticed.inc conceptPracticed
       if conceptPracticed notin conceptSlugs:
@@ -391,15 +391,15 @@ proc checkConceptExercisePrerequisites(trackConfig: TrackConfig;
                    "`slug` in the top-level `concepts` array"
         b.setFalseAndPrint(msg, path)
 
-proc checkPracticeExercisePrerequisites(trackConfig: TrackConfig;
-                                        conceptSlugs, conceptsTaught: HashSet[string];
-                                        b: var bool; path: Path) =
-  ## Checks the `prerequisites` array of each user-facing Practice Exercise in
-  ## `trackConfig`, and sets `b` to `false` if a check fails.
+proc checkPrerequisites(practiceExercises: seq[PracticeExercise];
+                        conceptSlugs, conceptsTaught: HashSet[string];
+                        b: var bool; path: Path) =
+  ## Checks the `prerequisites` of each user-facing Practice Exercise in
+  ## `practiceExercises`, and sets `b` to `false` if a check fails.
   var prereqsNotTaught = initOrderedSet[string]()
   var prereqsNotInTopLevelConcepts = initOrderedSet[string]()
 
-  for practiceExercise in trackConfig.exercises.practice:
+  for practiceExercise in practiceExercises:
     case practiceExercise.status
     of sMissing, sBeta, sActive:
       for prereq in practiceExercise.prerequisites:
@@ -580,13 +580,13 @@ proc satisfiesSecondPass(trackConfigContents: string; path: Path): bool =
   result = true
 
   let conceptSlugs = getConceptSlugs(trackConfig)
-  checkExercisePractices(trackConfig, conceptSlugs, result, path)
+  checkPractices(trackConfig.exercises.practice, conceptSlugs, result, path)
   let conceptsTaught = checkExerciseConcepts(trackConfig, conceptSlugs, result,
                                              path)
   checkConceptExercisePrerequisites(trackConfig, conceptSlugs, conceptsTaught,
                                     result, path)
-  checkPracticeExercisePrerequisites(trackConfig, conceptSlugs, conceptsTaught,
-                                     result, path)
+  checkPrerequisites(trackConfig.exercises.practice, conceptSlugs,
+                     conceptsTaught, result, path)
   checkExercisesPCP(trackConfig.exercises.`concept`, result, path)
   checkExercisesPCP(trackConfig.exercises.practice, result, path)
   checkExerciseSlugsAndForegone(trackConfig.exercises, result, path)


### PR DESCRIPTION
With this PR, `configlet lint` now checks that a track-level
`config.json` file follows the below rules:

- The `exercises.practice[].prerequisites` values must match any
  concept exercise's `exercises.concept[].concepts` values
- The `exercises.practice[].prerequisites` values must match the
  `concepts[].slug` property of one of the concepts
- The `exercises.practice[].practices` values must match the
 `concepts[].slug` property of one of the concepts
- The `exercises.practice[].practices` values must refer to an
  individual concept's slug at most 10 times (across all exercises)

---

At the time of writing, this PR produces [this diff](https://gist.github.com/ee7/d7b3b2c1ba0db95a299eee3fd472604e) to the output of `configlet lint`, per track.

The diff is very large - bigger than the maximum length of a GitHub PR. What do we want to do?
