### PR TITLE
sync: fix null handling when updating filepaths/metadata

### DIFF
--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -490,20 +490,23 @@ proc pretty*(e: ConceptExerciseConfig | PracticeExerciseConfig,
     of eckAuthors:
       result.addArray("authors", e.authors)
     of eckContributors:
-      result.addArray("contributors", e.contributors.get())
+      if e.contributors.isSome():
+        result.addArray("contributors", e.contributors.get())
     of eckFiles:
       result.addFiles(e.files, prettyMode)
     of eckLanguageVersions:
       result.addString("language_versions", e.language_versions)
     of eckForkedFrom:
       when e is ConceptExerciseConfig:
-        result.addArray("forked_from", e.forked_from.get())
+        if e.forked_from.isSome():
+          result.addArray("forked_from", e.forked_from.get())
     of eckIcon:
       when e is ConceptExerciseConfig:
         result.addString("icon", e.icon)
     of eckTestRunner:
       when e is PracticeExerciseConfig:
-        result.addBool("test_runner", e.test_runner.get())
+        if e.test_runner.isSome():
+          result.addBool("test_runner", e.test_runner.get())
     of eckBlurb:
       result.addString("blurb", e.blurb)
     of eckSource:
@@ -511,6 +514,7 @@ proc pretty*(e: ConceptExerciseConfig | PracticeExerciseConfig,
     of eckSourceUrl:
       result.addString("source_url", e.source_url)
     of eckCustom:
-      result.addObject("custom", e.custom.get())
+      if e.custom.isSome():
+        result.addObject("custom", e.custom.get())
   result.removeComma()
   result.add "\n}\n"

--- a/tests/test_sync.nim
+++ b/tests/test_sync.nim
@@ -303,6 +303,24 @@ proc testSyncCommon =
       check:
         exerciseConfig.pretty(pmSync) == expected
 
+    test "pretty: can use `pmSync` when an optional key has the value `null`":
+      let exerciseConfig = PracticeExerciseConfig(
+        originalKeyOrder: @[eckContributors],
+        contributors: none(seq[string])
+      )
+      const expected = """{
+        "authors": [],
+        "files": {
+          "solution": [],
+          "test": [],
+          "example": []
+        },
+        "blurb": ""
+      }
+      """.dedent(6)
+      check:
+        exerciseConfig.pretty(pmSync) == expected
+
     proc stdlibSerialize(path: string): string =
       var j = json.parseFile(path)
       for key in j.keys():


### PR DESCRIPTION
Before this commit, when updating a `.meta/config.json` file that
contained an optional key with the value of `null`, configlet would
produce an `UnpackDefect`. For example:

    git clone https://github.com/exercism/common-lisp
    cd common-lisp
    git checkout 4fc524e24a69
    configlet sync --metadata -e binary -u
    Checking exercises...
    Cloning https://github.com/exercism/problem-specifications/... success
    [warn] metadata: unsynced: binary
    sync the above metadata ([y]es/[n]o)? y
    options.nim(194)         get
    Error: unhandled exception: Can't obtain a value from a `none` [UnpackDefect]

For now, let's resolve the problem by stripping any optional key with
the value of `null` when updating filepaths or metadata.

Fixes: #500