### PR TITLE
lint: clarify message about updating configlet

### DIFF
--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -24,7 +24,8 @@ proc allChecksPass(trackDir: Path): bool =
 proc lint*(conf: Conf) =
   echo """
     The lint command is under development.
-    Please re-run this command regularly to see if your track passes the latest linting rules.
+    To check your track using the latest linting rules,
+    please regularly update configlet and re-run this command.
   """.unindent()
 
   let trackDir = Path(conf.trackDir)


### PR DESCRIPTION
The previous message implied that running `configlet lint` without
updating `configlet` would use the latest linting rules.