### PR TITLE
github: create only one draft release

### DIFF
--- a/.github/bin/publish-release
+++ b/.github/bin/publish-release
@@ -1,9 +1,8 @@
 #!/usr/bin/env sh
 
-latest_release_tag="$(gh release view --json tagName --jq '.tagName')"
 build_tag="$(echo "${REF}" | cut -d'/' -f3)"
 
-if [ "${latest_release_tag}" != "${build_tag}" ]; then
+if ! gh release view "${build_tag}"; then
   gh release create --draft "${build_tag}"
 fi
 gh release upload "${build_tag}" "${ARTIFACT_FILE}"


### PR DESCRIPTION
Even after commit a103ac4607d9, three draft releases were created during
the latest release build.

It looks like the flaw was that `gh release view` returns the latest
non-draft release, and so `gh release create --draft` always ran.

Fixes: #484

---

This time, I tested it better. It seems to work here: https://github.com/ee7/exercism-configlet/releases/tag/untagged-820ff06a337a5d420c03

It seems that `gh release view foo` returns an exit code of 0 when there is a draft release or release with the tag `foo`, and an exit code of 1 otherwise.