### PR TITLE
Implement the config.json files section linting.

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -27,6 +27,31 @@ proc hasValidOnlineEditor(data: JsonNode; path: Path): bool =
     ]
     result = allTrue(checks)
 
+proc hasValidFiles(data: JsonNode; path: Path): bool =
+  const f = "files"
+  if hasKey(data, f):
+    if hasObject(data, f, path, isRequired = false):
+      let checks = [
+        hasArrayOfStrings(data[f], "solution", path, context = f,
+            uniqueValues = true, isRequired = false,
+                checkIsFilesPattern = true),
+        hasArrayOfStrings(data[f], "test", path, context = f,
+            uniqueValues = true, isRequired = false,
+                checkIsFilesPattern = true),
+        hasArrayOfStrings(data[f], "example", path, context = f,
+            uniqueValues = true, isRequired = false,
+                checkIsFilesPattern = true),
+        hasArrayOfStrings(data[f], "exemplar", path, context = f,
+            uniqueValues = true, isRequired = false,
+                checkIsFilesPattern = true),
+        hasArrayOfStrings(data[f], "editor", path, context = f,
+            uniqueValues = true, isRequired = false,
+                checkIsFilesPattern = true),
+      ]
+      result = allTrue(checks)
+  else:
+    result = true
+
 proc hasValidTestRunner(data: JsonNode; path: Path): bool =
   const s = "status"
   if hasObject(data, s, path):
@@ -210,6 +235,7 @@ proc satisfiesFirstPass(data: JsonNode; path: Path): bool =
       hasInteger(data, "version", path, allowed = 3..3),
       hasValidStatus(data, path),
       hasValidOnlineEditor(data, path),
+      hasValidFiles(data, path),
       hasValidTestRunner(data, path),
       hasValidExercises(data, path),
       hasValidConcepts(data, path),

--- a/tests/test_lint.nim
+++ b/tests/test_lint.nim
@@ -1,6 +1,26 @@
 import std/unittest
 import "."/lint/validators
 
+proc testIsFilesPattern =
+  suite "isFilesPattern":
+    test "invalid files patterns":
+      check:
+        not isFilesPattern("")
+        not isFilesPattern(" ")
+        not isFilesPattern("%{unknown_slug}suffix")
+        not isFilesPattern("prefix%{unknown_slug}suffix")
+        not isFilesPattern("prefix%{unknown_slug}")
+        not isFilesPattern("%{unknown_slug}")
+
+    test "valid files patterns":
+      check:
+        isFilesPattern("somefile")
+        isFilesPattern("somefile.go")
+        isFilesPattern("%{kebab_slug}.js")
+        isFilesPattern("foo%{snake_slug}bar")
+        isFilesPattern("foobar%{camel_slug}")
+        isFilesPattern("%{pascal_slug}")
+
 proc testIsKebabCase =
   suite "isKebabCase":
     test "invalid kebab-case strings":
@@ -204,6 +224,7 @@ proc testIsUuidV4 =
 proc main =
   testIsKebabCase()
   testIsUuidV4()
+  testIsFilesPattern()
 
 main()
 {.used.}


### PR DESCRIPTION
Addresses some of #249 

Implements the following rules:

-  The "files" key is optional
-  The "files" value must be an object
-  The "files.solution" key is optional
-  The "files.solution" value must be an array
-  The "files.solution" values must be valid patterns⁴
-  The "files.solution" values must not have duplicates
-  The "files.test" key is optional
-  The "files.test" value must be an array
-  The "files.test" values must be valid patterns⁴
-  The "files.test" values must not have duplicates
-  The "files.example" key is optional
-  The "files.example" value must be an array
-  The "files.example" values must be valid patterns⁴
-  The "files.example" values must not have duplicates
-  The "files.exemplar" key is optional
-  The "files.exemplar" value must be an array
-  The "files.exemplar" values must be valid patterns⁴
-  The "files.exemplar" values must not have duplicates
-  The "files.editor" key is optional
-  The "files.editor" value must be an array
-  The "files.editor" values must be valid patterns⁴
-  The "files.editor" values must not have duplicates
-  Patterns can only be listed in either the "files.solution", "files.test", "files.example, "files.exemplar or "files.editor array (no overlap)