### PR TITLE
prefer `Foo.init` object construction style

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -313,17 +313,17 @@ func formatOpt(kind: CmdLineKind, key: string, val = ""): string =
     else:
       &"'{prefix}{key}'"
 
-func initAction*(actionKind: ActionKind, probSpecsDir = "",
-                 scope: set[SyncKind] = {}): Action =
+func init*(T: typedesc[Action], actionKind: ActionKind, probSpecsDir = "",
+           scope: set[SyncKind] = {}): T =
   case actionKind
   of actNil, actFmt, actGenerate, actInfo, actLint:
-    Action(kind: actionKind)
+    T(kind: actionKind)
   of actSync:
-    Action(kind: actionKind, probSpecsDir: probSpecsDir, scope: scope)
+    T(kind: actionKind, probSpecsDir: probSpecsDir, scope: scope)
   of actUuid:
-    Action(kind: actionKind, num: 1)
+    T(kind: actionKind, num: 1)
 
-func initConf*(action = initAction(actNil), trackDir = getCurrentDir(),
+func initConf*(action = Action.init(actNil), trackDir = getCurrentDir(),
                verbosity = verNormal): Conf =
   result = Conf(
     action: action,
@@ -402,7 +402,7 @@ proc parseVal[T: enum](kind: CmdLineKind, key: string, val: string): T =
 proc handleArgument(conf: var Conf; kind: CmdLineKind; key: string) =
   if conf.action.kind == actNil:
     let actionKind = parseActionKind(key)
-    let action = initAction(actionKind)
+    let action = Action.init(actionKind)
     conf = initConf(action, conf.trackDir, conf.verbosity)
   else:
     showError(&"invalid argument for command '{conf.action.kind}': '{key}'")

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -323,9 +323,9 @@ func init*(T: typedesc[Action], actionKind: ActionKind, probSpecsDir = "",
   of actUuid:
     T(kind: actionKind, num: 1)
 
-func initConf*(action = Action.init(actNil), trackDir = getCurrentDir(),
-               verbosity = verNormal): Conf =
-  result = Conf(
+func init*(T: typedesc[Conf], action = Action.init(actNil),
+           trackDir = getCurrentDir(), verbosity = verNormal): T =
+  T(
     action: action,
     trackDir: trackDir,
     verbosity: verbosity,
@@ -403,7 +403,7 @@ proc handleArgument(conf: var Conf; kind: CmdLineKind; key: string) =
   if conf.action.kind == actNil:
     let actionKind = parseActionKind(key)
     let action = Action.init(actionKind)
-    conf = initConf(action, conf.trackDir, conf.verbosity)
+    conf = Conf.init(action, conf.trackDir, conf.verbosity)
   else:
     showError(&"invalid argument for command '{conf.action.kind}': '{key}'")
 
@@ -491,7 +491,7 @@ proc handleOption(conf: var Conf; kind: CmdLineKind; key, val: string) =
                 &"{formatOpt(kind, key)}")
 
 proc processCmdLine*: Conf =
-  result = initConf()
+  result = Conf.init()
 
   for kind, key, val in getopt(shortNoVal = shortNoVal, longNoVal = longNoVal):
     case kind

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -46,8 +46,8 @@ proc init(T: typedesc[ExerciseTests],
     else:
       result.missing.incl uuid
 
-proc newExerciseTestCase(testCase: ProbSpecsTestCase): ExerciseTestCase =
-  ExerciseTestCase(
+proc new(T: typedesc[ExerciseTestCase], testCase: ProbSpecsTestCase): T =
+  T(
     uuid: uuid(testCase),
     description: description(testCase),
     json: testCase,
@@ -68,7 +68,7 @@ proc init(T: typedesc[ExerciseTestCases],
   var hasReimplementation = false
 
   for i, testCase in testCases:
-    result[i] = newExerciseTestCase(testCase)
+    result[i] = ExerciseTestCase.new(testCase)
     if testCase.isReimplementation():
       hasReimplementation = true
 

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -35,7 +35,7 @@ func init(T: typedesc[ExerciseTests]): T =
 
 proc init(T: typedesc[ExerciseTests],
           practiceExerciseTests: PracticeExerciseTests,
-          probSpecsTestCases: seq[ProbSpecsTestCase]): T =
+          probSpecsTestCases: ProbSpecsTestCases): T =
   result = ExerciseTests.init()
   for testCase in probSpecsTestCases:
     let uuid = uuid(testCase)
@@ -53,7 +53,7 @@ proc new(T: typedesc[ExerciseTestCase], testCase: ProbSpecsTestCase): T =
     json: testCase,
   )
 
-proc getReimplementations(testCases: seq[ProbSpecsTestCase]): Table[string, string] =
+proc getReimplementations(testCases: ProbSpecsTestCases): Table[string, string] =
   for testCase in testCases:
     if testCase.isReimplementation():
       result[testCase.uuid()] = testCase.reimplements()
@@ -62,8 +62,7 @@ func uuidToTestCase(testCases: ExerciseTestCases): Table[string, ExerciseTestCas
   for testCase in testCases:
     result[testCase.uuid] = testCase
 
-proc init(T: typedesc[ExerciseTestCases],
-          testCases: seq[ProbSpecsTestCase]): T =
+proc init(T: typedesc[ExerciseTestCases], testCases: ProbSpecsTestCases): T =
   result = newSeq[ExerciseTestCase](testCases.len)
   var hasReimplementation = false
 

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -11,6 +11,8 @@ type
     json*: ProbSpecsTestCase
     reimplements*: Option[ExerciseTestCase]
 
+  ExerciseTestCases = seq[ExerciseTestCase]
+
   ExerciseTests* {.requiresInit.} = object
     included*: HashSet[string]
     excluded*: HashSet[string]
@@ -22,7 +24,7 @@ type
   Exercise* {.requiresInit.} = object
     slug*: PracticeExerciseSlug
     tests*: ExerciseTests
-    testCases*: seq[ExerciseTestCase]
+    testCases*: ExerciseTestCases
 
 func init(T: typedesc[ExerciseTests]): T =
   T(
@@ -56,11 +58,12 @@ proc getReimplementations(testCases: seq[ProbSpecsTestCase]): Table[string, stri
     if testCase.isReimplementation():
       result[testCase.uuid()] = testCase.reimplements()
 
-func uuidToTestCase(testCases: seq[ExerciseTestCase]): Table[string, ExerciseTestCase] =
+func uuidToTestCase(testCases: ExerciseTestCases): Table[string, ExerciseTestCase] =
   for testCase in testCases:
     result[testCase.uuid] = testCase
 
-proc initExerciseTestCases(testCases: seq[ProbSpecsTestCase]): seq[ExerciseTestCase] =
+proc init(T: typedesc[ExerciseTestCases],
+          testCases: seq[ProbSpecsTestCase]): T =
   result = newSeq[ExerciseTestCase](testCases.len)
   var hasReimplementation = false
 
@@ -87,7 +90,7 @@ iterator findExercises*(conf: Conf, probSpecsDir: ProbSpecsDir): Exercise {.inli
       yield Exercise(
         slug: practiceExercise.slug,
         tests: ExerciseTests.init(practiceExercise.tests, testCases),
-        testCases: initExerciseTestCases(testCases),
+        testCases: ExerciseTestCases.init(testCases),
       )
     else:
       yield Exercise(

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -24,16 +24,17 @@ type
     tests*: ExerciseTests
     testCases*: seq[ExerciseTestCase]
 
-func initExerciseTests: ExerciseTests =
-  ExerciseTests(
+func init(T: typedesc[ExerciseTests]): T =
+  T(
     included: initHashSet[string](),
     excluded: initHashSet[string](),
     missing: initHashSet[string](),
   )
 
-proc initExerciseTests(practiceExerciseTests: PracticeExerciseTests,
-                       probSpecsTestCases: seq[ProbSpecsTestCase]): ExerciseTests =
-  result = initExerciseTests()
+proc init(T: typedesc[ExerciseTests],
+          practiceExerciseTests: PracticeExerciseTests,
+          probSpecsTestCases: seq[ProbSpecsTestCase]): T =
+  result = ExerciseTests.init()
   for testCase in probSpecsTestCases:
     let uuid = uuid(testCase)
     if uuid in practiceExerciseTests.included:
@@ -85,13 +86,13 @@ iterator findExercises*(conf: Conf, probSpecsDir: ProbSpecsDir): Exercise {.inli
       let testCases = getCanonicalTests(probSpecsDir, practiceExercise.slug.string)
       yield Exercise(
         slug: practiceExercise.slug,
-        tests: initExerciseTests(practiceExercise.tests, testCases),
+        tests: ExerciseTests.init(practiceExercise.tests, testCases),
         testCases: initExerciseTestCases(testCases),
       )
     else:
       yield Exercise(
         slug: practiceExercise.slug,
-        tests: initExerciseTests(),
+        tests: ExerciseTests.init(),
         testCases: @[],
       )
 

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -8,7 +8,7 @@ type
 
   ProbSpecsTestCase* = distinct JsonNode
 
-  ProbSpecsTestCases = seq[ProbSpecsTestCase]
+  ProbSpecsTestCases* = seq[ProbSpecsTestCase]
 
 proc `$`(dir: ProbSpecsDir): string {.borrow.}
 proc dirExists(dir: ProbSpecsDir): bool {.borrow.}

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -145,11 +145,11 @@ proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
         showError("the given problem-specifications directory is not " &
                   &"up-to-date: '{probSpecsDir}'")
 
-proc initProbSpecsDir*(conf: Conf): ProbSpecsDir =
+proc init*(T: typedesc[ProbSpecsDir], conf: Conf): T =
   if conf.action.probSpecsDir.len > 0:
-    result = ProbSpecsDir(conf.action.probSpecsDir)
+    result = T(conf.action.probSpecsDir)
     validate(result, conf)
   else:
-    result = ProbSpecsDir(getCurrentDir() / ".problem-specifications")
+    result = T(getCurrentDir() / ".problem-specifications")
     removeDir(result)
     cloneExercismRepo("problem-specifications", result.string, shallow = true)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -69,10 +69,12 @@ proc parseProbSpecsTestCases(probSpecsExerciseDir: ProbSpecsExerciseDir): ProbSp
   ## Parses the `canonical-data.json` file for the given exercise, and returns
   ## a seq of, essentially, the JsonNode for each test.
   let canonicalJsonPath = canonicalDataFile(probSpecsExerciseDir)
-  if slug(probSpecsExerciseDir) == "grains":
-    ProbSpecsTestCases.init(canonicalJsonPath.grainsWorkaround())
-  else:
-    ProbSpecsTestCases.init(canonicalJsonPath.parseFile())
+  let j =
+    if slug(probSpecsExerciseDir) == "grains":
+      canonicalJsonPath.grainsWorkaround()
+    else:
+      canonicalJsonPath.parseFile()
+  result = ProbSpecsTestCases.init(j)
 
 proc getCanonicalTests*(probSpecsDir: ProbSpecsDir,
                         slug: string): ProbSpecsTestCases =

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -91,7 +91,7 @@ proc syncImpl(conf: Conf): set[SyncKind] =
     if conf.action.scope == {skFilepaths}:
       ProbSpecsDir("this_will_not_be_used")
     else:
-      initProbSpecsDir(conf)
+      ProbSpecsDir.init(conf)
 
   try:
     let psExercisesDir = probSpecsDir / "exercises"

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -54,16 +54,16 @@ proc getPracticeExerciseSlugs(trackDir: TrackDir): seq[PracticeExerciseSlug] =
 
   sort result
 
-func initPracticeExerciseTests: PracticeExerciseTests =
-  PracticeExerciseTests(
+func init(T: typedesc[PracticeExerciseTests]): T =
+  T(
     included: initHashSet[string](),
     excluded: initHashSet[string](),
   )
 
-proc initPracticeExerciseTests(testsPath: string): PracticeExerciseTests =
+proc init(T: typedesc[PracticeExerciseTests], testsPath: string): T =
   ## Parses the `tests.toml` file at `testsPath` and returns HashSets of the
   ## included and excluded test case UUIDs.
-  result = initPracticeExerciseTests()
+  result = PracticeExerciseTests.init()
   if fileExists(testsPath):
     let tests = parsetoml.parseFile(testsPath)
 
@@ -96,10 +96,10 @@ iterator findPracticeExercises*(conf: Conf): PracticeExercise {.inline.} =
         let testsPath = testsPath(trackDir, slug)
         yield PracticeExercise(
           slug: slug,
-          tests: initPracticeExerciseTests(testsPath),
+          tests: PracticeExerciseTests.init(testsPath),
         )
       else:
         yield PracticeExercise(
           slug: slug,
-          tests: initPracticeExerciseTests(),
+          tests: PracticeExerciseTests.init(),
         )

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -32,7 +32,7 @@ proc main =
 
       let action = Action.init(actSync, probSpecsPath)
       let conf = Conf.init(action)
-      let probSpecsDir = initProbSpecsDir(conf)
+      let probSpecsDir = ProbSpecsDir.init(conf)
       let probSpecsExercises = getProbSpecsExercises(probSpecsDir)
 
       test "can return the exercises":

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -31,7 +31,7 @@ proc main =
         of psExisting: existingDir
 
       let action = Action.init(actSync, probSpecsPath)
-      let conf = initConf(action)
+      let conf = Conf.init(action)
       let probSpecsDir = initProbSpecsDir(conf)
       let probSpecsExercises = getProbSpecsExercises(probSpecsDir)
 

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -30,7 +30,7 @@ proc main =
         of psFresh: ""
         of psExisting: existingDir
 
-      let action = initAction(actSync, probSpecsPath)
+      let action = Action.init(actSync, probSpecsPath)
       let conf = initConf(action)
       let probSpecsDir = initProbSpecsDir(conf)
       let probSpecsExercises = getProbSpecsExercises(probSpecsDir)

--- a/tests/test_tracks.nim
+++ b/tests/test_tracks.nim
@@ -12,7 +12,7 @@ proc main =
                       "736245965db724cafc5ec8e9dcae83c850b7c5a8") # 2021-10-22
 
     let conf = Conf(
-      action: initAction(actSync, scope = {skTests}),
+      action: Action.init(actSync, scope = {skTests}),
       trackDir: trackDir,
     )
     let practiceExercises = toSeq findPracticeExercises(conf)


### PR DESCRIPTION
This commit makes our object construction style in older code consistent with the style that I used in the newer sync code (1fd2a46fddfb):

https://github.com/exercism/configlet/blob/9296b431572af4306e07b0a0696e5813204f17e4/src/sync/sync.nim#L40-L44

https://github.com/exercism/configlet/blob/9296b431572af4306e07b0a0696e5813204f17e4/src/sync/sync_filepaths.nim#L78-L88

People have differing opinions on Nim object construction style (and I haven't fully got used to the style in this PR myself) but this is at least more DRY. One advantage is for refactoring: if you want to rename a type from `Foo` to `Bar`, you no longer also need to rename the constructor from `initFoo` to `initBar`.

With this PR, we use the `Foo.init` and `Foo.new` style everywhere (excluding the patched `json.nim` and `parsejson.nim`):
```console
$ git grep --heading --break -E '(proc|func) (init|new)' -- :^src/patched_stdlib
src/cli.nim
316:func init*(T: typedesc[Action], actionKind: ActionKind, probSpecsDir = "",
326:func init*(T: typedesc[Conf], action = Action.init(actNil),

src/lint/track_config.nim
321:proc init*(T: typedesc[TrackConfig]; trackConfigContents: string): T =

src/sync/exercises.nim
29:func init(T: typedesc[ExerciseTests]): T =
36:proc init(T: typedesc[ExerciseTests],
49:proc new(T: typedesc[ExerciseTestCase], testCase: ProbSpecsTestCase): T =
65:proc init(T: typedesc[ExerciseTestCases], testCases: ProbSpecsTestCases): T =

src/sync/probspecs.nim
41:proc init(T: typedesc[ProbSpecsTestCases], node: JsonNode, prefix = ""): T =
152:proc init*(T: typedesc[ProbSpecsDir], conf: Conf): T =

src/sync/sync.nim
40:func init*(T: typedesc[TrackExerciseSlugs], exercises: Exercises): T =

src/sync/sync_filepaths.nim
78:proc init*(T: typedesc[ExerciseConfig], kind: ExerciseKind,

src/sync/tracks.nim
57:func init(T: typedesc[PracticeExerciseTests]): T =
63:proc init(T: typedesc[PracticeExerciseTests], testsPath: string): T =
```

---

An alternative style is like the below (note the underscore):

```Nim
type
  Foo = object
    bar: int

proc init(_: typedesc[Foo], bar: int): Foo =
  Foo(bar: bar)
``` 

But this repeats the type name. 

See also:
- https://forum.nim-lang.org/t/8819
- https://status-im.github.io/nim-style-guide/language.objconstr.html