### PR TITLE
build(config): fix error with clang on Linux

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -10,11 +10,16 @@ patchFile("stdlib", "parsejson", "src/patched_stdlib/parsejson")
 if defined(release):
   switch("opt", "size")
   switch("passC", "-flto")
+  switch("passL", "-flto")
 
   if defined(linux) or defined(windows):
     switch("passL", "-s")
     switch("passL", "-static")
 
   if defined(linux):
-    switch("gcc.exe", "musl-gcc")
-    switch("gcc.linkerexe", "musl-gcc")
+    if defined(gcc):
+      switch("gcc.exe", "musl-gcc")
+      switch("gcc.linkerexe", "musl-gcc")
+    elif defined(clang):
+      switch("clang.exe", "musl-clang")
+      switch("clang.linkerexe", "musl-clang")


### PR DESCRIPTION
Before this commit, running

```
$ nimble build -d:release --cc:clang
```

on Linux could produce an error like

>/foo/nimcache/configlet/r/stdlib_digitsutils.nim.c.o: file not recognized: file format not recognized
>clang-12: error: linker command failed with exit code 1

The fix (at least on my machine) involves passing `-flto` to the linker. That's also required in some other situations, e.g. when using GCC 4.8 or earlier.

The GCC 4.8.5 (2015-06-23) [manual](https://gcc.gnu.org/onlinedocs/gcc-4.8.5/gcc/Optimize-Options.html) contains

> The only important thing to keep in mind is that to enable link-time optimizations the -flto flag needs to be passed to both the compile and the link commands.

but the GCC 4.9.0 (2014-04-22) [manual](https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Optimize-Options.html) contains

>The only important thing to keep in mind is that to enable link-time optimizations you need to use the GCC driver to perform the link-step. GCC then automatically performs link-time optimization if any of the objects involved were compiled with the `-flto`.