### PR TITLE
github: simplify determination of build tag

### DIFF
--- a/.github/bin/publish-release
+++ b/.github/bin/publish-release
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-build_tag="$(echo "${REF}" | cut -d'/' -f3)"
+build_tag="${GITHUB_REF_NAME}"
 
 if ! gh release view "${build_tag}"; then
   gh release create --draft "${build_tag}" "${ARTIFACT_FILE}"

--- a/.github/bin/upload-checksums-file
+++ b/.github/bin/upload-checksums-file
@@ -2,7 +2,7 @@
 
 set -e
 
-build_tag="$(echo "${REF}" | cut -d'/' -f3)"
+build_tag="${GITHUB_REF_NAME}"
 
 # Download every release asset
 download_dir="releases/${build_tag}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,6 @@ jobs:
         run: ./.github/bin/publish-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REF: ${{ github.ref }}
 
   checksums:
     needs: [build]
@@ -76,4 +75,3 @@ jobs:
         run: ./.github/bin/upload-checksums-file
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REF: ${{ github.ref }}


### PR DESCRIPTION
Previously, the reader had to understand that:

- The `REF` environment variable is set in the steps of the build job
  that run the `publish-release` and `upload-checksums-file` scripts.

- The build job is triggered by pushing a tag, which means that the
  given `cut` command gets the build tag.

From the [GitHub Actions docs on the default environment variables](https://docs.github.com/en/actions/learn-github-actions/environment-variables):

> GITHUB_REF
>
> The branch or tag ref that triggered the workflow run.
> For workflows triggered by `push`, this is the branch or tag ref
> that was pushed.
> For workflows triggered by `pull_request`, this is the pull request
> merge branch.
> For workflows triggered by `release`, this is the release tag
> created.
> For other triggers, this is the branch or tag ref that triggered the
> workflow run. This is only set if a branch or tag is available for
> the event type. The ref given is fully-formed, meaning that for
> branches the format is `refs/heads/<branch_name>`, for pull requests
> it is `refs/pull/<pr_number>/merge`, and for tags it is
> `refs/tags/<tag_name>`. For example, `refs/heads/feature-branch-1`.

> GITHUB_REF_NAME
> 
> The branch or tag name that triggered the workflow run.
> For example, `feature-branch-1.`

---

Edit 2022-08-18: I have tested this by triggering the `build` workflow on my fork:

- [this run](https://github.com/ee7/exercism-configlet/actions/runs/2881588184) was triggered by `workflow_dispatch`, and created [this release](https://github.com/ee7/exercism-configlet/releases/tag/test-release-github-refactor-build-tag). 
- [this run](https://github.com/ee7/exercism-configlet/actions/runs/2881719950) was triggered by pushing a tag to my fork, and created [this release](https://github.com/ee7/exercism-configlet/releases/tag/test-build-by-tag-push).

Note that the checksum assets are named

```text
configlet_github-refactor-build-tag_checksums_sha256.txt
```

and

```text
configlet_test-build-by-tag-push_checksums_sha256.txt
```

where the middle part is the value of `build_tag`. So I believe this PR works.

---

I considered using

```shell
build_tag="$(git tag --points-at)"
```

but that would make it harder to run the `build` workflow manually on a fork via `workflow_dispatch`.

[Upstream docs for `git tag`](https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---points-atltobjectgt):

>`--points-at <object>`
>Only list tags of the given object (HEAD if not specified). Implies `--list`.