### PR TITLE
logger: refactor

### DIFF
--- a/src/configlet.nim
+++ b/src/configlet.nim
@@ -8,7 +8,7 @@ proc main =
 
   let conf = processCmdLine()
 
-  setupLogging(conf)
+  setupLogging(conf.verbosity)
 
   case conf.action.kind
   of actNil:

--- a/src/logger.nim
+++ b/src/logger.nim
@@ -8,7 +8,8 @@ func levelThreshold(verbosity: Verbosity): Level =
   of verDetailed: lvlInfo
 
 proc setupLogging*(conf: Conf) =
-  let consoleLogger = newConsoleLogger(levelThreshold = levelThreshold(conf.verbosity), fmtStr = "")
+  let consoleLogger = newConsoleLogger(levelThreshold = levelThreshold(conf.verbosity),
+                                       fmtStr = "")
   addHandler(consoleLogger)
 
 proc logNormal*(conf: varargs[string]) =

--- a/src/logger.nim
+++ b/src/logger.nim
@@ -12,8 +12,8 @@ proc setupLogging*(conf: Conf) =
                                        fmtStr = "")
   addHandler(consoleLogger)
 
-proc logNormal*(msgs: varargs[string]) =
+template logNormal*(msgs: varargs[string]) =
   notice(msgs)
 
-proc logDetailed*(msgs: varargs[string]) =
+template logDetailed*(msgs: varargs[string]) =
   info(msgs)

--- a/src/logger.nim
+++ b/src/logger.nim
@@ -12,8 +12,8 @@ proc setupLogging*(conf: Conf) =
                                        fmtStr = "")
   addHandler(consoleLogger)
 
-proc logNormal*(conf: varargs[string]) =
-  notice(conf)
+proc logNormal*(msgs: varargs[string]) =
+  notice(msgs)
 
-proc logDetailed*(conf: varargs[string]) =
-  info(conf)
+proc logDetailed*(msgs: varargs[string]) =
+  info(msgs)

--- a/src/logger.nim
+++ b/src/logger.nim
@@ -1,14 +1,14 @@
 import std/logging
 import "."/cli
 
-func levelThreshold(verbosity: Verbosity): Level =
+func toLevel(verbosity: Verbosity): Level =
   case verbosity
   of verQuiet: lvlNone
   of verNormal: lvlNotice
   of verDetailed: lvlInfo
 
 proc setupLogging*(verbosity: Verbosity) =
-  let consoleLogger = newConsoleLogger(levelThreshold = levelThreshold(verbosity),
+  let consoleLogger = newConsoleLogger(levelThreshold = toLevel(verbosity),
                                        fmtStr = "")
   addHandler(consoleLogger)
 

--- a/src/logger.nim
+++ b/src/logger.nim
@@ -7,8 +7,8 @@ func levelThreshold(verbosity: Verbosity): Level =
   of verNormal: lvlNotice
   of verDetailed: lvlInfo
 
-proc setupLogging*(conf: Conf) =
-  let consoleLogger = newConsoleLogger(levelThreshold = levelThreshold(conf.verbosity),
+proc setupLogging*(verbosity: Verbosity) =
+  let consoleLogger = newConsoleLogger(levelThreshold = levelThreshold(verbosity),
                                        fmtStr = "")
   addHandler(consoleLogger)
 


### PR DESCRIPTION
Summary:
- Clarify that `setupLogging` only needs only the verbosity information
  from `conf`.
- Improve proc name.
- Shorten a long line.
- Fix `conf` parameter name.
- Use `template` for logging routines. Before this commit, arguments to
  `logNormal` and `logDetailed` were evaluated even if the logging level
  is such that the message is not printed. Note that the underlying
  `notice` and `info` are both templates.

From the [template section of the Nim Tutorial (Part II)](https://nim-lang.org/docs/tut2.html#templates):

> Templates are especially useful for lazy evaluation purposes.
> Consider a simple proc for logging:
>
> ```nim
> const debug = true
>       
> proc log(msg: string) {.inline.} =
>   if debug: stdout.writeLine(msg)
>       
> var x = 4
> log("x has the value: " & $x)
> ```
>
> This code has a shortcoming: if `debug` is set to `false` someday,
> the quite expensive `$` and `&` operations are still performed!
> (The argument evaluation for procedures is eager).
>
> Turning the `log` proc into a template solves this problem.