### PR TITLE
lint(track_config): check exercise directories are slugs

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -654,8 +654,8 @@ proc checkExerciseDirsAreInTrackConfig(trackDir: Path; data: JsonNode;
           if dirSlug notin exerciseSlugs:
             let msg = &"{q $exercisesDir} contains a directory named {q dirSlug}, " &
                       &"which is not a `slug` in the array of {exerciseKind} " &
-                       "exercises. Please add an entry for this exercise. If " &
-                       "the exercise is not ready to be shown on the " &
+                       "exercises. Please add the exercise to that array. " &
+                       "If the exercise is not ready to be shown on the " &
                        "website, please set its `status` value to \"wip\""
             b.setFalseAndPrint(msg, path)
 

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -623,20 +623,22 @@ proc satisfiesSecondPass(trackConfigContents: string; path: Path): bool =
 
 proc getExerciseSlugs(data: JsonNode; k: string): HashSet[string] =
   result = initHashSet[string]()
-  if data.kind == JObject:
-    if data.hasKey("exercises"):
-      let exercises = data["exercises"]
-      if exercises.kind == JObject:
-        if exercises.hasKey(k):
-          if exercises[k].kind == JArray:
-            for exercise in exercises[k]:
-              if exercise.kind == JObject:
-                if exercise.hasKey("slug"):
-                  let slug = exercise["slug"]
-                  if slug.kind == JString:
-                    let slugStr = slug.getStr()
-                    if slugStr.len > 0:
-                      result.incl slugStr
+  if data.kind != JObject or "exercises" notin data:
+    return
+
+  let exercises = data["exercises"]
+
+  if exercises.kind != JObject or k notin exercises or exercises[k].kind != JArray:
+    return
+
+  for exercise in exercises[k]:
+    if exercise.kind == JObject:
+      if exercise.hasKey("slug"):
+        let slug = exercise["slug"]
+        if slug.kind == JString:
+          let slugStr = slug.getStr()
+          if slugStr.len > 0:
+            result.incl slugStr
 
 proc checkExerciseDirsAreInTrackConfig(trackDir: Path; data: JsonNode;
                                        b: var bool; path: Path) =

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -651,7 +651,10 @@ proc checkExerciseDirsAreInTrackConfig(trackDir: Path; data: JsonNode;
           let dirSlug = lastPathPart(exerciseDir.string)
           if dirSlug notin exerciseSlugs:
             let msg = &"{q $exercisesDir} contains a directory named {q dirSlug}, " &
-                      &"which is not a `slug` in the array of {exerciseKind} exercises"
+                      &"which is not a `slug` in the array of {exerciseKind} " &
+                       "exercises. Please add an entry for this exercise. If " &
+                       "the exercise is not ready to be shown on the " &
+                       "website, please set its `status` value to \"wip\""
             b.setFalseAndPrint(msg, path)
 
 proc isTrackConfigValid*(trackDir: Path): bool =


### PR DESCRIPTION
This PR currently causes the below diff to the output of `configlet lint`, per track:

#### clojure
```diff
+`./exercises/concept` contains a directory named `international-calling-connoisseur`, which is not a `slug` in the array of concept exercises:
+./config.json
+
+`./exercises/concept` contains a directory named `squeaky-clean`, which is not a `slug` in the array of concept exercises:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### go
```diff
+`./exercises/concept` contains a directory named `the-farm`, which is not a `slug` in the array of concept exercises:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### javascript
```diff
+`./exercises/concept` contains a directory named `elyses-transformative-enchantments`, which is not a `slug` in the array of concept exercises:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### php
```diff
+`./exercises/practice` contains a directory named `darts`, which is not a `slug` in the array of practice exercises:
+./config.json
+
+`./exercises/practice` contains a directory named `mask-credit-card`, which is not a `slug` in the array of practice exercises:
+./config.json
+
+`./exercises/practice` contains a directory named `ordinal-number`, which is not a `slug` in the array of practice exercises:
+./config.json
+
+`./exercises/practice` contains a directory named `scale-generator`, which is not a `slug` in the array of practice exercises:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### vbnet
```diff
+`./exercises/practice` contains a directory named `matching-brackets`, which is not a `slug` in the array of practice exercises:
+./config.json
+
+`./exercises/practice` contains a directory named `perfect-numbers`, which is not a `slug` in the array of practice exercises:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### wren
```diff
+`./exercises/practice` contains a directory named `sieve`, which is not a `slug` in the array of practice exercises:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```

#### z3
```diff
+`./exercises/practice` contains a directory named `propositional-logic`, which is not a `slug` in the array of practice exercises:
+./config.json
+
+Configlet detected at least one problem.
+For more information on resolving the problems, please see the documentation:
+https://github.com/exercism/docs/blob/main/building/configlet/lint.md

```
