### PR TITLE
cli: avoid the word "generate" in uuid help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Options for sync:
                                Allowed values: c[hoose], i[nclude], e[xclude] (default: choose)
 
 Options for uuid:
-  -n, --num <int>              Number of UUIDs to generate
+  -n, --num <int>              Number of UUIDs to output
 
 Global options:
   -h, --help                   Show this help message and exit

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -211,7 +211,7 @@ func genHelpText: string =
     optSyncTests: &"Sync Practice Exercise '.meta/tests.toml' files.\n" &
                   &"{paddingOpt}The mode value specifies how missing tests are handled when using --{$optFmtSyncUpdate}.\n" &
                   &"{paddingOpt}{allowedValues(TestsMode)} (default: choose)",
-    optUuidNum: "Number of UUIDs to generate",
+    optUuidNum: "Number of UUIDs to output",
   ]
 
   result = "Commands:\n"


### PR DESCRIPTION
This removes potential for confusion with `configlet generate`.

---

A bit nitpick-y, but worthwhile?

Another reason: if `configlet uuid` is ever updated to just "read" from a system UUID provider (see #424), we might say that it no longer "generates" the UUIDs.