### PR TITLE
tests(binary): test that README contains help message

### DIFF
--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -1050,14 +1050,13 @@ proc main =
         for line in outp.strip.splitLines:
           check line.isUuidV4
 
-  suite "README":
-    test "README contains help message":
-      var (outp, _) = execCmdEx(&"{binaryPath} --help")
-      let readmeContents = readFile(repoRootDir / "README.md")
-      when defined(windows):
-        outp = outp.replace("configlet.exe", "configlet")
-      check:
-        outp in readmeContents
+  when not defined(windows): # Ignore differences due to ".exe" and line endings.
+    suite "README":
+      test "README contains help message":
+        let (outp, _) = execCmdEx(&"{binaryPath} --help")
+        let readmeContents = readFile(repoRootDir / "README.md")
+        check:
+          outp in readmeContents
 
   testsForSync(binaryPath)
 

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -1050,6 +1050,13 @@ proc main =
         for line in outp.strip.splitLines:
           check line.isUuidV4
 
+  suite "README":
+    test "README contains help message":
+      let (outp, _) = execCmdEx(&"{binaryPath} --help")
+      let readmeContents = readFile(repoRootDir / "README.md")
+      check:
+        outp in readmeContents
+
   testsForSync(binaryPath)
 
   testsForGenerate(binaryPath)

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -1052,8 +1052,10 @@ proc main =
 
   suite "README":
     test "README contains help message":
-      let (outp, _) = execCmdEx(&"{binaryPath} --help")
+      var (outp, _) = execCmdEx(&"{binaryPath} --help")
       let readmeContents = readFile(repoRootDir / "README.md")
+      when defined(windows):
+        outp = outp.replace("configlet.exe", "configlet")
       check:
         outp in readmeContents
 


### PR DESCRIPTION
This ensures that we update the repo README after the `configlet --help`
message changes.

Closes: #73