### PR TITLE
cli: set help text at compile time

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -214,7 +214,14 @@ func genHelpText: string =
     optUuidNum: "Number of UUIDs to output",
   ]
 
-  result = "Commands:\n"
+  const binaryExt = when defined(windows): ".exe" else: ""
+
+  result = fmt"""
+    Usage:
+      configlet{binaryExt} [global-options] <command> [command-options]
+
+    Commands:
+  """.dedent(4)
 
   for action in ActionKind:
     if action != actNil:
@@ -261,11 +268,7 @@ func genHelpText: string =
 
 proc showHelp(exitCode: range[0..255] = 0) =
   const helpText = genHelpText()
-  let appName = extractFilename(getAppFilename())
-  let usage = "Usage:\n" &
-              &"  {appName} [global-options] <command> [command-options]\n"
   let f = if exitCode == 0: stdout else: stderr
-  f.writeLine usage
   f.writeLine helpText
   if f == stdout:
     f.flushFile()


### PR DESCRIPTION
Before this commit, the name of the executable in the help message was
set at execution time. That is, renaming the configlet executable to
`foo` and then running `foo --help` would produce a help message that
begins:

    Usage:
      foo [global-options] <command> [command-options]

We don't need to support this, so let's set the name of the application
at compile time. This saves a call to `getAppFilename`, and makes it
cleaner to add a short description of configlet to the top of the help
message in the future.

---

This commit doesn't change the help message under normal circumstances (as shown by the test added in 8b67417667e9).