### PR TITLE
README: lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a development version of Configlet for use with v3 of Exercism.
 
 The application is a single binary and can be used as follows:
 
-```
+```text
 Usage:
   configlet [global-options] <command> [command-options]
 
@@ -84,26 +84,26 @@ A Practice Exercise that is derived from the `problem-specifications` repo must 
 
 To check every Practice Exercise on the track for available documentation updates (exiting with a non-zero exit code if at least one update is available):
 
-```
+```shell
 configlet sync --docs
 ```
 
 To interactively update the docs for every Practice Exercise, add the `--update` option (or `-u` for short):
 
-```
+```shell
 configlet sync --docs --update
 ```
 
 To non-interactively update the docs for every Practice Exercise, add the `--yes` option (or `-y` for short):
 
-```
+```shell
 configlet sync --docs --update --yes
 ```
 
 To operate on a single Practice Exercise, use the `--exercise` option (or `-e` for short).
 For example, to non-interactively update the docs for the `prime-factors` exercise:
 
-```
+```shell
 configlet sync --docs -uy -e prime-factors
 ```
 
@@ -114,26 +114,26 @@ For a Practice Exercise that is derived from the `problem-specifications` repo, 
 
 To check every Practice Exercise for available metadata updates (exiting with a non-zero exit code if at least one update is available):
 
-```
+```shell
 configlet sync --metadata
 ```
 
 To interactively update the metadata for every Practice Exercise, add the `--update` option (or `-u` for short):
 
-```
+```shell
 configlet sync --metadata --update
 ```
 
 To non-interactively update the metadata for every Practice Exercise, add the `--yes` option (or `-y` for short):
 
-```
+```shell
 configlet sync --metadata --update --yes
 ```
 
 To operate on a single Practice Exercise, use the `--exercise` option (or `-e` for short).
 For example, to non-interactively update the metadata for the `prime-factors` exercise:
 
-```
+```shell
 configlet sync --metadata -uy -e prime-factors
 ```
 
@@ -171,13 +171,13 @@ In this case, the track has chosen to implement two of the three available tests
 
 To check every Practice Exercise `tests.toml` file for available tests updates (exiting with a non-zero exit code if there is at least one test case that appears in the exercise's canonical data, but not in the `tests.toml`):
 
-```
+```shell
 configlet sync --tests
 ```
 
 To interactively update the `tests.toml` file for every Practice Exercise, add the `--update` option:
 
-```
+```shell
 configlet sync --tests --update
 ```
 
@@ -187,7 +187,7 @@ This means that you can terminate configlet at a prompt (for example, by pressin
 
 To non-interactively include every unseen test case, use `--tests include`. For example, to do so for an exercise named `prime-factors`:
 
-```
+```shell
 configlet sync --tests include -u -e prime-factors
 ```
 
@@ -201,7 +201,7 @@ Such filepaths usually follow a simple pattern, and so configlet can populate th
 
 To check that every Concept Exercise and Practice Exercise on the track has a fully populated `files` key (or at least one that cannot be populated from the track-level `files` key):
 
-```
+```shell
 configlet sync --filepaths
 ```
 
@@ -209,13 +209,13 @@ configlet sync --filepaths
 
 To populate empty/missing values of the exercise-level `files` key for every Concept Exercise and Practice Exercise from the patterns in the track-level `files` key:
 
-```
+```shell
 configlet sync --filepaths --update
 ```
 
 To do this non-interactively and for a single exercise named `prime-factors`:
 
-```
+```shell
 configlet sync --filepaths -uy -e prime-factors
 ```
 
@@ -252,26 +252,26 @@ and checks the formatting of the `.meta/config.json` file for every Concept Exer
 To print a list of paths for which there is not already a formatted exercise `.meta/config.json` file
 (exiting with a non-zero exit code if at least one exercise lacks a formatted config file):
 
-```
+```shell
 configlet fmt
 ```
 
 To be prompted to write formatted config files, add the `--update` option (or `-u` for short):
 
-```
+```shell
 configlet fmt --update
 ```
 
 To non-interactively write the formatted config files, add the `--yes` option (or `-y` for short):
 
-```
+```shell
 configlet fmt --update --yes
 ```
 
 To operate on a single exercise, use the `--exercise` option (or `-e` for short).
 For example, to non-interactively write the formatted config file for the `prime-factors` exercise:
 
-```
+```shell
 configlet fmt -uy -e prime-factors
 ```
 
@@ -293,7 +293,7 @@ When writing JSON files, `configlet fmt` will:
 
 The canonical key order for an exercise `.meta/config.json` file is:
 
-```
+```text
 - authors
 - [contributors]
 - files
@@ -325,13 +325,13 @@ The exit code is 0 when every seen exercise has a formatted `.meta/config.json` 
 
 Each exercise and concept has a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier), which must only appear once across all of Exercism. It must be a valid version 4 UUID (compliant with RFC 4122) in the canonical textual representation, which means that it must match the below regular expression:
 
-```
+```text
 ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
 ```
 
 You can run `configlet uuid` to output a new, appropriate UUID. There is also the `-n, --num` option for outputting multiple new UUIDs:
 
-```
+```console
 $ configlet uuid --num 5
 3823f890-be49-4700-baac-e19de8fda76f
 c12309a2-8bd6-4b9c-a511-e1ee4083f492
@@ -346,13 +346,13 @@ Each concept exercise and concept have an `introduction.md` file. If you want th
 
 Concept placeholders must use the following format:
 
-```
+```text
 %{concept:<slug>}
 ```
 
 For example, if the track has a concept named `floating-point-numbers` then an `introduction.md.tpl` file can contain:
 
-```
+```text
 %{concept:floating-point-numbers}
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,26 +85,26 @@ A Practice Exercise that is derived from the `problem-specifications` repo must 
 To check every Practice Exercise on the track for available documentation updates (exiting with a non-zero exit code if at least one update is available):
 
 ```
-$ configlet sync --docs
+configlet sync --docs
 ```
 
 To interactively update the docs for every Practice Exercise, add the `--update` option (or `-u` for short):
 
 ```
-$ configlet sync --docs --update
+configlet sync --docs --update
 ```
 
 To non-interactively update the docs for every Practice Exercise, add the `--yes` option (or `-y` for short):
 
 ```
-$ configlet sync --docs --update --yes
+configlet sync --docs --update --yes
 ```
 
 To operate on a single Practice Exercise, use the `--exercise` option (or `-e` for short).
 For example, to non-interactively update the docs for the `prime-factors` exercise:
 
 ```
-$ configlet sync --docs -uy -e prime-factors
+configlet sync --docs -uy -e prime-factors
 ```
 
 ### Metadata
@@ -115,26 +115,26 @@ For a Practice Exercise that is derived from the `problem-specifications` repo, 
 To check every Practice Exercise for available metadata updates (exiting with a non-zero exit code if at least one update is available):
 
 ```
-$ configlet sync --metadata
+configlet sync --metadata
 ```
 
 To interactively update the metadata for every Practice Exercise, add the `--update` option (or `-u` for short):
 
 ```
-$ configlet sync --metadata --update
+configlet sync --metadata --update
 ```
 
 To non-interactively update the metadata for every Practice Exercise, add the `--yes` option (or `-y` for short):
 
 ```
-$ configlet sync --metadata --update --yes
+configlet sync --metadata --update --yes
 ```
 
 To operate on a single Practice Exercise, use the `--exercise` option (or `-e` for short).
 For example, to non-interactively update the metadata for the `prime-factors` exercise:
 
 ```
-$ configlet sync --metadata -uy -e prime-factors
+configlet sync --metadata -uy -e prime-factors
 ```
 
 ### Tests
@@ -172,13 +172,13 @@ In this case, the track has chosen to implement two of the three available tests
 To check every Practice Exercise `tests.toml` file for available tests updates (exiting with a non-zero exit code if there is at least one test case that appears in the exercise's canonical data, but not in the `tests.toml`):
 
 ```
-$ configlet sync --tests
+configlet sync --tests
 ```
 
 To interactively update the `tests.toml` file for every Practice Exercise, add the `--update` option:
 
 ```
-$ configlet sync --tests --update
+configlet sync --tests --update
 ```
 
 For each missing test, this prompts the user to choose whether to include/exclude/skip it, and updates the corresponding `tests.toml` file accordingly.
@@ -188,7 +188,7 @@ This means that you can terminate configlet at a prompt (for example, by pressin
 To non-interactively include every unseen test case, use `--tests include`. For example, to do so for an exercise named `prime-factors`:
 
 ```
-$ configlet sync --tests include -u -e prime-factors
+configlet sync --tests include -u -e prime-factors
 ```
 
 Remember to actually implement these tests on the track!
@@ -202,7 +202,7 @@ Such filepaths usually follow a simple pattern, and so configlet can populate th
 To check that every Concept Exercise and Practice Exercise on the track has a fully populated `files` key (or at least one that cannot be populated from the track-level `files` key):
 
 ```
-$ configlet sync --filepaths
+configlet sync --filepaths
 ```
 
 (Note that `configlet lint` will also produce an error when an exercise has a missing/empty `files` key.)
@@ -210,13 +210,13 @@ $ configlet sync --filepaths
 To populate empty/missing values of the exercise-level `files` key for every Concept Exercise and Practice Exercise from the patterns in the track-level `files` key:
 
 ```
-$ configlet sync --filepaths --update
+configlet sync --filepaths --update
 ```
 
 To do this non-interactively and for a single exercise named `prime-factors`:
 
 ```
-$ configlet sync --filepaths -uy -e prime-factors
+configlet sync --filepaths -uy -e prime-factors
 ```
 
 ### Using `sync` when adding a new exercise to a track
@@ -253,26 +253,26 @@ To print a list of paths for which there is not already a formatted exercise `.m
 (exiting with a non-zero exit code if at least one exercise lacks a formatted config file):
 
 ```
-$ configlet fmt
+configlet fmt
 ```
 
 To be prompted to write formatted config files, add the `--update` option (or `-u` for short):
 
 ```
-$ configlet fmt --update
+configlet fmt --update
 ```
 
 To non-interactively write the formatted config files, add the `--yes` option (or `-y` for short):
 
 ```
-$ configlet fmt --update --yes
+configlet fmt --update --yes
 ```
 
 To operate on a single exercise, use the `--exercise` option (or `-e` for short).
 For example, to non-interactively write the formatted config file for the `prime-factors` exercise:
 
 ```
-$ configlet fmt -uy -e prime-factors
+configlet fmt -uy -e prime-factors
 ```
 
 When writing JSON files, `configlet fmt` will:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ There are three kinds of data that can be updated from `problem-specifications`:
 There is also one kind of data that can be populated from the track-level `config.json` file: filepaths in exercise config files.
 
 We describe the checking and updating of these data kinds in individual sections below, but as a quick summary:
+
 - `configlet sync` only operates on exercises that exist in the track-level `config.json` file. Therefore if you are implementing a new exercise on a track and want to add the initial files with `configlet sync`, please add the exercise to the track-level `config.json` file first. If the exercise is not yet ready to be user-facing, please set its `status` value to `wip`.
 - A plain `configlet sync` makes no changes to the track, and checks every data kind for every exercise.
 - To operate on a subset of data kinds, use some combination of the `--docs`, `--filepaths`, `--metadata`, and `--tests` options.
@@ -222,6 +223,7 @@ configlet sync --filepaths -uy -e prime-factors
 ### Using `sync` when adding a new exercise to a track
 
 The `sync` command is useful when adding a new exercise to a track. If you are adding a Practice Exercise named `foo` that exists in `problem-specifications`, one possible workflow is:
+
 1. Manually add an entry to the track-level `config.json` file for the exercise `foo`. This makes the exercise visible to `configlet sync`.
 1. Run `configlet sync --docs --filepaths --metadata -uy -e foo` to create the exercise's documentation, and a starter `.meta/config.json` file with populated `files`, `blurb`, and perhaps `source` and `source_url` values.
 1. Edit the exercise `.meta/config.json` file as desired. For example, add yourself to the `authors` array.

--- a/README.md
+++ b/README.md
@@ -368,4 +368,4 @@ Running one of these scripts downloads the latest version of configlet to the `b
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/exercism/configlet.
+Bug reports and pull requests are welcome on GitHub at <https://github.com/exercism/configlet>.


### PR DESCRIPTION
#462 included some markdown linting, but commits 1fd2a46fddfb and 4a88c133fe98 added a lot to the repo `README.md`, and introduced some markdown issues.

Let's fix these markdown issues in this PR, then rebase that PR on top.

Resolved `markdownlint` rule violations:

- [MD014](https://github.com/DavidAnson/markdownlint/blob/v0.24.0/doc/Rules.md#md014)
- [MD040](https://github.com/DavidAnson/markdownlint/blob/v0.24.0/doc/Rules.md#md040)
- [MD032](https://github.com/DavidAnson/markdownlint/blob/v0.24.0/doc/Rules.md#md032)
- [MD034](https://github.com/DavidAnson/markdownlint/blob/v0.24.0/doc/Rules.md#md034)