### PR TITLE
build(config): add `-d:nimStrictDelete`

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,6 +1,7 @@
 switch("styleCheck", "hint")
 hint("Name", on)
 switch("experimental", "strictFuncs")
+switch("define", "nimStrictDelete")
 
 # Replace the stdlib JSON modules with our own stricter versions.
 patchFile("stdlib", "json", "src/patched_stdlib/json")


### PR DESCRIPTION
From [the changelog](https://github.com/nim-lang/Nim/blob/e645be4d0c6c/changelog.md) for the upcoming Nim 1.6.0 release:

    `system.delete` had a most surprising behavior when the index passed
    to it was out of bounds (it would delete the last entry then).

    Compile with `-d:nimStrictDelete` so that an index error is produced
    instead. But be aware that your code might depend on this quirky
    behavior so a review process is required on your part before you can
    use `-d:nimStrictDelete`.

    To make this review easier, use the `-d:nimAuditDelete` switch.
    It pretends that `system.delete` is deprecated so that it is
    easier to see where it was used in your code.

    `-d:nimStrictDelete` will become the default in upcoming versions.

The configlet codebase doesn't use `system.delete`, but let's add this
flag to ensure that we don't accidentally start to rely on the
"quirky behavior".

---

Confirming that we don't use `system.delete`:
```
$ git grep --heading 'delete'
src/patched_stdlib/json.nim
585:proc delete*(obj: JsonNode, key: string) =
```

If approved, I'll probably merge this before the 1.6.0 release (which is planned for October). The added flag doesn't affect Nim 1.4.x, and works for a configlet developer using the development version of the Nim compiler.

I've got a bunch of branches with `config.nims` changes - I'll start pushing them.