### PR TITLE
remove trailing whitespace

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -198,7 +198,7 @@ proc isValidKeyFeature(data: JsonNode; context: string; path: Path): bool =
 
     For more information on key features see:
     https://exercism.org/docs/building/tracks/config-json#h-key-features""".unindent()
- 
+
   if isObject(data, context, path):
     let checks = [
       hasString(data, "icon", path, context, allowed = keyFeatureIcons,
@@ -717,7 +717,7 @@ proc checkFilePatternsOverlap(filePatterns: FilePatterns; trackSlug: string,
     ("test", "exemplar"),
     ("test", "editor"),
     ("editor", "example"),
-    ("editor", "exemplar"),    
+    ("editor", "exemplar"),
   ]
 
   var seenFilePatterns = initTable[string, HashSet[string]](250)
@@ -790,7 +790,7 @@ proc checkExerciseDirsAndTrackConfigAreInSync(trackDir: Path; data: JsonNode;
   ## Sets `b` to `false` if there is an exercise directory that is
   ## not an exercise `slug` in `data` and vice versa.
   for exerciseKind in ["concept", "practice"]:
-    let exerciseSlugs = getExerciseSlugs(data, exerciseKind)    
+    let exerciseSlugs = getExerciseSlugs(data, exerciseKind)
     let exercisesDir = trackDir / "exercises" / exerciseKind
     var exerciseDirSlugs = initHashSet[string]()
 

--- a/src/lint/validators.nim
+++ b/src/lint/validators.nim
@@ -419,7 +419,7 @@ proc hasArrayOfFiles*(data: JsonNode;
                       key: string;
                       path: Path;
                       context = "";
-                      relativeToPath: Path;                      
+                      relativeToPath: Path;
                       errorAnnotation = ""): bool =
   if hasArrayOfStrings(data, key, path, context):
     result = true


### PR DESCRIPTION
With this PR, the following command produces no output when run in the repo root directory.

```shell
git grep -r '[[:blank:]]$'
```

The commits that added the whitespace:
- [`a71637f`](https://github.com/exercism/configlet/commit/a71637f7c46cbd42e28f04bcbae52590e3a67fe3#diff-102d5f2912d17ee5540fbbbc4884ab571929bffc35a5d9c4b24dbe9bca240d32R201) lint: add annotation for key features in config.json
- [`fea7bcc`](https://github.com/exercism/configlet/commit/fea7bccd8f5b56cedf74aa7cc27594d4f4778efe#diff-102d5f2912d17ee5540fbbbc4884ab571929bffc35a5d9c4b24dbe9bca240d32R678) lint: allow overlap of `files.example` and `files.exemplar` values
- [`d0cd08c`](https://github.com/exercism/configlet/commit/d0cd08cce8b405be9526f5c53537237a86521c26#diff-102d5f2912d17ee5540fbbbc4884ab571929bffc35a5d9c4b24dbe9bca240d32R793) lint: error on missing concept/exercise files
- [`3a55f57`](https://github.com/exercism/configlet/commit/3a55f57acdab06da02d48b63e9c809bb36102e42#diff-1cb0fd6d875cb2d69997fcb4b1e0b0cce76911cf21256d19a5bc09ee064de61cR428) lint: support error annotations