### PR TITLE
lint: link to docs on exercism.org, not GitHub

### DIFF
--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -30,7 +30,7 @@ proc lint*(conf: Conf) =
 
   let trackDir = Path(conf.trackDir)
 
-  const url = "https://github.com/exercism/docs/blob/main/building/configlet/lint.md"
+  const url = "https://exercism.org/docs/building/configlet/lint"
 
   if allChecksPass(trackDir):
     echo """


### PR DESCRIPTION
Better to link to exercism.org everywhere, I guess?

Follow-up from https://github.com/exercism/configlet/pull/517#pullrequestreview-884706384