### PR TITLE
bump_version, tag_release: add tagging script

### DIFF
--- a/bin/bump_version.nim
+++ b/bin/bump_version.nim
@@ -15,10 +15,10 @@
 import std/[os, osproc, strformat, strscans, strutils]
 
 type
-  BumpError = object of CatchableError
+  BumpError* = object of CatchableError
   BumpQuit = object of CatchableError
 
-proc error(msg: string) =
+proc error*(msg: string) =
   ## Raises a `BumpError`.
   raise newException(BumpError, msg)
 
@@ -27,7 +27,7 @@ proc exit0(msg: string) =
   raise newException(BumpQuit, msg)
 
 type
-  Command = enum
+  Command* = enum
     GitAdd = "git add"
     GitBranch = "git branch"
     GitCheckout = "git checkout"
@@ -40,6 +40,7 @@ type
     GitPush = "git push"
     GitRemote = "git remote"
     GitRevParse = "git rev-parse"
+    GitTag = "git tag"
     GhPr = "gh pr"
 
 proc exec(command: Command; args: openArray[string] = []): (string, int) =
@@ -52,8 +53,8 @@ proc exec(command: Command; args: openArray[string] = []): (string, int) =
     cmd.add quoteShell(arg)
   result = execCmdEx(cmd)
 
-proc execAndCheck(command: Command; args: openArray[string] = [];
-                  errorMsg = ""): string =
+proc execAndCheck*(command: Command; args: openArray[string] = [];
+                   errorMsg = ""): string =
   ## Runs the given command with `args` and returns the output (without a final
   ## newline).
   ##
@@ -69,7 +70,7 @@ proc execAndCheck(command: Command; args: openArray[string] = [];
       error(&"""the exit code was non-zero: {command} {args.join(" ")}""")
   stripLineEnd result
 
-proc getGitHubRemoteName(owner, repo: static string): string =
+proc getGitHubRemoteName*(owner, repo: static string): string =
   ## Returns the name of the remote that points to `github.com/owner/repo`.
   ##
   ## Raises `BumpError` if there is no such remote.
@@ -82,7 +83,7 @@ proc getGitHubRemoteName(owner, repo: static string): string =
       return remoteName
   error(&"there is no remote that points to '{url}'")
 
-proc checkRepoState =
+proc checkRepoState* =
   ## Raises `BumpError` if any of these is not satisfied:
   ## - There are no changes in the working directory.
   ## - We can switch to the `main` branch.

--- a/bin/tag_release.nim
+++ b/bin/tag_release.nim
@@ -1,0 +1,61 @@
+#!/usr/bin/env -S nim r --verbosity:0 --skipParentCfg:on
+
+## Running this file will:
+## 1. Switch to the `main` branch, if there are no uncommitted changes (exiting
+##    otherwise).
+## 2. Pull the upstream `main` branch from github.com/exercism/configlet.
+## 3. Check that the local `main` branch is not ahead of upstream.
+## 4. Check that the most recent commit on the `main` branch is an untagged
+##    release commit.
+## 5. Prompt the user to tag the commit and push the tag to exercism/configlet,
+##    which will trigger a build job and create a draft release.
+import std/[strformat, strscans, strutils]
+import "."/bump_version
+
+proc checkRepoIsInPreTagState: string =
+  ## Returns the to-be-tagged version.
+  checkRepoState()
+  let commitTitle = execAndCheck(GitLog, ["-n1", "--format='%s'"])
+  let (isMatch, version, _) = commitTitle.scanTuple("release: $+ (#$i)$.")
+  if isMatch:
+    let existingTag = execAndCheck(GitTag, ["--points-at"])
+    if existingTag.len > 0:
+      error(&"the commit has already been tagged: {existingTag}")
+    result = version
+  else:
+    error(&"the most recent commit on branch 'main' is not a release commit:\n    {commitTitle}")
+
+proc promptToTagAndPush(version: string) =
+  while true:
+    stderr.write "tag the current commit and push the tag to exercism/configlet? ([y]es/[n]o) "
+    case stdin.readLine().toLowerAscii()
+    of "y", "yes":
+      discard execAndCheck(GitTag, ["-a", "-m", version, version])
+      let remote = getGitHubRemoteName("exercism", "configlet")
+      discard execAndCheck(GitPush, [remote, version])
+      echo &"Successfully pushed tag for {version}"
+      echo """
+        Remaining steps to release:
+        1. Edit the release notes to contain the list of user-facing changes,
+           separating by features and bug fixes.
+        2. Wait for every build job to finish.
+        3. Check that CI is green.
+        4. Un-draft the release.
+      """.unindent()
+      return
+    of "n", "no":
+      return
+    else:
+      stderr.writeLine "unrecognized choice. Try again."
+
+proc main =
+  try:
+    let bumpedVersion = checkRepoIsInPreTagState()
+    promptToTagAndPush(bumpedVersion)
+  except BumpError:
+    let msg = getCurrentExceptionMsg()
+    stderr.writeLine &"Error: {msg}"
+    quit 1
+
+when isMainModule:
+  main()

--- a/bin/tag_release.nim
+++ b/bin/tag_release.nim
@@ -17,7 +17,7 @@ proc getVersionFromLatestCommitMessage: string =
   ##
   ## Raises `BumpError` if the repo does not have a valid pre-tagging state.
   checkRepoState()
-  let commitTitle = execAndCheck(GitLog, ["-n1", "--format='%s'"])
+  let commitTitle = execAndCheck(GitLog, ["-n1", "--format=%s"])
   let (isMatch, version, _) = commitTitle.scanTuple("release: $+ (#$i)$.")
   if isMatch:
     let existingTag = execAndCheck(GitTag, ["--points-at"])

--- a/bin/tag_release.nim
+++ b/bin/tag_release.nim
@@ -12,8 +12,10 @@
 import std/[strformat, strscans, strutils]
 import "."/bump_version
 
-proc checkRepoIsInPreTagState: string =
+proc getVersionFromLatestCommitMessage: string =
   ## Returns the to-be-tagged version.
+  ##
+  ## Raises `BumpError` if the repo does not have a valid pre-tagging state.
   checkRepoState()
   let commitTitle = execAndCheck(GitLog, ["-n1", "--format='%s'"])
   let (isMatch, version, _) = commitTitle.scanTuple("release: $+ (#$i)$.")
@@ -62,7 +64,7 @@ proc promptToTagAndPush(version: string) =
 
 proc main =
   try:
-    let bumpedVersion = checkRepoIsInPreTagState()
+    let bumpedVersion = getVersionFromLatestCommitMessage()
     promptToTagAndPush(bumpedVersion)
   except BumpError:
     let msg = getCurrentExceptionMsg()

--- a/bin/tag_release.nim
+++ b/bin/tag_release.nim
@@ -38,15 +38,14 @@ proc promptToTagAndPush(version: string) =
       discard execAndCheck(GitTag, ["-a", "-m", version, version])
       try:
         discard execAndCheck(GitPush, [remote, version])
-        echo &"Successfully pushed tag for {version}"
+        echo &"Successfully pushed tag for {version}\n"
         echo """
           Remaining steps to release:
           1. Edit the release notes to contain the list of user-facing changes,
-            separating by features and bug fixes.
+             separating by features and bug fixes.
           2. Wait for every build job to finish.
           3. Check that CI is green.
-          4. Un-draft the release.
-        """.unindent()
+          4. Un-draft the release.""".dedent()
         return
       except BumpError:
         # Delete the newly-added tag if we could not push, so we do not end in

--- a/bin/tag_release.nim
+++ b/bin/tag_release.nim
@@ -49,7 +49,7 @@ proc promptToTagAndPush(version: string) =
       except BumpError:
         # Delete the newly-added tag if we could not push, so we do not end in
         # an intermediate state. The script either successfully tags and pushes,
-        # or returns us to the initial state.
+        # or returns us to the untagged state.
         echo "Failed to push the tag. Deleting it."
         echo "Please check your network connection, and that you have write " &
              "access to exercism/configlet, then re-run this script."

--- a/bin/tag_release.nim
+++ b/bin/tag_release.nim
@@ -23,11 +23,13 @@ proc checkRepoIsInPreTagState: string =
       error(&"the commit has already been tagged: {existingTag}")
     result = version
   else:
-    error(&"the most recent commit on branch 'main' is not a release commit:\n    {commitTitle}")
+    error("the most recent commit on branch 'main' is not a release commit:\n" &
+          &"    {commitTitle}")
 
 proc promptToTagAndPush(version: string) =
   while true:
-    stderr.write "tag the current commit and push the tag to exercism/configlet? ([y]es/[n]o) "
+    stderr.write "Tag the latest commit on the 'main' branch and push the " &
+                 "tag to exercism/configlet? ([y]es/[n]o) "
     case stdin.readLine().toLowerAscii()
     of "y", "yes":
       discard execAndCheck(GitTag, ["-a", "-m", version, version])


### PR DESCRIPTION
I always did the tagging part manually, but here's an attempted script for it. 

With this PR, the entire release process can be:
1. Run `bin/bump_version.nim`
2. Merge the PR created by the above step
3. Run `bin/tag_release.nim`
4. Follow the instructions printed by the above step:

> Remaining steps to release:
> 1. Edit the release notes to contain the list of user-facing changes,
>    separating by features and bug fixes.
> 2. Wait for every build job to finish.
> 3. Check that CI is green.
> 4. Un-draft the release.

Refs: #523 