### PR TITLE
lint(track_config): check concept directory names are in config

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -750,7 +750,6 @@ proc checkConceptDirsAreInTrackConfig(trackDir: Path; data: JsonNode;
                      "Please add the concept to that array"
           b.setFalseAndPrint(msg, path)
 
-
 proc isTrackConfigValid*(trackDir: Path): bool =
   result = true
   let trackConfigPath = trackDir / "config.json"

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -747,7 +747,7 @@ proc checkConceptDirsAreInTrackConfig(trackDir: Path; data: JsonNode;
         if dirSlug notin conceptSlugs:
           let msg = &"{q $conceptsDir} contains a directory named {q dirSlug}, " &
                     &"which is not a `slug` in the concepts array. " &
-                     "Please add the concept to that array."
+                     "Please add the concept to that array"
           b.setFalseAndPrint(msg, path)
 
 

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -747,7 +747,7 @@ proc checkConceptDirsAreInTrackConfig(trackDir: Path; data: JsonNode;
         if dirSlug notin conceptSlugs:
           let msg = &"{q $conceptsDir} contains a directory named {q dirSlug}, " &
                     &"which is not a `slug` in the concepts array. " &
-                      "Please add the concept to that array. "
+                     "Please add the concept to that array. "
           b.setFalseAndPrint(msg, path)
 
 

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -747,7 +747,7 @@ proc checkConceptDirsAreInTrackConfig(trackDir: Path; data: JsonNode;
         if dirSlug notin conceptSlugs:
           let msg = &"{q $conceptsDir} contains a directory named {q dirSlug}, " &
                     &"which is not a `slug` in the concepts array. " &
-                     "Please add the concept to that array. "
+                     "Please add the concept to that array."
           b.setFalseAndPrint(msg, path)
 
 

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -716,6 +716,41 @@ proc checkExerciseDirsAreInTrackConfig(trackDir: Path; data: JsonNode;
                        "website, please set its `status` value to \"wip\""
             b.setFalseAndPrint(msg, path)
 
+proc getConceptSlugs(data: JsonNode): HashSet[string] =
+  result = initHashSet[string]()
+  if data.kind != JObject or "concepts" notin data:
+    return
+
+  let concepts = data["concepts"]
+  if concepts.kind != JArray:
+    return
+
+  for conceptNode in concepts:
+    if conceptNode.kind == JObject:
+      if conceptNode.hasKey("slug"):
+        let slug = conceptNode["slug"]
+        if slug.kind == JString:
+          let slugStr = slug.getStr()
+          if slugStr.len > 0:
+            result.incl slugStr
+
+proc checkConceptDirsAreInTrackConfig(trackDir: Path; data: JsonNode;
+                                      b: var bool; path: Path) =
+  ## Sets `b` to `false` if there is a concept directory that is
+  ## not a concept `slug` in `data`.
+  let conceptSlugs = getConceptSlugs(data)
+  if conceptSlugs.len > 0:
+    let conceptsDir = trackDir / "concepts"
+    if dirExists(conceptsDir):
+      for conceptDir in getSortedSubdirs(conceptsDir):
+        let dirSlug = lastPathPart(conceptDir.string)
+        if dirSlug notin conceptSlugs:
+          let msg = &"{q $conceptsDir} contains a directory named {q dirSlug}, " &
+                    &"which is not a `slug` in the concepts array. " &
+                      "Please add the concept to that array. "
+          b.setFalseAndPrint(msg, path)
+
+
 proc isTrackConfigValid*(trackDir: Path): bool =
   result = true
   let trackConfigPath = trackDir / "config.json"
@@ -731,3 +766,4 @@ proc isTrackConfigValid*(trackDir: Path): bool =
 
   if j != nil:
     checkExerciseDirsAreInTrackConfig(trackDir, j, result, trackConfigPath)
+    checkConceptDirsAreInTrackConfig(trackDir, j, result, trackConfigPath)


### PR DESCRIPTION
With this PR, `configlet lint` now produces an error if there is a subdirectory in the `concepts` directory of a track that does not have a corresponding entry in the track-level `config.json` file.

The implementation is similar to the exercise-based check.

See https://github.com/exercism/rust/pull/1363#issue-1022516101 CC @coriolinus
