### PR TITLE
lint: add error annotations for tags and key features

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -175,17 +175,52 @@ const keyFeatureIcons = [
 ].toHashSet()
 
 proc isValidKeyFeature(data: JsonNode; context: string; path: Path): bool =
+  const iconErrorAnnotation = """
+    A key feature's `icon` is shown for the feature when presented on the website.
+    The icon must be chosen from our list of supported icons:
+    https://exercism.org/docs/building/tracks/icons#h-key-feature-icons
+    You can choose any icon that you think fits, regardless of its name.
+
+    For more information on key features see:
+    https://exercism.org/docs/building/tracks/config-json#h-key-features""".unindent()
+
+  const titleErrorAnnotation = """
+    A key feature's `title` is a concise header for the key feature.
+    As little technical jargon as possible should be used.
+    Its length must be <= 25 and Markdown is not supported.
+
+    For more information on key features see:
+    https://exercism.org/docs/building/tracks/config-json#h-key-features""".unindent()
+
+  const contentErrorAnnotation = """
+    A key feature's `content` is a description of the key feature.
+    Its length must be <= 100 and Markdown is not supported.
+
+    For more information on key features see:
+    https://exercism.org/docs/building/tracks/config-json#h-key-features""".unindent()
+ 
   if isObject(data, context, path):
     let checks = [
-      hasString(data, "icon", path, context, allowed = keyFeatureIcons),
-      hasString(data, "title", path, context, maxLen = 25),
-      hasString(data, "content", path, context, maxLen = 100),
+      hasString(data, "icon", path, context, allowed = keyFeatureIcons,
+                errorAnnotation = iconErrorAnnotation),
+      hasString(data, "title", path, context, maxLen = 25,
+                errorAnnotation = titleErrorAnnotation),
+      hasString(data, "content", path, context, maxLen = 100,
+                errorAnnotation = contentErrorAnnotation),
     ]
     result = allTrue(checks)
 
 proc hasValidKeyFeatures(data: JsonNode; path: Path): bool =
+  const errorAnnotation = """
+    The key features succinctly describe the most important features
+    of the language to promote the language to potential students.
+    Exactly 6 key features must be specified.
+
+    For more information on key features see:
+    https://exercism.org/docs/building/tracks/config-json#h-key-features""".unindent()
   result = hasArrayOf(data, "key_features", path, isValidKeyFeature,
-                      isRequired = false, allowedLength = 6..6)
+                      isRequired = false, allowedLength = 6..6,
+                      errorAnnotation = errorAnnotation)
 
 const tags = [
   "paradigm/declarative",

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -228,8 +228,14 @@ const tags = [
 ].toHashSet()
 
 proc hasValidTags(data: JsonNode; path: Path): bool =
+  const errorAnnotation = """
+    Tracks are annotated with tags to allow searching for tracks with certain tags.
+    Tags must be chosen from our list of supported tags.
+    Tags should be selected based on the general usage of their language.
+    For more information on tags and the list of supported tags see:
+    https://exercism.org/docs/building/tracks/config-json#h-tags""".unindent()
   result = hasArrayOfStrings(data, "tags", path, allowed = tags,
-                             uniqueValues = true)
+                             uniqueValues = true, errorAnnotation = errorAnnotation)
 
 proc satisfiesFirstPass(data: JsonNode; path: Path): bool =
   ## Returns `true` if `data` passes the first round of checks for a track-level

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -300,7 +300,7 @@ proc isString*(data: JsonNode; key: string; path: Path; context: string;
               &"A {format(context, key)} value is {q s}, which is not a " &
               &"valid file pattern. Allowed placeholders are: {placeholders}"
             result.setFalseAndPrint(msg, path, annotation = errorAnnotation)
-        if not hasValidRuneLength(s, key, path, context, maxLen):
+        if not hasValidRuneLength(s, key, path, context, maxLen, errorAnnotation = errorAnnotation):
           result = false
       else:
         let msg =


### PR DESCRIPTION
- validation: allow printing an annotation for error message
- validation: allow passing an error annotation to validation functions
- lint: add annotation for tags in config.json
