### PR TITLE
github: create only one draft release

### DIFF
--- a/.github/bin/publish-release
+++ b/.github/bin/publish-release
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 
 latest_release_tag="$(gh release view --json tagName --jq '.tagName')"
-version="$(echo "${REF}" | cut -d'/' -f3)"
+build_tag="$(echo "${REF}" | cut -d'/' -f3)"
 
-if [ "${latest_release_tag}" != "${version}" ]; then
-  gh release create --draft "${version}"
+if [ "${latest_release_tag}" != "${build_tag}" ]; then
+  gh release create --draft "${build_tag}"
 fi
-gh release upload "${version}" "${ARTIFACT_FILE}"
+gh release upload "${build_tag}" "${ARTIFACT_FILE}"


### PR DESCRIPTION
In the latest release, commit ecc22452d2d7 caused a new draft release to
be created for each asset - I had to combine these releases manually.
What we want is to create only one draft release, and for each build job
to upload assets to the same release.

We previously relied on the fact that calling

```
gh release create
```

multiple times creates only one release, but it turns out that calling

```
gh release create --draft
```

multiple times creates multiple draft releases.

With this commit, we run the latter command only if there is no release
yet for the tag.

Closes: #450

---

Note that the `--jq` syntax has an advantage over piping to `jq`. It doesn't require `jq` to be installed.

```
$ gh help formatting
Some gh commands support exporting the data as JSON as an alternative to their usual
line-based plain text output. This is suitable for passing structured data to scripts.
The JSON output is enabled with the `--json` option, followed by the list of fields
to fetch. Use the flag without a value to get the list of available fields.

The `--jq` option accepts a query in jq syntax and will print only the resulting
values that match the query. This is equivalent to piping the output to `jq -r`,
but does not require the jq utility to be installed on the system. To learn more
about the query syntax, see: https://stedolan.github.io/jq/manual/v1.6/

...
```

Although here it doesn't matter, because this script should only ever be run in the GitHub Actions environment. I plan to make that fact clearer.