### PR TITLE
build(config): use `strictEffects`

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,5 +1,6 @@
 switch("styleCheck", "hint")
 hint("Name", on)
+switch("experimental", "strictEffects")
 switch("experimental", "strictFuncs")
 switch("define", "nimStrictDelete")
 


### PR DESCRIPTION
This is one of [Araq's recommended options](https://forum.nim-lang.org/t/8404#54227) for the recent Nim 1.6.0
release.

To illustrate, recall that `func` is syntactic sugar for a 
`noSideEffect` proc, and consider the below code.

```Nim
proc doSomething(n: int) =
  echo n

func foo(n: int, bar: proc(x: int)) =
  bar(n)

foo(42, doSomething)
```

Without `strictEffects`, it compiles without error. But
with `strictEffects`, it produces:

```
/tmp/this_module.nim(4, 6) Error: 'foo' can have side effects
> /tmp/this_module.nim(5, 6) Hint: 'foo' calls routine via hidden pointer indirection
````

Thus, one use of `strictEffects` is that we can enforce that `foo` is
instead written as a regular proc like:

```Nim
proc foo(n: int, bar: proc(x: int)) =
```

or we can keep `foo` as a `func` by annotating the parameter so that
`bar` is not allowed to have side effects:

```Nim
func foo(n: int, bar: proc(x: int) {.noSideEffect.}) =
```

in which case we would see a compile-time error if we used
`doSomething` with its above implementation as `bar`.

See also: the [effects section of the Nim Manual](https://nim-lang.org/docs/manual.html#effect-system)