### PR TITLE
github: set configlet release as draft initially

### DIFF
--- a/.github/bin/publish-release
+++ b/.github/bin/publish-release
@@ -2,5 +2,5 @@
 
 version="$(echo "${REF}" | cut -d'/' -f3)"
 
-gh release create "${version}"
+gh release create --draft "${version}"
 gh release upload "${version}" "${ARTIFACT_FILE}"


### PR DESCRIPTION
I think this is sufficient for now.

I haven't tested that `gh release create --draft` exits successfully if the release already exists, but a plain `gh release create` does exit successfully if the release already exists.

We **could** do something like "automatically make the release non-draft if we just uploaded the final asset successfully" - for example, by testing if the below equals the expected final number of assets (currently 3)
```
gh release view --json assets | jq -r '.assets | length'  
```

But that's less robust, and it's probably better for a human to have a final button to un-draft the release regardless. This PR also makes it less necessary for a configlet maintainer to be actively overseeing the release process, in case there's a transient error with one of the builds that causes one asset to not be uploaded.

At release-time a configlet maintainer should also edit the release notes, which is in the same place as "the un-draft button" anyway - this PR really only improves convenience for maintainers. (We could generate the release notes automatically, but involving a human in the process makes it easier to categorize the changes, and mention only the user-facing ones).

Closes: https://github.com/exercism/configlet/issues/223
Closes: https://github.com/exercism/github-actions/issues/19
Resolves: https://github.com/exercism/configlet/issues/439