### PR TITLE
Allow file pattern overlap exceptions

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -666,6 +666,7 @@ proc checkExerciseSlugsAndForegone(exercises: Exercises; b: var bool;
 
 proc checkFilePatternsOverlap(filePatterns: FilePatterns; trackSlug: string,
                               b: var bool; path: Path) =
+  const overlappingSolutionTestTrackSlugs = ["d", "plsql"]
   const uniqueFilePatternCombinations = [
     ("solution", "test"),
     ("solution", "example"),
@@ -683,6 +684,9 @@ proc checkFilePatternsOverlap(filePatterns: FilePatterns; trackSlug: string,
     seenFilePatterns[key] = patterns.toHashSet
 
   for (key1, key2) in uniqueFilePatternCombinations:
+    if key1 == "solution" and key2 == "test" and trackSlug in overlappingSolutionTestTrackSlugs:
+      continue
+
     let duplicatePatterns = seenFilePatterns[key1] * seenFilePatterns[key2]
     for duplicatePattern in duplicatePatterns:
       let msg =

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -229,7 +229,6 @@ func list(a: SomeSet[string]; prefix = ""; suffix = ""): string =
       result.add ", and "
 
 var seenUuids = initHashSet[string](250)
-var seenFilePatterns = initHashSet[string](250)
 
 proc isString*(data: JsonNode; key: string; path: Path; context: string;
                isRequired = true; allowed = emptySetOfStrings;
@@ -282,11 +281,6 @@ proc isString*(data: JsonNode; key: string; path: Path; context: string;
                "lowercased version 4 UUID"
             result.setFalseAndPrint(msg, path, annotation = errorAnnotation)
         elif checkIsFilesPattern:
-          if seenFilePatterns.containsOrIncl(s):
-            let msg =
-              &"A {format(context, key)} value is {q s}, which is not a unique " &
-               "`files` entry"
-            result.setFalseAndPrint(msg, path, annotation = errorAnnotation)
           if isFilesPattern(s):
             if "%{" in s and "}" notin s:
               let msg =


### PR DESCRIPTION
- lint: allow overlap of `files.example` and `files.exemplar` values
- lint: allow overlap of solution and test files for `d` and `plsql` tracks

See https://github.com/exercism/docs/pull/321/files
