### PR TITLE
lint: support error annotations

### DIFF
--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -25,7 +25,7 @@ proc getSortedSubdirs*(dir: Path): seq[Path] =
       result.add Path(path)
   sort result
 
-proc setFalseAndPrint*(b: var bool; description: string; path: Path) =
+proc setFalseAndPrint*(b: var bool; description: string; path: Path, annotation = "") =
   ## Sets `b` to `false` and writes a message to stdout containing `description`
   ## and `path`.
   b = false
@@ -35,6 +35,11 @@ proc setFalseAndPrint*(b: var bool; description: string; path: Path) =
   else:
     stdout.writeLine(descriptionPrefix)
   stdout.writeLine(path.string)
+  if annotation.len > 0:
+    if colorStdout:
+      stdout.styledWriteLine(fgYellow, annotation)
+    else:
+      stdout.writeLine(descriptionPrefix, annotation)
   stdout.write "\n"
 
 var printedWarning* = false


### PR DESCRIPTION
This PR adds support for linting errors to also print an annotation,
which can be used to give more detailed information on a certain
linting rule validation error.

For example, the following is now printed when the `tags` key in the
track's `config.json` file does not validate:

```
The `tags` array is empty:
../csharp/config.json
Tracks are annotated with tags to allow searching for tracks with certain tags.
The tags should be chosen based on the general usage of their language.
For more information and the full list of supported tags see:
https://exercism.org/docs/building/tracks/config-json#h-tags
```

Note that the first line ("The `tags` array is empty:") is output in the color red, while the annotation lines are printed in yellow.