### PR TITLE
build, ci: bump macOS from 10.15 to 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
             builder: ubuntu-20.04
           - target:
               os: mac
-            builder: macos-10.15
+            builder: macos-11
           - target:
               os: windows
             builder: windows-2019

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
             builder: ubuntu-20.04
           - target:
               os: mac
-            builder: macos-10.15
+            builder: macos-11
           - target:
               os: windows
             builder: windows-2019


### PR DESCRIPTION
Maybe this helps for https://github.com/exercism/configlet/issues/222

Our logs [contained](https://github.com/exercism/configlet/actions/runs/1337134731) this warning:

```
macOS-latest workflows will use macOS-11 soon.
For more details, see https://github.com/actions/virtual-environments/issues/4060
```

The upstream issue says:

>### Breaking changes
>macOS-11 is ready to be the default version for the "macos-latest" label in GitHub Actions and Azure DevOps.
>
>### Target date
>This change will be rolled out over a period of several weeks beginning on September, 15. We plan to complete the migration by November, 3.
>
>### The motivation for the changes
>GitHub Actions and Azure DevOps have supported macOS-11 in preview since October 2020, and starting from August 2021 macOS-11 is available for all customers. For almost a year we have monitored customer feedback to improve the macOS-11 image stability and now we are ready to set it as the latest.