### PR TITLE
labels: replace repo-specific hacktoberfest label

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -15,10 +15,6 @@
   description: "Pull requests that update a dependency file"
   color: "0366d6"
 
-- name: "hacktoberfest-accepted"
-  description: ""
-  color: "ffffff"
-
 - name: "kind: bug"
   description: "User-facing incorrect behavior"
   color: "e31a1c"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -133,6 +133,11 @@
   description: "Work on Documentation"
   color: "3c2d9f"
 
+# This label can be added to accept PRs as part of Hacktoberfest
+- name: "hacktoberfest-accepted"
+  description: "Make this PR count for hacktoberfest"
+  color: "ff7518"
+
 # This Exercism-wide label is added to all automatically created pull requests that help migrate/prepare a track for Exercism v3
 - name: "v3-migration 🤖"
   description: "Preparing for Exercism v3"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -160,10 +160,6 @@
   description: "Pull requests that update a dependency file"
   color: "0366d6"
 
-- name: "hacktoberfest-accepted"
-  description: ""
-  color: "ffffff"
-
 - name: "kind: bug"
   description: "User-facing incorrect behavior"
   color: "e31a1c"


### PR DESCRIPTION
Possible alternative to https://github.com/exercism/configlet/pull/431

Is this better?