### PR TITLE
build: bump Nim from 1.6.0 to 1.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@7098c87428beed5a48148cfa8234e3e075881f46 # 1.3.15
         with:
-          nim-version: "1.6.0"
+          nim-version: "1.6.2"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@7098c87428beed5a48148cfa8234e3e075881f46 # 1.3.15
         with:
-          nim-version: "1.6.0"
+          nim-version: "1.6.2"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/config.nims
+++ b/config.nims
@@ -1,6 +1,6 @@
 switch("styleCheck", "hint")
 hint("Name", on)
-switch("experimental", "strictEffects")
+# switch("experimental", "strictEffects") # TODO: re-enable when possible with `parsetoml`
 switch("experimental", "strictFuncs")
 switch("define", "nimStrictDelete")
 

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -9,7 +9,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 1.6.0"
+requires "nim >= 1.6.2"
 requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"    # 1.5.19 (2021-09-13)
 requires "jsony#eb63a326b7f16537764c090f8859eb2451ad8d4d"     # 1.1.1  (2021-11-16)
 requires "parsetoml#9cdeb3f65fd10302da157db8a8bac5c42f055249" # 0.6.0  (2021-06-07)

--- a/src/patched_stdlib/json.nim
+++ b/src/patched_stdlib/json.nim
@@ -1,5 +1,5 @@
 # This file is minimally adapted from this version in the Nim standard library:
-# https://github.com/nim-lang/Nim/blob/58080525a1dc/lib/pure/json.nim
+# https://github.com/nim-lang/Nim/blob/fce89cb60a34/lib/pure/json.nim
 # The standard library version is lenient: it silently allows a trailing comma.
 # The below version is stricter: it raises a `JsonParsingError` for a trailing
 # comma.
@@ -454,7 +454,7 @@ macro `%*`*(x: untyped): untyped =
   ## `%` for every element.
   result = toJsonImpl(x)
 
-proc `==`*(a, b: JsonNode): bool =
+proc `==`*(a, b: JsonNode): bool {.noSideEffect.} =
   ## Check two nodes for equality
   if a.isNil:
     if b.isNil: return true
@@ -481,12 +481,16 @@ proc `==`*(a, b: JsonNode): bool =
       if a.fields.len != b.fields.len: return false
       for key, val in a.fields:
         if not b.fields.hasKey(key): return false
-        if b.fields[key] != val: return false
+        when defined(nimHasEffectsOf):
+          {.noSideEffect.}:
+            if b.fields[key] != val: return false
+        else:
+          if b.fields[key] != val: return false
       result = true
 
 proc hash*(n: OrderedTable[string, JsonNode]): Hash {.noSideEffect.}
 
-proc hash*(n: JsonNode): Hash =
+proc hash*(n: JsonNode): Hash {.noSideEffect.} =
   ## Compute the hash for a JSON node
   case n.kind
   of JArray:


### PR DESCRIPTION
See:
- https://nim-lang.org/blog/2021/12/17/version-162-released.html
- https://github.com/nim-lang/Nim/compare/v1.6.0...version-1-6
- https://forum.nim-lang.org/t/8717

Nim 1.6.2 supports Nimble 0.14 (which supports lockfiles) but does not ship with it.

If we want to merge #418 without waiting for Nim to release with that Nimble version, we'll have to install that Nimble ourselves in the build environment.

Please compare with the previous Nim version bump: https://github.com/exercism/configlet/pull/419

The CI failure seems like a regression in `strictEffects` with Nim 1.6.2. I've reported it upstream.