### PR TITLE
sync(probspecs): fix message for missing prob-specs dir

### DIFF
--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -111,6 +111,8 @@ proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
     showError("the given problem-specifications directory does not exist: " &
               &"'{probSpecsDir}'")
 
+  # Validate the `problem-specifications` repo without checking the ref of the
+  # root commit, allowing the `--prob-specs-dir` location to be a shallow clone.
   withDir probSpecsDir.string:
     # Exit if the given directory is not a git repo.
     discard gitCheck(0, ["rev-parse"], "the given problem-specifications " &

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -100,7 +100,7 @@ proc getNameOfRemote(probSpecsDir: ProbSpecsDir;
             &"the given problem-specifications directory: '{probSpecsDir}'")
 
 proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
-  ## Raises an error if the given `probSpecsRepo` is not a valid
+  ## Raises an error if the given `probSpecsDir` is not a valid
   ## `problem-specifications` repo that is up-to-date with upstream.
   const mainBranchName = "main"
 

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -99,7 +99,7 @@ proc getNameOfRemote(probSpecsDir: ProbSpecsDir;
   showError(&"there is no remote that points to '{location}' at '{host}' in " &
             &"the given problem-specifications directory: '{probSpecsDir}'")
 
-proc validate(probSpecsDir: ProbSpecsDir) =
+proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
   ## Raises an error if the given `probSpecsRepo` is not a valid
   ## `problem-specifications` repo that is up-to-date with upstream.
   const mainBranchName = "main"
@@ -121,33 +121,33 @@ proc validate(probSpecsDir: ProbSpecsDir) =
                      "problem-specifications working directory is not clean: " &
                      &"'{probSpecsDir}'")
 
-    # Find the name of the remote that points to upstream. Don't assume the
-    # remote is called 'upstream'.
-    # Exit if the repo has no remote that points to upstream.
-    const upstreamHost = "github.com"
-    const upstreamLocation = "exercism/problem-specifications"
-    let remoteName = getNameOfRemote(probSpecsDir, upstreamHost, upstreamLocation)
+    if not conf.action.offline:
+      # Find the name of the remote that points to upstream. Don't assume the
+      # remote is called 'upstream'.
+      # Exit if the repo has no remote that points to upstream.
+      const upstreamHost = "github.com"
+      const upstreamLocation = "exercism/problem-specifications"
+      let remoteName = getNameOfRemote(probSpecsDir, upstreamHost, upstreamLocation)
 
-    # For now, just exit with an error if the HEAD is not up-to-date with
-    # upstream, even if it's possible to do a fast-forward merge.
+      # For now, just exit with an error if the HEAD is not up-to-date with
+      # upstream, even if it's possible to do a fast-forward merge.
 
-    discard gitCheck(0, ["fetch", "--quiet", remoteName, mainBranchName],
-                     &"failed to fetch `{mainBranchName}` in " &
-                     &"problem-specifications directory: '{probSpecsDir}'")
+      discard gitCheck(0, ["fetch", "--quiet", remoteName, mainBranchName],
+                       &"failed to fetch `{mainBranchName}` in " &
+                       &"problem-specifications directory: '{probSpecsDir}'")
 
-    # Allow HEAD to be on a non-`main` branch, as long as it's up-to-date
-    # with `upstream/main`.
-    let revHead = gitCheck(0, ["rev-parse", "HEAD"])
-    let revUpstream = gitCheck(0, ["rev-parse", &"{remoteName}/{mainBranchName}"])
-    if revHead != revUpstream:
-      showError("the given problem-specifications directory is not " &
-                &"up-to-date: '{probSpecsDir}'")
+      # Allow HEAD to be on a non-`main` branch, as long as it's up-to-date
+      # with `upstream/main`.
+      let revHead = gitCheck(0, ["rev-parse", "HEAD"])
+      let revUpstream = gitCheck(0, ["rev-parse", &"{remoteName}/{mainBranchName}"])
+      if revHead != revUpstream:
+        showError("the given problem-specifications directory is not " &
+                  &"up-to-date: '{probSpecsDir}'")
 
 proc initProbSpecsDir*(conf: Conf): ProbSpecsDir =
   if conf.action.probSpecsDir.len > 0:
     result = ProbSpecsDir(conf.action.probSpecsDir)
-    if not conf.action.offline:
-      validate(result)
+    validate(result, conf)
   else:
     result = ProbSpecsDir(getCurrentDir() / ".problem-specifications")
     removeDir(result)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -121,17 +121,16 @@ proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
                      "problem-specifications working directory is not clean: " &
                      &"'{probSpecsDir}'")
 
-    if not conf.action.offline:
-      # Find the name of the remote that points to upstream. Don't assume the
-      # remote is called 'upstream'.
-      # Exit if the repo has no remote that points to upstream.
-      const upstreamHost = "github.com"
-      const upstreamLocation = "exercism/problem-specifications"
-      let remoteName = getNameOfRemote(probSpecsDir, upstreamHost, upstreamLocation)
+    # Find the name of the remote that points to upstream. Don't assume the
+    # remote is called 'upstream'.
+    # Exit if the repo has no remote that points to upstream.
+    const upstreamHost = "github.com"
+    const upstreamLocation = "exercism/problem-specifications"
+    let remoteName = getNameOfRemote(probSpecsDir, upstreamHost, upstreamLocation)
 
+    if not conf.action.offline:
       # For now, just exit with an error if the HEAD is not up-to-date with
       # upstream, even if it's possible to do a fast-forward merge.
-
       discard gitCheck(0, ["fetch", "--quiet", remoteName, mainBranchName],
                        &"failed to fetch `{mainBranchName}` in " &
                        &"problem-specifications directory: '{probSpecsDir}'")


### PR DESCRIPTION
When performing an offline sync, and specifying a problem-specifications
directory that does not exist, e.g. via

```
$ configlet sync -o -p /foo/bar
```

before this commit, we would see this misleading message:

```
Checking exercises...
Every Practice Exercise has up-to-date docs, filepaths, metadata, and tests!
```

But with this commit, we see:

```
Checking exercises...
Error: the given problem-specifications directory does not exist: '/foo/bar'
```

Fixes: #74