### PR TITLE
build: bump Nim from 1.6.2 to 1.6.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@5f0615c23aa478a77d895b5044748a62b5397eca # 1.3.32
         with:
-          nim-version: "1.6.2"
+          nim-version: "1.6.4"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Nim
         uses: jiro4989/setup-nim-action@5f0615c23aa478a77d895b5044748a62b5397eca # 1.3.32
         with:
-          nim-version: "1.6.2"
+          nim-version: "1.6.4"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -9,7 +9,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 1.6.2"
+requires "nim >= 1.6.4"
 requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"    # 1.5.19 (2021-09-13)
 requires "jsony#eb63a326b7f16537764c090f8859eb2451ad8d4d"     # 1.1.1  (2021-11-16)
 requires "parsetoml#9cdeb3f65fd10302da157db8a8bac5c42f055249" # 0.6.0  (2021-06-07)


### PR DESCRIPTION
~Creating this in advance.~

~1.6.4 rc1 was released - see https://forum.nim-lang.org/t/8839~

~CI is expected to fail until it's actually released.~

---

See:
- Blog post: https://nim-lang.org/blog/2022/02/08/version-164-released.html
- Forum post: https://forum.nim-lang.org/t/8887
- Changes: https://github.com/nim-lang/Nim/compare/v1.6.2...v1.6.4 (no changes in `json.nim` or `parsejson.nim` for us to port)

Previous Nim bump PR: #480