### PR TITLE
fmt: implement

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,12 +226,25 @@ The `sync` command is useful when adding a new exercise to a track. If you are a
 
 ## `configlet fmt`
 
-Every Concept Exercise and Practice Exercise on an Exercism track must have a `.meta/config.json` file.
-To ensure that each of these files is in the canonical form, you can use the `configlet fmt` command.
+An Exercism track repo has many JSON files, including:
 
-A plain `configlet fmt` makes no changes to the track, and checks the `.meta/config.json` file for every Concept Exercise and Practice Exercise.
+- The track `config.json` file.
 
-To print a list of paths for which there is not already a formatted exercise `.meta/config.json` file (exiting with a non-zero exit code if at least one exercise lacks a formatted config file):
+- For each concept, a `.meta/config.json` and `links.json` file.
+
+- For each Concept Exercise or Practice Exercise, a `.meta/config.json` file.
+
+These files are more readable if they have a consistent formatting Exercism-wide,
+and so configlet has a `fmt` command for rewriting a track's JSON files in a canonical form.
+
+The `fmt` command currently only operates on the exercise `.meta/config.json` files,
+but it is likely to operate on all the track JSON files in the future.
+
+A plain `configlet fmt` makes no changes to the track,
+and checks the formatting of the `.meta/config.json` file for every Concept Exercise and Practice Exercise.
+
+To print a list of paths for which there is not already a formatted exercise `.meta/config.json` file
+(exiting with a non-zero exit code if at least one exercise lacks a formatted config file):
 
 ```
 $ configlet fmt
@@ -256,21 +269,23 @@ For example, to non-interactively write the formatted config file for the `prime
 $ configlet fmt -uy -e prime-factors
 ```
 
-"Formatting" or "rewriting in the canonical form" means:
+When writing JSON files, `configlet fmt` will:
 
 - Write the key/value pairs in the canonical order.
 
-- Use two spaces for indentation, and use a separate line for each item in a JSON array/object.
+- Use two spaces for indentation.
 
-- Strip key/value pairs for keys that are optional and have empty values.
-  For example, `contributors: []` is removed.
+- Use a separate line for each item in a JSON array, and each key in a JSON object.
 
-- Strip `test_runner: true` for Practice Exercise config files.
+- Remove key/value pairs for keys that are optional and have empty values.
+  For example, `"source": ""` is removed.
+
+- Remove `"test_runner": true` from Practice Exercise config files.
   This is an optional key - the spec says that an omitted `test_runner` key implies the value `true`.
 
-- When there is more than one key/value pair with the same name, keep only the final one.
+- When a JSON object has more than one key/value pair with some key name, keep only the final one.
 
-The canonical order is:
+The canonical key order for an exercise `.meta/config.json` file is:
 
 ```
 - authors
@@ -294,7 +309,8 @@ The canonical order is:
 where the square brackets indicate that the enclosed key is optional.
 
 Note that `configlet fmt` only operates on exercises that exist in the track-level `config.json` file.
-Therefore if you are implementing a new exercise on a track and want to format its `.meta/config.json` file, please add the exercise to the track-level `config.json` file first.
+Therefore if you are implementing a new exercise on a track and want to format its `.meta/config.json` file,
+please add the exercise to the track-level `config.json` file first.
 If the exercise is not yet ready to be user-facing, please set its `status` value to `wip`.
 
 The exit code is 0 when every seen exercise has a formatted `.meta/config.json` file when configlet exits, and 1 otherwise.

--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ The canonical order is:
 
 where the square brackets indicate that the enclosed key is optional.
 
+Note that `configlet fmt` only operates on exercises that exist in the track-level `config.json` file.
+Therefore if you are implementing a new exercise on a track and want to format its `.meta/config.json` file, please add the exercise to the track-level `config.json` file first.
+If the exercise is not yet ready to be user-facing, please set its `status` value to `wip`.
+
+The exit code is 0 when every seen exercise has a formatted `.meta/config.json` file when configlet exits, and 1 otherwise.
+
 ## `configlet uuid`
 
 Each exercise and concept has a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier), which must only appear once across all of Exercism. It must be a valid version 4 UUID (compliant with RFC 4122) in the canonical textual representation, which means that it must match the below regular expression:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Usage:
 Commands:
   fmt, lint, sync, uuid, generate, info
 
+Options for fmt:
+  -e, --exercise <slug>        Only operate on this exercise
+  -y, --yes                    Format without prompting for confirmation
+
 Options for sync:
   -e, --exercise <slug>        Only operate on this exercise
   -p, --prob-specs-dir <dir>   Use this 'problem-specifications' directory, rather than cloning temporarily

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage:
   configlet [global-options] <command> [command-options]
 
 Commands:
-  lint, sync, uuid, generate, info
+  fmt, lint, sync, uuid, generate, info
 
 Options for sync:
   -e, --exercise <slug>        Only operate on this exercise
@@ -61,7 +61,7 @@ We describe the checking and updating of these data kinds in individual sections
 - To non-interactively update docs, filepaths, and metadata on the track, use `--update --yes`.
 - To non-interactively include every unseen test for a given exercise, use e.g. `--update --tests include --exercise prime-factors`.
 - To skip downloading the `problem-specifications` repo, add `--offline --prob-specs-dir /path/to/local/problem-specifications`
-- Note that `configlet sync` tries to maintain the key order in exercise `.meta/config.json` files when updating. To write these files in a canonical form without syncing, please use the upcoming `configlet fmt` command. However, `configlet sync` _does_ add (possibly empty) required keys (`authors`, `files`, `blurb`) when they are missing. This is less "sync-like", but more ergonomic: when implementing a new exercise, you can use `sync` to create a starter `.meta/config.json` file.
+- Note that `configlet sync` tries to maintain the key order in exercise `.meta/config.json` files when updating. To write these files in a canonical form without syncing, please use the `configlet fmt` command. However, `configlet sync` _does_ add (possibly empty) required keys (`authors`, `files`, `blurb`) when they are missing. This is less "sync-like", but more ergonomic: when implementing a new exercise, you can use `sync` to create a starter `.meta/config.json` file.
 - `configlet sync` removes keys that are not in the spec. Custom key/value pairs are still supported: they must be written inside a JSON object named `custom`.
 - The exit code is 0 when all the seen data are synced when configlet exits, and 1 otherwise.
 
@@ -218,6 +218,55 @@ The `sync` command is useful when adding a new exercise to a track. If you are a
 1. View that `.meta/tests.toml` file, and add `include = false` to any test case that the exercise will not implement.
 1. Implement the tests for the exercise to match those included in `.meta/tests.toml`.
 1. Add the other required files.
+
+## `configlet fmt`
+
+Every Concept Exercise and Practice Exercise on an Exercism track must have a `.meta/config.json` file.
+
+To rewrite every exercise config file in the canonical form, run:
+
+```
+$ configlet fmt
+```
+
+This will print a list of paths for which there is not already a formatted exercise `.meta/config.json` file, and write the formatted files if you confirm.
+
+"Formatting" or "rewriting in the canonical form" means:
+
+- Write the key/value pairs in the canonical order.
+
+- Use two spaces for indentation, and use a separate line for each item in a JSON array/object.
+
+- Strip key/value pairs for keys that are optional and have empty values.
+  For example, `contributors: []` is removed.
+
+- Strip `test_runner: true` for Practice Exercise config files.
+  This is an optional key - the spec says that an omitted `test_runner` key implies the value `true`.
+
+- When there is more than one key/value pair with the same name, keep only the final one.
+
+The canonical order is:
+
+```
+- authors
+- [contributors]
+- files
+  - solution
+  - test
+  - exemplar           (Concept Exercises only)
+  - example            (Practice Exercises only)
+  - [editor]
+- [language_versions]
+- [forked_from]        (Concept Exercises only)
+- [icon]               (Concept Exercises only)
+- [test_runner]        (Practice Exercises only)
+- blurb
+- [source]
+- [source_url]
+- [custom]
+```
+
+where the square brackets indicate that the enclosed key is optional.
 
 ## `configlet uuid`
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Commands:
 
 Options for fmt:
   -e, --exercise <slug>        Only operate on this exercise
-  -y, --yes                    Format without prompting for confirmation
+  -u, --update                 Prompt to write formatted files
+  -y, --yes                    Auto-confirm the prompt from --update
 
 Options for sync:
   -e, --exercise <slug>        Only operate on this exercise
@@ -226,14 +227,34 @@ The `sync` command is useful when adding a new exercise to a track. If you are a
 ## `configlet fmt`
 
 Every Concept Exercise and Practice Exercise on an Exercism track must have a `.meta/config.json` file.
+To ensure that each of these files is in the canonical form, you can use the `configlet fmt` command.
 
-To rewrite every exercise config file in the canonical form, run:
+A plain `configlet fmt` makes no changes to the track, and checks the `.meta/config.json` file for every Concept Exercise and Practice Exercise.
+
+To print a list of paths for which there is not already a formatted exercise `.meta/config.json` file (exiting with a non-zero exit code if at least one exercise lacks a formatted config file):
 
 ```
 $ configlet fmt
 ```
 
-This will print a list of paths for which there is not already a formatted exercise `.meta/config.json` file, and write the formatted files if you confirm.
+To be prompted to write formatted config files, add the `--update` option (or `-u` for short):
+
+```
+$ configlet fmt --update
+```
+
+To non-interactively write the formatted config files, add the `--yes` option (or `-y` for short):
+
+```
+$ configlet fmt --update --yes
+```
+
+To operate on a single exercise, use the `--exercise` option (or `-e` for short).
+For example, to non-interactively write the formatted config file for the `prime-factors` exercise:
+
+```
+$ configlet fmt -uy -e prime-factors
+```
 
 "Formatting" or "rewriting in the canonical form" means:
 

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -337,8 +337,8 @@ proc parseActionKind(key: string): ActionKind =
   try:
     result = parseEnum[ActionKind](keyNormalized)
   except ValueError:
-    if keyNormalized == "format": # Silently accept `configlet format`.
-      result = actFmt
+    if keyNormalized == "format":
+      showError(&"invalid command: '{key}'\nDid you mean 'fmt'?")
     else:
       showError(&"invalid command: '{key}'")
 

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -427,11 +427,9 @@ proc handleOption(conf: var Conf; kind: CmdLineKind; key, val: string) =
     of actFmt:
       case opt
       of optFmtSyncExercise:
-        conf.action.exerciseFmt = val
-        isActionOpt = true
+        setActionOpt(exerciseFmt, val)
       of optFmtSyncYes:
-        conf.action.yesFmt = true
-        isActionOpt = true
+        setActionOpt(yesFmt, true)
       else:
         discard
     of actLint:

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -171,6 +171,13 @@ func genHelpText: string =
   const (syntax, maxLen) = genSyntaxStrings()
   const padding = repeat(' ', maxLen)
 
+  # For some options that are common between commands, we want different
+  # descriptions in the help message. But we currently use `parseEnum` to parse
+  # a user-provided option, and so `Opt` can't have e.g. separate `optSyncYes`
+  # and `optFmtYes` values with the same string value of "yes".
+  # We define most of the option descriptions below. For the options that are
+  # common to both `sync` and `fmt`, we set the `sync` descriptions here and
+  # set the `fmt` ones later.
   const descriptions: array[Opt, string] = [
     optHelp: "Show this help message and exit",
     optVersion: "Show this tool's version information and exit",
@@ -221,6 +228,7 @@ func genHelpText: string =
               optFmtSyncYes
             else:
               parseEnum[Opt](key)
+          # Set the description for `fmt` options.
           let desc =
             if opt == optFmtSyncYes and actionKind == actFmt:
               "Format without prompting for confirmation"

--- a/src/configlet.nim
+++ b/src/configlet.nim
@@ -1,6 +1,6 @@
 import std/posix
-import "."/[cli, info/info, generate/generate, lint/lint, logger, sync/sync,
-            uuid/uuid]
+import "."/[cli, fmt/fmt, info/info, generate/generate, lint/lint, logger,
+            sync/sync, uuid/uuid]
 
 proc main =
   onSignal(SIGTERM):
@@ -13,6 +13,8 @@ proc main =
   case conf.action.kind
   of actNil:
     discard
+  of actFmt:
+    fmt(conf)
   of actLint:
     lint(conf)
   of actSync:

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -51,12 +51,13 @@ proc fmtImpl(trackExerciseSlugs: TrackExerciseSlugs,
                                                    trackExercisesDir):
     let formatted = formatFile(exerciseKind, configPath)
     # TODO: remove duplicate `readFile`.
-    if not fileExists(configPath) or readFile(configPath) != formatted:
+    if fileExists(configPath) and readFile(configPath) == formatted:
+      logDetailed(&"Already formatted: {relativePath(configPath, trackDir)}")
+    else:
       if not seenUnformatted:
         logNormal(&"The below paths are relative to '{trackDir}'")
       seenUnformatted = true
-      let configPathRelative = relativePath(configPath, trackDir)
-      logNormal(&"Not formatted: {configPathRelative}")
+      logNormal(&"Not formatted: {relativePath(configPath, trackDir)}")
       result.add PathAndFormattedExerciseConfig(
         path: configPath,
         formattedExerciseConfig: formatted

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -53,9 +53,9 @@ proc fmtImpl(trackExerciseSlugs: TrackExerciseSlugs,
     # TODO: remove duplicate `readFile`.
     if not fileExists(configPath) or readFile(configPath) != formatted:
       if not seenUnformatted:
-        logNormal(&"The below paths are relative to '{trackExercisesDir}'")
+        logNormal(&"The below paths are relative to '{trackDir}'")
       seenUnformatted = true
-      let configPathRelative = relativePath(configPath, trackExercisesDir)
+      let configPathRelative = relativePath(configPath, trackDir)
       logNormal(&"Not formatted: {configPathRelative}")
       result.add PathAndFormattedExerciseConfig(
         path: configPath,

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -85,11 +85,10 @@ proc fmt*(conf: Conf) =
   ## the user confirms.
   let trackConfigPath = conf.trackDir / "config.json"
   let trackConfig = parseFile(trackConfigPath, TrackConfig)
-  let trackExerciseSlugs = TrackExerciseSlugs.init(trackConfig.exercises)
-
-  logNormal(&"Found {trackExerciseSlugs.`concept`.len} Concept Exercises " &
-            &"and {trackExerciseSlugs.practice.len} Practice Exercises in " &
+  logNormal(&"Found {trackConfig.exercises.`concept`.len} Concept Exercises " &
+            &"and {trackConfig.exercises.practice.len} Practice Exercises in " &
             trackConfigPath)
+  let trackExerciseSlugs = getSlugs(trackConfig.exercises, conf, trackConfigPath)
   logNormal("Looking for exercises that lack a formatted '.meta/config.json' " &
             "file...")
 
@@ -97,7 +96,13 @@ proc fmt*(conf: Conf) =
   let pairs = fmtImpl(trackExerciseSlugs, trackExercisesDir)
 
   if pairs.len > 0:
-    if userSaysYes():
+    if conf.action.yesFmt or userSaysYes():
       writeFormatted(pairs)
   else:
-    logNormal("Every exercise config is already formatted!")
+    let userExercise = conf.action.exerciseFmt
+    let wording =
+      if userExercise.len > 0:
+        &"The `{userExercise}`"
+      else:
+        "Every"
+    logNormal(&"{wording} exercise config is already formatted!")

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -56,11 +56,12 @@ proc fmtImpl(trackExerciseSlugs: TrackExerciseSlugs,
         formattedExerciseConfig: formatted
       )
 
-proc userSaysYes: bool =
+proc userSaysYes(userExercise: string): bool =
   ## Asks the user if they want to format files, and returns `true` if they
   ## confirm.
+  let s = if userExercise.len > 0: "" else: "s"
   while true:
-    stderr.write &"Format the above exercise configs ([y]es/[n]o)? "
+    stderr.write &"Format the above exercise config{s} ([y]es/[n]o)? "
     case stdin.readLine().toLowerAscii()
     of "y", "yes":
       return true
@@ -95,16 +96,16 @@ proc fmt*(conf: Conf) =
   let trackExercisesDir = conf.trackDir / "exercises"
   let pairs = fmtImpl(trackExerciseSlugs, trackExercisesDir)
 
+  let userExercise = conf.action.exerciseFmt
   if pairs.len > 0:
     if conf.action.updateFmt:
-      if conf.action.yesFmt or userSaysYes():
+      if conf.action.yesFmt or userSaysYes(userExercise):
         writeFormatted(pairs)
       else:
         quit 1
     else:
       quit 1
   else:
-    let userExercise = conf.action.exerciseFmt
     let wording =
       if userExercise.len > 0:
         &"The `{userExercise}`"

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -96,8 +96,13 @@ proc fmt*(conf: Conf) =
   let pairs = fmtImpl(trackExerciseSlugs, trackExercisesDir)
 
   if pairs.len > 0:
-    if conf.action.yesFmt or userSaysYes():
-      writeFormatted(pairs)
+    if conf.action.updateFmt:
+      if conf.action.yesFmt or userSaysYes():
+        writeFormatted(pairs)
+      else:
+        quit 1
+    else:
+      quit 1
   else:
     let userExercise = conf.action.exerciseFmt
     let wording =

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -1,0 +1,103 @@
+import std/[os, strformat, strutils]
+import ".."/[cli, logger, sync/sync_common, sync/sync_filepaths, sync/sync]
+
+type
+  PathAndFormattedExerciseConfig = object
+    path: string
+    formattedExerciseConfig: string
+
+iterator getConfigPaths(trackExerciseSlugs: TrackExerciseSlugs,
+                        trackExercisesDir: string): (ExerciseKind, string) =
+  ## Yields the `.meta/config.json` path for each exercise in
+  ## `trackExerciseSlugs` in `trackExercisesDir`.
+  for exerciseKind in [ekConcept, ekPractice]:
+    let slugs =
+      case exerciseKind
+      of ekConcept: trackExerciseSlugs.`concept`
+      of ekPractice: trackExerciseSlugs.practice
+    var trackExerciseConfigPath =
+      case exerciseKind
+      of ekConcept: trackExercisesDir / "concept"
+      of ekPractice: trackExercisesDir / "practice"
+    normalizePathEnd(trackExerciseConfigPath, trailingSep = true)
+    let startLen = trackExerciseConfigPath.len
+
+    for slug in slugs:
+      trackExerciseConfigPath.truncateAndAdd(startLen, slug)
+      trackExerciseConfigPath.addExerciseConfigPath()
+      yield (exerciseKind, trackExerciseConfigPath)
+
+proc formatFile(exerciseKind: ExerciseKind,
+                configPath: string): string =
+  ## Parses the `.meta/config.json` file at `configPath` and returns it in the
+  ## canonical form.
+  let exerciseConfig = ExerciseConfig.init(exerciseKind, configPath)
+  case exerciseKind
+  of ekConcept:
+    pretty(exerciseConfig.c, pmFmt)
+  of ekPractice:
+    pretty(exerciseConfig.p, pmFmt)
+
+proc fmtImpl(trackExerciseSlugs: TrackExerciseSlugs,
+             trackExercisesDir: string): seq[PathAndFormattedExerciseConfig] =
+  ## Reads the `.meta/config.json` file for every slug in `trackExerciseSlugs`
+  ## in `trackExerciseDir`.
+  ##
+  ## Returns a seq of (path, formatted config) objects containing every exercise
+  ## config that is not already formatted.
+  for (exerciseKind, configPath) in getConfigPaths(trackExerciseSlugs,
+                                                   trackExercisesDir):
+    let formatted = formatFile(exerciseKind, configPath)
+    # TODO: remove duplicate `readFile`.
+    if not fileExists(configPath) or readFile(configPath) != formatted:
+      logNormal(&"Not formatted: {configPath}")
+      result.add PathAndFormattedExerciseConfig(
+        path: configPath,
+        formattedExerciseConfig: formatted
+      )
+
+proc userSaysYes: bool =
+  ## Asks the user if they want to format files, and returns `true` if they
+  ## confirm.
+  while true:
+    stderr.write &"Format the above exercise configs ([y]es/[n]o)? "
+    case stdin.readLine().toLowerAscii()
+    of "y", "yes":
+      return true
+    of "n", "no":
+      return false
+    else:
+      stderr.writeLine "Unrecognized response. Please answer [y]es or [n]o."
+
+proc writeFormatted(prettyPairs: seq[PathAndFormattedExerciseConfig]) =
+  for prettyPair in prettyPairs:
+    let path = prettyPair.path
+    doAssert lastPathPart(path) == "config.json"
+    createDir path.parentDir()
+    logDetailed(&"Writing formatted: {path}")
+    writeFile(path, prettyPair.formattedExerciseConfig)
+  let s = if prettyPairs.len > 1: "s" else: ""
+  logNormal(&"Formatted the exercise config for {prettyPairs.len} exercise{s}")
+
+proc fmt*(conf: Conf) =
+  ## Prints a list of `.meta/config.json` paths in `conf.trackDir` where the
+  ## config file is missing or not in the canonical form, and formats them if
+  ## the user confirms.
+  let trackConfigPath = conf.trackDir / "config.json"
+  let trackConfig = parseFile(trackConfigPath, TrackConfig)
+  let trackExerciseSlugs = TrackExerciseSlugs.init(trackConfig.exercises)
+
+  logNormal(&"Found {trackExerciseSlugs.`concept`.len} Concept Exercises " &
+            &"and {trackExerciseSlugs.practice.len} Practice Exercises in " &
+            trackConfigPath)
+  logNormal("Looking for exercises that lack a formatted '.meta/config.json' " &
+            "file...")
+
+  let trackExercisesDir = conf.trackDir / "exercises"
+  let pairs = fmtImpl(trackExerciseSlugs, trackExercisesDir)
+
+  if pairs.len > 0:
+    if userSaysYes():
+      writeFormatted(pairs)
+  else:
+    logNormal("Every exercise config is already formatted!")

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -33,11 +33,11 @@ proc validate(conf: Conf) =
           showError(msg)
 
 type
-  TrackExerciseSlugs = object
-    `concept`: seq[Slug]
-    practice: seq[Slug]
+  TrackExerciseSlugs* = object
+    `concept`*: seq[Slug]
+    practice*: seq[Slug]
 
-func init(T: typedesc[TrackExerciseSlugs], exercises: Exercises): T =
+func init*(T: typedesc[TrackExerciseSlugs], exercises: Exercises): T =
   T(
     `concept`: getSlugs(exercises.`concept`),
     practice: getSlugs(exercises.practice)

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -12,9 +12,9 @@ proc validate(conf: Conf) =
   if conf.action.update:
     if conf.action.yes and skTests in conf.action.scope:
       let msg = fmt"""
-        '{list(optSyncYes)}' was provided to non-interactively update, but the tests updating mode is still 'choose'.
+        '{list(optFmtSyncYes)}' was provided to non-interactively update, but the tests updating mode is still 'choose'.
         You can either:
-        - remove '{list(optSyncYes)}', and update by confirming prompts
+        - remove '{list(optFmtSyncYes)}', and update by confirming prompts
         - or narrow the syncing scope via some combination of --docs, --filepaths, and --metadata
         - or add '--tests include' or '--tests exclude' to non-interactively include/exclude missing tests
         If no syncing scope option is provided, configlet uses the full syncing scope.
@@ -43,15 +43,22 @@ func init*(T: typedesc[TrackExerciseSlugs], exercises: Exercises): T =
     practice: getSlugs(exercises.practice)
   )
 
-proc getSlugs(exercises: Exercises, conf: Conf,
-              trackConfigPath: string): TrackExerciseSlugs =
+proc getSlugs*(exercises: Exercises, conf: Conf,
+               trackConfigPath: string): TrackExerciseSlugs =
   ## Returns the slugs of Concept Exercises and Practice Exercises in
-  ## `exercises`. If `conf.action.exercise` has a non-zero length, returns only
-  ## that one slug if the given exercise was found on the track.
+  ## `exercises`. If `conf.action.exercise(Fmt)` has a non-zero length, returns
+  ## only that one slug if the given exercise was found on the track.
   ##
   ## If that exercise was not found, prints an error and exits.
   result = TrackExerciseSlugs.init(exercises)
-  let userExercise = Slug(conf.action.exercise)
+  let userExercise =
+    case conf.action.kind
+    of actFmt:
+      Slug(conf.action.exerciseFmt)
+    of actSync:
+      Slug(conf.action.exercise)
+    else:
+      Slug("")
   if userExercise.len > 0:
     if userExercise in result.`concept`:
       result.`concept` = @[userExercise]

--- a/src/sync/sync_filepaths.nim
+++ b/src/sync/sync_filepaths.nim
@@ -64,19 +64,19 @@ func isSynced(f: ConceptExerciseFiles | PracticeExerciseFiles,
   uniqueCond and genCond(solution) and genCond(test) and genCond(editor)
 
 type
-  ExerciseConfig = object
+  ExerciseConfig* = object
     case kind: ExerciseKind
     of ekConcept:
-      c: ConceptExerciseConfig
+      c*: ConceptExerciseConfig
     of ekPractice:
-      p: PracticeExerciseConfig
+      p*: PracticeExerciseConfig
 
   PathAndUpdatedExerciseConfig = object
     path: string
     exerciseConfig: ExerciseConfig
 
-proc init(T: typedesc[ExerciseConfig], kind: ExerciseKind,
-          trackExerciseConfigPath: string): T =
+proc init*(T: typedesc[ExerciseConfig], kind: ExerciseKind,
+           trackExerciseConfigPath: string): T =
   case kind
   of ekConcept: T(
     kind: kind,

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -1,5 +1,6 @@
 import "."/[
   test_binary,
+  test_fmt,
   test_json,
   test_lint,
   test_probspecs,

--- a/tests/test_fmt.nim
+++ b/tests/test_fmt.nim
@@ -1,0 +1,365 @@
+import std/[importutils, json, os, options, random, strutils, unittest]
+import pkg/jsony
+import "."/[exec, helpers, sync/sync_common]
+
+const
+  testsDir = currentSourcePath().parentDir()
+
+proc testFmt =
+  const trackDir = testsDir / ".test_elixir_track_repo"
+
+  # Setup: clone a track repo, and checkout a known state
+  setupExercismRepo("elixir", trackDir,
+                    "8447eaeb5ae8bdd0ae94383e6ec5bcfa21a7f993") # 2021-10-28
+
+  const conceptExercisesDir = joinPath(trackDir, "exercises", "concept")
+  const practiceExercisesDir = joinPath(trackDir, "exercises", "practice")
+
+  suite "fmt":
+    privateAccess(ConceptExerciseConfig)
+    privateAccess(PracticeExerciseConfig)
+    privateAccess(ConceptExerciseFiles)
+    privateAccess(PracticeExerciseFiles)
+
+    block:
+      const emptyConceptExerciseContents = """
+      {
+        "authors": [],
+        "files": {
+          "solution": [],
+          "test": [],
+          "exemplar": []
+        },
+        "blurb": ""
+      }
+      """.dedent(6)
+      const emptyPracticeExerciseContents = """
+      {
+        "authors": [],
+        "files": {
+          "solution": [],
+          "test": [],
+          "example": []
+        },
+        "blurb": ""
+      }
+      """.dedent(6)
+
+      test "empty Concept Exercise":
+        let empty = ConceptExerciseConfig()
+        check:
+          empty.pretty(pmFmt) == emptyConceptExerciseContents
+
+      test "empty Practice Exercise":
+        let empty = PracticeExerciseConfig()
+        check:
+          empty.pretty(pmFmt) == emptyPracticeExerciseContents
+
+      test "reorders mandatory keys - Concept Exercise":
+        let empty = ConceptExerciseConfig(
+          originalKeyOrder: @[eckBlurb, eckAuthors, eckFiles]
+        )
+        check:
+          empty.pretty(pmFmt) == emptyConceptExerciseContents
+
+      test "reorders mandatory keys - Practice Exercise":
+        let empty = PracticeExerciseConfig(
+          originalKeyOrder: @[eckBlurb, eckAuthors, eckFiles]
+        )
+        check:
+          empty.pretty(pmFmt) == emptyPracticeExerciseContents
+
+    test "omits optional keys that have an empty value - Concept Exercise":
+      let p = ConceptExerciseConfig(
+        originalKeyOrder: @[eckContributors, eckFiles, eckLanguageVersions,
+                            eckForkedFrom, eckIcon, eckSource, eckSourceUrl,
+                            eckCustom],
+        contributors: some(newSeq[string]()),
+        files: ConceptExerciseFiles(
+          originalKeyOrder: @[fkEditor],
+        ),
+        custom: some(newJObject())
+      )
+      const expected = """{
+        "authors": [],
+        "files": {
+          "solution": [],
+          "test": [],
+          "exemplar": []
+        },
+        "blurb": ""
+      }
+      """.dedent(6)
+      check:
+        p.pretty(pmFmt) == expected
+
+    test "omits optional keys that have an empty value - Practice Exercise":
+      let p = PracticeExerciseConfig(
+        originalKeyOrder: @[eckContributors, eckFiles, eckLanguageVersions,
+                            eckSource, eckSourceUrl, eckCustom],
+        contributors: some(newSeq[string]()),
+        files: PracticeExerciseFiles(
+          originalKeyOrder: @[fkEditor],
+        ),
+        custom: some(newJObject())
+      )
+      const expected = """{
+        "authors": [],
+        "files": {
+          "solution": [],
+          "test": [],
+          "example": []
+        },
+        "blurb": ""
+      }
+      """.dedent(6)
+      check:
+        p.pretty(pmFmt) == expected
+
+    block:
+      let customJson = """
+        {
+          "foo": true,
+          "bar": 7,
+          "baz": "hi",
+          "stuff": [1, 2, 3],
+          "my_object": {
+            "foo": false,
+            "bar": ["a", "b", "c"]
+          }
+        }
+      """.parseJson()
+      randomize()
+
+      test "populated config with random key order - Concept Exercise":
+        var exerciseConfig = ConceptExerciseConfig(
+          originalKeyOrder: @[eckAuthors, eckContributors, eckFiles,
+                              eckLanguageVersions, eckForkedFrom, eckIcon,
+                              eckBlurb, eckSource, eckSourceUrl,
+                              eckCustom],
+          authors: @["author1"],
+          contributors: some(@["contributor1"]),
+          files: ConceptExerciseFiles(
+            originalKeyOrder: @[fkSolution, fkTest, fkExemplar, fkEditor],
+            solution: @["lasagna.foo"],
+            test: @["test_lasagna.foo"],
+            exemplar: @[".meta/exemplar.foo"],
+            editor: @["extra_file.foo"]
+          ),
+          language_versions: ">=1.2.3",
+          forked_from: some(@["bar/lovely-lasagna"]),
+          icon: "myicon",
+          blurb: "Learn about the basics of Foo by following a lasagna recipe.",
+          source: "mysource",
+          source_url: "https://example.com",
+          custom: some(customJson)
+        )
+        const expected = """{
+          "authors": [
+            "author1"
+          ],
+          "contributors": [
+            "contributor1"
+          ],
+          "files": {
+            "solution": [
+              "lasagna.foo"
+            ],
+            "test": [
+              "test_lasagna.foo"
+            ],
+            "exemplar": [
+              ".meta/exemplar.foo"
+            ],
+            "editor": [
+              "extra_file.foo"
+            ]
+          },
+          "language_versions": ">=1.2.3",
+          "forked_from": [
+            "bar/lovely-lasagna"
+          ],
+          "icon": "myicon",
+          "blurb": "Learn about the basics of Foo by following a lasagna recipe.",
+          "source": "mysource",
+          "source_url": "https://example.com",
+          "custom": {
+            "foo": true,
+            "bar": 7,
+            "baz": "hi",
+            "stuff": [
+              1,
+              2,
+              3
+            ],
+            "my_object": {
+              "foo": false,
+              "bar": [
+                "a",
+                "b",
+                "c"
+              ]
+            }
+          }
+        }
+        """.dedent(8)
+
+        for i in 1..100:
+          shuffle(exerciseConfig.originalKeyOrder)
+          shuffle(exerciseConfig.files.originalKeyOrder)
+          check:
+            exerciseConfig.pretty(pmFmt) == expected
+
+      test "populated config with random key order - Practice Exercise":
+        var exerciseConfig = PracticeExerciseConfig(
+          originalKeyOrder: @[eckAuthors, eckContributors, eckFiles,
+                              eckLanguageVersions, eckTestRunner,
+                              eckBlurb, eckSource, eckSourceUrl,
+                              eckCustom],
+          authors: @["author1"],
+          contributors: some(@["contributor1"]),
+          files: PracticeExerciseFiles(
+            originalKeyOrder: @[fkSolution, fkTest, fkExample, fkEditor],
+            solution: @["darts.foo"],
+            test: @["test_darts.foo"],
+            example: @[".meta/example.foo"],
+            editor: @["extra_file.foo"]
+          ),
+          language_versions: ">=1.2.3",
+          test_runner: some(false),
+          blurb: "Write a function that returns the earned points in a single toss of a Darts game.",
+          source: "Inspired by an exercise created by a professor Della Paolera in Argentina",
+          source_url: "https://example.com",
+          custom: some(customJson)
+        )
+        const expected = """{
+          "authors": [
+            "author1"
+          ],
+          "contributors": [
+            "contributor1"
+          ],
+          "files": {
+            "solution": [
+              "darts.foo"
+            ],
+            "test": [
+              "test_darts.foo"
+            ],
+            "example": [
+              ".meta/example.foo"
+            ],
+            "editor": [
+              "extra_file.foo"
+            ]
+          },
+          "language_versions": ">=1.2.3",
+          "test_runner": false,
+          "blurb": "Write a function that returns the earned points in a single toss of a Darts game.",
+          "source": "Inspired by an exercise created by a professor Della Paolera in Argentina",
+          "source_url": "https://example.com",
+          "custom": {
+            "foo": true,
+            "bar": 7,
+            "baz": "hi",
+            "stuff": [
+              1,
+              2,
+              3
+            ],
+            "my_object": {
+              "foo": false,
+              "bar": [
+                "a",
+                "b",
+                "c"
+              ]
+            }
+          }
+        }
+        """.dedent(8)
+
+        for i in 1..100:
+          shuffle(exerciseConfig.originalKeyOrder)
+          shuffle(exerciseConfig.files.originalKeyOrder)
+          check:
+            exerciseConfig.pretty(pmFmt) == expected
+
+    test "fmt omits `test_runner: true`":
+      let exerciseConfig = PracticeExerciseConfig(
+        originalKeyOrder: @[eckTestRunner],
+        test_runner: some(true)
+      )
+      const expected = """{
+        "authors": [],
+        "files": {
+          "solution": [],
+          "test": [],
+          "example": []
+        },
+        "blurb": ""
+      }
+      """.dedent(6)
+      check:
+        exerciseConfig.pretty(pmFmt) == expected
+
+    block:
+      # This checks that we format every exercise `.meta/config.json` file in
+      # the `exercism/elixir` repo the same as a convoluted round-trip
+      # serialization process that uses `jsony.toJson` -> `json.parseJson` and
+      # then conditionally removes some key/value pairs.
+      #
+      # If this test fails, the problem might be in the round-trip
+      # serialization. For example, it's easy to miss or introduce a bug like
+      #     if j["icon"].len == 0:
+      #       delete(j, "icon")
+      # which compiles, but doesn't do what was intended (`getStr` is missing).
+      proc fmtViaRoundtrip(e: ConceptExerciseConfig |
+                              PracticeExerciseConfig): string =
+        var j = e.toJson().parseJson()
+        delete(j, "originalKeyOrder")
+        if j["contributors"].len == 0:
+          delete(j, "contributors")
+        delete(j["files"], "originalKeyOrder")
+        if j["files"]["editor"].len == 0:
+          delete(j["files"], "editor")
+        when e is ConceptExerciseConfig:
+          let val = j["forked_from"]
+          if val.kind == JNull or (val.kind == JArray and val.len == 0):
+            delete(j, "forked_from")
+          if j["icon"].getStr().len == 0:
+            delete(j, "icon")
+        when e is PracticeExerciseConfig:
+          let val = j["test_runner"]
+          # Strip `"test_runner": true`
+          if val.kind == JNull or (val.kind == JBool and val.getBool()):
+            delete(j, "test_runner")
+        for k in ["language_versions", "source", "source_url"]:
+          if j[k].getStr().len == 0:
+            delete(j, k)
+        if j["custom"].kind != JObject or j["custom"].len == 0:
+          delete(j, "custom")
+        result = j.pretty()
+        result.add '\n'
+
+      test "with every Elixir Concept Exercise":
+        for exerciseDir in getSortedSubdirs(conceptExercisesDir.Path):
+          let exerciseConfigPath = joinPath(exerciseDir.string, ".meta", "config.json")
+          let exerciseConfig = parseFile(exerciseConfigPath, ConceptExerciseConfig)
+          let ourSerialization = exerciseConfig.pretty(pmFmt)
+          let stdlibSerialization = fmtViaRoundtrip(exerciseConfig)
+          check ourSerialization == stdlibSerialization
+
+      test "with every Elixir Practice Exercise":
+        for exerciseDir in getSortedSubdirs(practiceExercisesDir.Path):
+          let exerciseConfigPath = joinPath(exerciseDir.string, ".meta", "config.json")
+          let exerciseConfig = parseFile(exerciseConfigPath, PracticeExerciseConfig)
+          let ourSerialization = exerciseConfig.pretty(pmFmt)
+          let stdlibSerialization = fmtViaRoundtrip(exerciseConfig)
+          check ourSerialization == stdlibSerialization
+
+proc main =
+  testFmt()
+
+main()
+{.used.}


### PR DESCRIPTION
@ErikSchierboom what do you think about the interactivity here? Options:
1. `configlet fmt` prompts the user when the terminal is interactive (like `configlet sync`)
2. `configlet fmt` non-interactively formats.

For consistency with `configlet sync`, ~I did the latter~ (edit: I meant "I did option 1")

Ideally I'd have some "end-to-end" tests for this. But if you're happy, we can add them later.

To-do:
- [x] Support the `-e, --exercise` option that `configlet sync` supports.
- [x] Support the `-y, --yes` option that `configlet sync` supports. Note that
providing 'y' or 'yes' on stdin also works, like `echo 'y' | configlet fmt`
- [x] Merge the big sync PR first, and rebase this PR on top.

---

This commit adds the `fmt` command to configlet.

Running `configlet fmt` will print a list of paths for which there is
not already a formatted exercise `.meta/config.json` file, and write the
formatted files if the user confirms.

"Formatting" means:

- Write the key/value pairs in the canonical order.

- Use two spaces for indentation, and use a separate line for each item
  in a JSON array (and each key in a JSON object).

- Strip key/value pairs for keys that are optional and have empty
  values. For example, `contributors: []` is removed.

- Strip `test_runner: true` for Practice Exercise config files. This is
  an optional key - the spec says that an omitted `test_runner` key
  implies the value `true`.

The canonical order is:

    - authors
    - [contributors]
    - files
      - solution
      - test
      - exemplar           (Concept Exercises only)
      - example            (Practice Exercises only)
      - [editor]
    - [language_versions]
    - [forked_from]        (Concept Exercises only)
    - [icon]               (Concept Exercises only)
    - [test_runner]        (Practice Exercises only)
    - blurb
    - [source]
    - [source_url]
    - [custom]

where [key] indicates that the key is optional. This order tries to:

- maximize visual consistency between Concept and Practice Exercise
  configs by writing their unique keys in the same place.

- maximize visual consistency between files that contain and omit
  optional keys, by writing those keys later (e.g. `custom`), except
  that we:

  - write `contributors` under `authors`, since these keys are similar.

  - write `blurb` near the bottom, and above `source`, and `source_url`,
    since these keys are all synced with `problem-specifications` for a
    Practice Exercise.

Some possible future work:

- Support formatting the track `config.json` file.