### PR TITLE
info: omit deprecated exercises

### DIFF
--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -1,4 +1,4 @@
-import std/[algorithm, os, strscans, sequtils, sets, strformat, strutils,
+import std/[algorithm, os, sequtils, sets, strformat, strscans, strutils,
             terminal]
 import ".."/[cli, lint/track_config]
 

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -109,11 +109,11 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
                                      probSpecsSlugs: HashSet[string]): string =
   let practiceExerciseSlugs = getSlugs(practiceExercises)
   let unimplementedProbSpecsSlugs = probSpecsSlugs - practiceExerciseSlugs - foregone
-  result = show(unimplementedProbSpecsSlugs,
-      &"There are {unimplementedProbSpecsSlugs.len} exercises from " &
-       "`exercism/problem-specifications` that are neither implemented, nor " &
-       "deprecated upstream, nor in the track config " &
-       "`exercises.foregone` array:")
+  let msg =
+    &"There are {unimplementedProbSpecsSlugs.len} exercises from " &
+     "`exercism/problem-specifications` that are neither implemented,\n" &
+     "nor deprecated upstream, nor in the track config `exercises.foregone` array:"
+  result = show(unimplementedProbSpecsSlugs, msg)
   stripLineEnd(result)
 
 func count(exercises: seq[ConceptExercise] |

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -5,7 +5,7 @@ import ".."/[cli, lint/track_config]
 type
   ProbSpecsExercises = object
     withCanonicalData: HashSet[string]
-    noCanonicalData: HashSet[string]
+    withoutCanonicalData: HashSet[string]
     deprecated: HashSet[string]
 
 proc getPsExercises(path: static string): ProbSpecsExercises =
@@ -24,8 +24,8 @@ proc getPsExercises(path: static string): ProbSpecsExercises =
           case header
           of "with-canonical-data":
             result.withCanonicalData.incl line
-          of "no-canonical-data":
-            result.noCanonicalData.incl line
+          of "without-canonical-data":
+            result.withoutCanonicalData.incl line
           of "deprecated":
             result.deprecated.incl line
           else:
@@ -35,7 +35,7 @@ proc getProbSpecsSlugs: HashSet[string] =
   # TODO: automatically update this at build-time?
   const slugsPath = currentSourcePath().parentDir() / "prob_specs_slugs.txt"
   let psExercises = getPsExercises(slugsPath)
-  result = psExercises.withCanonicalData + psExercises.noCanonicalData
+  result = psExercises.withCanonicalData + psExercises.withoutCanonicalData
 
 func getConceptSlugs(concepts: Concepts): HashSet[string] =
   ## Returns the `slug` of every concept in `concepts`.

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -110,10 +110,11 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
   let practiceExerciseSlugs = getSlugs(practiceExercises)
   let unimplementedProbSpecsSlugs = probSpecsSlugs - practiceExerciseSlugs - foregone
   let msg =
-    &"There are {unimplementedProbSpecsSlugs.len} exercises from " &
-     "`exercism/problem-specifications` that are neither implemented,\n" &
-     "nor deprecated upstream, nor in the track config `exercises.foregone` array:"
+    &"There are {unimplementedProbSpecsSlugs.len} non-deprecated exercises " &
+     "in `exercism/problem-specifications` that\n" &
+     "are both unimplemented and not in the track config `exercises.foregone` array:"
   result = show(unimplementedProbSpecsSlugs, msg)
+
   stripLineEnd(result)
 
 func count(exercises: seq[ConceptExercise] |

--- a/src/info/prob_specs_slugs.txt
+++ b/src/info/prob_specs_slugs.txt
@@ -1,4 +1,6 @@
-# Last updated: 2021-09-28T05:00:00Z
+# Last updated: 2021-12-09T05:00:00Z
+
+[with-canonical-data]
 accumulate
 acronym
 affine-cipher
@@ -8,9 +10,7 @@ alphametics
 anagram
 armstrong-numbers
 atbash-cipher
-bank-account
 beer-song
-binary
 binary-search
 binary-search-tree
 bob
@@ -22,7 +22,6 @@ clock
 collatz-conjecture
 complex-numbers
 connect
-counter
 crypto-square
 custom-set
 darts
@@ -31,8 +30,6 @@ difference-of-squares
 diffie-hellman
 dnd-character
 dominoes
-dot-dsl
-error-handling
 etl
 flatten-array
 food-chain
@@ -43,9 +40,7 @@ grade-school
 grains
 grep
 hamming
-hangman
 hello-world
-hexadecimal
 high-scores
 house
 isbn-verifier
@@ -54,8 +49,6 @@ kindergarten-garden
 knapsack
 largest-series-product
 leap
-ledger
-lens-person
 linked-list
 list-ops
 luhn
@@ -66,19 +59,14 @@ meetup
 micro-blog
 minesweeper
 nth-prime
-nucleotide-codons
 nucleotide-count
 ocr-numbers
-octal
-paasio
 palindrome-products
 pangram
-parallel-letter-frequency
 pascals-triangle
 perfect-numbers
 phone-number
 pig-latin
-point-mutations
 poker
 pov
 prime-factors
@@ -97,7 +85,6 @@ resistor-color-trio
 rest-api
 reverse-string
 rna-transcription
-robot-name
 robot-simulator
 roman-numerals
 rotational-cipher
@@ -112,18 +99,14 @@ series
 sgf-parsing
 sieve
 simple-cipher
-simple-linked-list
 space-age
 spiral-matrix
 square-root
-strain
 sublist
 sum-of-multiples
 tournament
 transpose
-tree-building
 triangle
-trinary
 twelve-days
 two-bucket
 two-fer
@@ -134,3 +117,26 @@ wordy
 yacht
 zebra-puzzle
 zipper
+
+[no-canonical-data]
+bank-account
+dot-dsl
+error-handling
+hangman
+ledger
+lens-person
+paasio
+parallel-letter-frequency
+robot-name
+simple-linked-list
+strain
+tree-building
+
+[deprecated]
+binary
+counter
+hexadecimal
+nucleotide-codons
+octal
+point-mutations
+trinary

--- a/src/info/prob_specs_slugs.txt
+++ b/src/info/prob_specs_slugs.txt
@@ -118,7 +118,7 @@ yacht
 zebra-puzzle
 zipper
 
-[no-canonical-data]
+[without-canonical-data]
 bank-account
 dot-dsl
 error-handling

--- a/src/info/prob_specs_slugs.txt
+++ b/src/info/prob_specs_slugs.txt
@@ -1,4 +1,4 @@
-# Last updated: 2021-12-09T05:00:00Z
+# Last updated: 2021-12-18T05:00:00Z
 
 [with-canonical-data]
 accumulate

--- a/src/info/prob_specs_slugs.txt
+++ b/src/info/prob_specs_slugs.txt
@@ -1,4 +1,5 @@
 # Last updated: 2021-12-18T05:00:00Z
+# problem-specifications commit: ba9e4ed606f1ecb4206e1ee48471a37999cdc0cf
 
 [with-canonical-data]
 accumulate


### PR DESCRIPTION
When running `configlet info`, the list of unimplemented exercises on a
track previously included exercises that are deprecated in
`problem-specifications`. With this commit, we show only
non-deprecated exercises.

Example output before this PR:

    $ configlet info

    [...]

    There are 11 exercises from `exercism/problem-specifications` that are neither implemented nor in the track config `exercises.foregone` array:
    counter
    error-handling
    hangman
    ledger
    lens-person
    nucleotide-codons
    octal
    paasio
    point-mutations
    tree-building
    trinary

    [...]

With this PR:

    $ configlet info

    [...]

    There are 6 non-deprecated exercises in `exercism/problem-specifications` that
    are both unimplemented and not in the track config `exercises.foregone` array:
    error-handling
    hangman
    ledger
    lens-person
    paasio
    tree-building

    [...]

For now, we do this by parsing a simple custom file format. In the
future, we could stop baking the slugs into the binary: `configlet info`
could use a (cached) `problem-specifications` directory at run-time,
similar to `configlet sync`.

Closes: #473
