### PR TITLE
nimble: bump `cligen` from 1.5.19 to 1.5.23

### DIFF
--- a/configlet.nimble
+++ b/configlet.nimble
@@ -10,7 +10,7 @@ bin           = @["configlet"]
 
 # Dependencies
 requires "nim >= 1.6.4"
-requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"    # 1.5.19 (2021-09-13)
+requires "cligen#cac47b08172978dad61d08debd0e68c3f249a3f7"    # 1.5.23 (2022-03-22)
 requires "jsony#eb63a326b7f16537764c090f8859eb2451ad8d4d"     # 1.1.1  (2021-11-16)
 requires "parsetoml#9cdeb3f65fd10302da157db8a8bac5c42f055249" # 0.6.0  (2021-06-07)
 requires "uuids#8cb8720b567c6bcb261bd1c0f7491bdb5209ad06"     # 0.1.11 (2021-01-15)


### PR DESCRIPTION
See:
- https://github.com/c-blake/cligen/blob/e791bda4159c/RELEASE-NOTES.md
- https://github.com/c-blake/cligen/compare/v1.5.19...v1.5.23