### PR TITLE
patched_stdlib(parsejson): resolve `CStringConv` warnings

### DIFF
--- a/src/patched_stdlib/parsejson.nim
+++ b/src/patched_stdlib/parsejson.nim
@@ -1,5 +1,5 @@
 # This file is minimally adapted from this version in the Nim standard library:
-# https://github.com/nim-lang/Nim/blob/285539c87aa2/lib/pure/parsejson.nim
+# https://github.com/nim-lang/Nim/blob/e8657c710776/lib/pure/parsejson.nim
 # The standard library version is lenient: it silently allows line comments
 # with `//`, and long comments with `/* */`.
 # The below version is stricter: it raises a `JsonParsingError` for such
@@ -31,6 +31,9 @@
 
 import strutils, lexbase, streams, unicode
 import std/private/decode_helpers
+
+when defined(nimPreviewSlimSystem):
+  import std/assertions
 
 type
   JsonEventKind* = enum ## enumeration of all events that may occur when parsing
@@ -234,7 +237,7 @@ proc parseString(my: var JsonParser): TokKind =
           add(my.a, 'u')
         inc(pos, 2)
         var pos2 = pos
-        var r = parseEscapedUTF16(my.buf, pos)
+        var r = parseEscapedUTF16(cstring(my.buf), pos)
         if r < 0:
           my.err = errInvalidToken
           break
@@ -244,7 +247,7 @@ proc parseString(my: var JsonParser): TokKind =
             my.err = errInvalidToken
             break
           inc(pos, 2)
-          var s = parseEscapedUTF16(my.buf, pos)
+          var s = parseEscapedUTF16(cstring(my.buf), pos)
           if (s and 0xfc00) == 0xdc00 and s > 0:
             r = 0x10000 + (((r - 0xd800) shl 10) or (s - 0xdc00))
           else:


### PR DESCRIPTION

After the upgrade to Nim 1.6.0 in commit 761936b99c58, a regular
`nimble build` would produce these warnings:

> /foo/configlet/src/patched_stdlib/parsejson.nim(237, 37) Warning: implicit conversion to 'cstring' from a non-const location: my.buf; this will become a compile time error in the future [CStringConv]
>
> /foo/configlet/src/patched_stdlib/parsejson.nim(247, 39) Warning: implicit conversion to 'cstring' from a non-const location: my.buf; this will become a compile time error in the future [CStringConv]

I [authored a commit](https://github.com/nim-lang/Nim/commit/e8657c710776) in the `nim-lang/Nim` repo that resolves the
most visible CStringConv warnings, including these in parsejson, by
making the cstring conversion explicit. Let's update configlet's copy of
parsejson without waiting for a Nim version bump, so that we no longer
see these CStringConv warnings while compiling configlet.

As a reminder, we maintain our own copy of std/json and std/parsejson in
the configlet repo so that we can forbid comments and trailing commas in
JSON (see 15c84037fadc for details).

As background, the Nim manual says that an implicit conversion to
cstring will eventually [not be allowed](https://github.com/nim-lang/Nim/blob/e8657c710776/doc/manual.md#cstring-type):

> A Nim `string` is implicitly convertible to `cstring` for convenience.
>
> [...]
>
> Even though the conversion is implicit, it is not *safe*: The garbage collector
> does not consider a `cstring` to be a root and may collect the underlying
> memory. For this reason, the implicit conversion will be removed in future
> releases of the Nim compiler. Certain idioms like conversion of a `const` string
> to `cstring` are safe and will remain to be allowed.

And from Nim 1.6.0, such a conversion [triggers a warning](https://github.com/nim-lang/Nim/blob/e8657c710776/changelogs/changelog_1_6_0.md#type-system):

> A dangerous implicit conversion to `cstring` now triggers a `[CStringConv]` warning.
> This warning will become an error in future versions! Use an explicit conversion
> like `cstring(x)` in order to silence the warning.

---

To-do:

- [x] Resolve this upstream, and then I can update the hash in our `parsejson.nim` file.