### PR TITLE
lint(track_config): speedup cycle checking slightly

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -427,7 +427,7 @@ proc checkForCycle(prerequisitesByConcept: Table[string, seq[string]];
   if hadCycle:
     return
 
-  let updatedPrereqPath = prereqPath & @[currentConcept]
+  let updatedPrereqPath = prereqPath & currentConcept
   if currentConcept in prereqPath:
     var formattedCycle = &"{q updatedPrereqPath[0]} depends on {q updatedPrereqPath[1]}"
     for i in 1..prereqPath.high:


### PR DESCRIPTION
We were using [concatenation of two sequences](https://github.com/nim-lang/Nim/blob/b812431f8317/lib/system.nim#L1672-L1686):

```Nim
proc `&`*[T](x, y: seq[T]): seq[T] {.noSideEffect.} =
  newSeq(result, x.len + y.len)
  for i in 0..x.len-1:
    result[i] = x[i]
  for i in 0..y.len-1:
    result[i+x.len] = y[i]
```

but we can use [the overload that appends one element](https://github.com/nim-lang/Nim/blob/b812431f8317/lib/system.nim#L1688-L1701):

```Nim
proc `&`*[T](x: seq[T], y: T): seq[T] {.noSideEffect.} =
  newSeq(result, x.len + 1)
  for i in 0..x.len-1:
    result[i] = x[i]
  result[x.len] = y
```


The Nim compiler doesn't optimize the creation+appending of a
one-element sequence into an append of the element. Somewhat similarly,
the compiler deliberately doesn't optimize `string1 = string1 & string2` -
it should be written as `string1.add string2` or `string1 &= string2`.

The concept cycle checking is a hotspot on tracks with a larger number
of Concept Exercises - for example, with the csharp track, about a third
of the `configlet lint` execution time was spent in `checkForCycle`.
This commit removes some unnecessary allocations within that hotspot,
and thereby produces a small (but measureable) `configlet lint` speedup
of 3-5% on such tracks. For the csharp track:

```shell
hyperfine -i \
  --warmup 100 \
  --runs 100 \
  -L binary configlet_before,configlet_after \
  './{binary} lint' \
  --export-markdown /tmp/bench_configlet_lint_csharp.md
```

| Command                   |  Mean [ms] | Min [ms] | Max [ms] |    Relative |
|:--------------------------|-----------:|---------:|---------:|:------------|
| `./configlet_before lint` | 39.9 ± 0.3 |     39.2 |     41.1 | 1.04 ± 0.01 |
| `./configlet_after lint`  | 38.5 ± 0.4 |     38.0 |     40.4 | 1.00        |