### PR TITLE
lint(track_config): fix error for missing track config

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -720,4 +720,5 @@ proc isTrackConfigValid*(trackDir: Path): bool =
     let trackConfigContents = readFile(trackConfigPath)
     result = satisfiesSecondPass(trackConfigContents, trackConfigPath)
 
-  checkExerciseDirsAreInTrackConfig(trackDir, j, result, trackConfigPath)
+  if j != nil:
+    checkExerciseDirsAreInTrackConfig(trackDir, j, result, trackConfigPath)


### PR DESCRIPTION
With the most recent configlet release (4.0.0-alpha.31), running
`configlet lint` using a directory that lacks a `config.json` file would
produce:

```
The lint command is under development.
Please re-run this command regularly to see if your track passes the latest linting rules.

Missing file:
/tmp/foo/config.json

SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```

With this commit, we get:

```
The lint command is under development.
Please re-run this command regularly to see if your track passes the latest linting rules.

Missing file:
/tmp/foo/config.json

Missing directory:
/tmp/foo/exercises/shared/.docs

Missing directory:
/tmp/foo/docs

Configlet detected at least one problem.
For more information on resolving the problems, please see the documentation:
https://github.com/exercism/docs/blob/main/building/configlet/lint.md
```

The problem was introduced by commit e732894895f8, and does not occur in
releases before `4.0.0-alpha.31`.