### PR TITLE
github(workflows): remove version comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # 2.4.0
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
 
       - name: Install Nim
-        uses: jiro4989/setup-nim-action@ebde5392eb73447228c5c53792cd209d798cdcf3 # 1.3.41
+        uses: jiro4989/setup-nim-action@ebde5392eb73447228c5c53792cd209d798cdcf3
         with:
           nim-version: "1.6.4"
 

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # 2.4.0
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@744f913a124058ee903768d3adb92a4847e5d132 # 5.1.0
+        uses: DavidAnson/markdownlint-cli2-action@744f913a124058ee903768d3adb92a4847e5d132
         with:
           globs: "**/*.md"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # 2.4.0
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
 
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9 # 1.1.0
+        uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,10 @@ jobs:
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # 2.4.0
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
 
       - name: Install Nim
-        uses: jiro4989/setup-nim-action@ebde5392eb73447228c5c53792cd209d798cdcf3 # 1.3.41
+        uses: jiro4989/setup-nim-action@ebde5392eb73447228c5c53792cd209d798cdcf3
         with:
           nim-version: "1.6.4"
 


### PR DESCRIPTION
These comments can be helpful, but dependabot doesn't support them -
they have to be bumped manually in dependabot PRs. To remove the burden
of keeping the comments in sync, let's just remove them.

---

I'd like to merge this today, before dependabot creates PRs tomorrow (the first of the month).

With this PR:
```console
$ git grep --break --heading '@' -- .github/workflows
.github/workflows/build.yml
36:        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
39:        uses: jiro4989/setup-nim-action@ebde5392eb73447228c5c53792cd209d798cdcf3

.github/workflows/markdownlint.yml
11:        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
14:        uses: DavidAnson/markdownlint-cli2-action@744f913a124058ee903768d3adb92a4847e5d132

.github/workflows/shellcheck.yml
11:        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
14:        uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9

.github/workflows/sync:labels.yml
19:    uses: exercism/github-actions/.github/workflows/labels.yml@main

.github/workflows/tests.yml
41:        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
44:        uses: jiro4989/setup-nim-action@ebde5392eb73447228c5c53792cd209d798cdcf3
```