### PR TITLE
sync: change some `func` to `proc`

### DIFF
--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -24,7 +24,7 @@ type
     tests*: ExerciseTests
     testCases*: seq[ExerciseTestCase]
 
-func initExerciseTests(practiceExerciseTests: PracticeExerciseTests,
+proc initExerciseTests(practiceExerciseTests: PracticeExerciseTests,
                        probSpecsTestCases: seq[ProbSpecsTestCase]): ExerciseTests =
   result = ExerciseTests(
     included: initHashSet[string](),
@@ -40,14 +40,14 @@ func initExerciseTests(practiceExerciseTests: PracticeExerciseTests,
     else:
       result.missing.incl uuid
 
-func newExerciseTestCase(testCase: ProbSpecsTestCase): ExerciseTestCase =
+proc newExerciseTestCase(testCase: ProbSpecsTestCase): ExerciseTestCase =
   ExerciseTestCase(
     uuid: uuid(testCase),
     description: description(testCase),
     json: testCase,
   )
 
-func getReimplementations(testCases: seq[ProbSpecsTestCase]): Table[string, string] =
+proc getReimplementations(testCases: seq[ProbSpecsTestCase]): Table[string, string] =
   for testCase in testCases:
     if testCase.isReimplementation():
       result[testCase.uuid()] = testCase.reimplements()
@@ -56,7 +56,7 @@ func uuidToTestCase(testCases: seq[ExerciseTestCase]): Table[string, ExerciseTes
   for testCase in testCases:
     result[testCase.uuid] = testCase
 
-func initExerciseTestCases(testCases: seq[ProbSpecsTestCase]): seq[ExerciseTestCase] =
+proc initExerciseTestCases(testCases: seq[ProbSpecsTestCase]): seq[ExerciseTestCase] =
   result = newSeq[ExerciseTestCase](testCases.len)
   var hasReimplementation = false
 

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -23,16 +23,16 @@ func canonicalDataFile(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
 func slug(probSpecsExerciseDir: ProbSpecsExerciseDir): string =
   lastPathPart(probSpecsExerciseDir)
 
-func uuid*(testCase: ProbSpecsTestCase): string =
+proc uuid*(testCase: ProbSpecsTestCase): string =
   testCase["uuid"].getStr()
 
-func description*(testCase: ProbSpecsTestCase): string =
+proc description*(testCase: ProbSpecsTestCase): string =
   testCase["description"].getStr()
 
 func isReimplementation*(testCase: ProbSpecsTestCase): bool =
   testCase.hasKey("reimplements")
 
-func reimplements*(testCase: ProbSpecsTestCase): string =
+proc reimplements*(testCase: ProbSpecsTestCase): string =
   testCase["reimplements"].getStr()
 
 proc initProbSpecsTestCases(node: JsonNode, prefix = ""): seq[ProbSpecsTestCase] =


### PR DESCRIPTION
This change is required for upgrading to Nim 1.6.0.

In Nim 1.4.x and Nim 1.6.0 rc2, compiling the below code with
`--experimental:strictFuncs` produces an error saying that `` `[]` `` has
side effects.

    func getFooVal(j: JsonNode): JsonNode =
      j["foo"]

However, in Nim 1.4.x, there was no error produced when similarly
compiling the below

    type
      MyNode = distinct JsonNode

    proc `[]`(j: MyNode, name: string): MyNode {.borrow.}

    func getFooVal(j: MyNode): MyNode =
      j["foo"]

Nim 1.6.0 **does** produce an error in the latter case, so that the side
effect error is produced for using `` `[]` `` with both a `JsonNode` **and** a
`distinct JsonNode`.

This means we need to change some `func` to `proc` in our codebase,
because we use

    ProbSpecsTestCase* = distinct JsonNode

and borrow the `` `[]` `` proc.

That is, compiling the below with `--experimental:strictFuncs` did not
produce an error with Nim 1.4.8, but does produce an error with
Nim 1.6.0.

    func uuid*(testCase: ProbSpecsTestCase): string =
      testCase["uuid"].getStr()

The underlying cause is that, until recently, Nim's effect tracking did not
work correctly for borrowed procs.

The problem was fixed upstream on 2021-09-23 in this commit: 
https://github.com/nim-lang/Nim/commit/90a2b5afd836