### PR TITLE
lint(track_config): warn for empty `practices` and Practice Exercise prereqs

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -544,6 +544,7 @@ proc checkExercisesPCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
     var conceptExercisesWithEmptyPrereqs = newSeq[string]()
   else:
     var countPracticeExercisesWithEmptyPractices = 0
+    var countPracticeExercisesWithEmptyPrereqs = 0
 
   for exercise in exercises:
     let conceptsOrPractices =
@@ -576,12 +577,10 @@ proc checkExercisesPCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
                       "empty array of `prerequisites`"
             b.setFalseAndPrint(msg, path)
         else:
-          # TODO: enable the Practice Exercise `prerequisites` check when more
-          # tracks have populated them.
-          if false:
-            if exercise.prerequisites.len == 0:
-              let msg = statusMsg(exercise, "an empty array of `prerequisites`")
-              b.setFalseAndPrint(msg, path)
+          # TODO: Make an empty Practice Exercise `prerequisites` array an error,
+          # not a warning
+          if exercise.prerequisites.len == 0:
+            inc countPracticeExercisesWithEmptyPrereqs
 
     of sDeprecated:
       # Check either `concepts` or `practices`
@@ -609,6 +608,10 @@ proc checkExercisesPCP(exercises: seq[ConceptExercise] | seq[PracticeExercise];
     if countPracticeExercisesWithEmptyPractices > 0:
       let msg = &"{countPracticeExercisesWithEmptyPractices} user-facing " &
                  "Practice Exercises have an empty `practices` array"
+      warn(msg, path)
+    if countPracticeExercisesWithEmptyPrereqs > 0:
+      let msg = &"{countPracticeExercisesWithEmptyPrereqs} user-facing " &
+                 "Practice Exercises have an empty `prerequisites` array"
       warn(msg, path)
 
 proc checkExerciseSlugsAndForegone(exercises: Exercises; b: var bool;


### PR DESCRIPTION
With this PR, `configlet lint` now checks that a track-level
`config.json` file follows the below rules:

- The `exercises.practice[].practices` value must be a non-empty array
  of strings if `exercises.practice[].status` is not equal to
  `deprecated`
- The `exercises.practice[].prerequisites` value must be a non-empty
  array of strings if `exercises.practice[].status` is not equal to
  `deprecated`

The checks are currently implemented as a warning. That is, a violation
does not by itself cause configlet to exit with a non-zero exit code.

---

@ErikSchierboom How should we approach this? Populating the values in these arrays is a lot of work, and many tracks don't even have concepts to populate them with. Should we maybe enable it as a warning only for tracks that set `status.concept_exercises` to `true`?

Currently this PR just prints the count, rather than each slug. I did this to reduce the verbosity, and because a maintainer probably fixes this by searching for "practices", not for each slug. But maybe printing the slugs makes more sense if we somehow warn only for tracks that have a small number of empty `practices` and Practice Exercise `prerequisites`.

One issue is that we might want a different timeline for these warnings than that shown in the current warning message:
> Configlet produced at least one warning.
> These warnings will become errors in a future configlet release (at the end of October 2021).

---

This PR currently produces the below diff to the output of `configlet lint`, per track:

#### babashka
```diff
+Warning: 76 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 75 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### bash
```diff
+Warning: 89 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 88 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### c
```diff
+Warning: 71 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 70 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### cfml
```diff
+Warning: 28 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 27 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### clojure
```diff
+Warning: 30 user-facing Practice Exercises have an empty `practices` array:
+./config.json
```

#### clojurescript
```diff
+Warning: 26 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 25 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### coffeescript
```diff
+Warning: 21 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 20 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### common-lisp
```diff
+Warning: 1 user-facing Practice Exercises have an empty `practices` array:
+./config.json
```

#### cpp
```diff
+Warning: 55 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 54 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### crystal
```diff
+Warning: 50 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 49 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### csharp
```diff
+Warning: 1 user-facing Practice Exercises have an empty `practices` array:
+./config.json
```

#### d
```diff
+Warning: 34 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 33 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### dart
```diff
+Warning: 37 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 36 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### delphi
```diff
+Warning: 76 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 75 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### elixir
```diff
+Warning: 5 user-facing Practice Exercises have an empty `practices` array:
+./config.json
```

#### elm
```diff
+Warning: 46 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 45 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### emacs-lisp
```diff
+Warning: 28 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 27 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### erlang
```diff
+Warning: 77 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 76 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### fortran
```diff
+Warning: 21 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 20 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### fsharp
```diff
+Warning: 14 user-facing Practice Exercises have an empty `practices` array:
+./config.json
```

#### gleam
```diff
+Warning: 5 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 4 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### go
```diff
+Warning: 109 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 108 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### groovy
```diff
+Warning: 55 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 54 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### haskell
```diff
+Warning: 96 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 95 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### java
```diff
+Warning: 114 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 113 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### javascript
```diff
+Warning: 107 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 83 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### julia
```diff
+Warning: 50 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 49 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### kotlin
```diff
+Warning: 84 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 83 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### lfe
```diff
+Warning: 31 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 30 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### lua
```diff
+Warning: 82 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 81 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### mips
```diff
+Warning: 15 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 14 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### nim
```diff
+Warning: 67 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 66 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### objective-c
```diff
+Warning: 51 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 50 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### ocaml
```diff
+Warning: 44 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 43 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### perl5
```diff
+Warning: 62 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 61 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### pharo-smalltalk
```diff
+Warning: 42 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 41 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### php
```diff
+Warning: 75 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 74 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### plsql
```diff
+Warning: 11 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 10 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### prolog
```diff
+Warning: 19 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 18 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### purescript
```diff
+Warning: 28 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 27 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### python
```diff
+Warning: 20 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 2 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### r
```diff
+Warning: 35 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 34 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### racket
```diff
+Warning: 33 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 32 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### raku
```diff
+Warning: 30 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 29 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### reasonml
```diff
+Warning: 24 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 23 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### ruby
```diff
+Warning: 3 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 1 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### rust
```diff
+Warning: 93 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 92 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### scala
```diff
+Warning: 91 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 90 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### scheme
```diff
+Warning: 39 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 38 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### shen
```diff
+Warning: 1 user-facing Practice Exercises have an empty `practices` array:
+./config.json
```

#### sml
```diff
+Warning: 27 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 26 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### swift
```diff
+Warning: 83 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 82 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### tcl
```diff
+Warning: 120 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 119 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### typescript
```diff
+Warning: 93 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 92 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### vbnet
```diff
+Warning: 13 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 12 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### vimscript
```diff
+Warning: 20 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 19 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### wren
```diff
+Warning: 19 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 51 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### x86-64-assembly
```diff
+Warning: 16 user-facing Practice Exercises have an empty `practices` array:
+./config.json
+
+Warning: 15 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```

#### z3
```diff
+Warning: 1 user-facing Practice Exercises have an empty `prerequisites` array:
+./config.json
```