### PR TITLE
nimble: bump `jsony` from 1.1.1 to 1.1.3

### DIFF
--- a/configlet.nimble
+++ b/configlet.nimble
@@ -11,7 +11,7 @@ bin           = @["configlet"]
 # Dependencies
 requires "nim >= 1.6.4"
 requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"    # 1.5.19 (2021-09-13)
-requires "jsony#eb63a326b7f16537764c090f8859eb2451ad8d4d"     # 1.1.1  (2021-11-16)
+requires "jsony#2a2cc4331720b7695c8b66529dbfea6952727e7b"     # 1.1.3  (2022-01-03)
 requires "parsetoml#9cdeb3f65fd10302da157db8a8bac5c42f055249" # 0.6.0  (2021-06-07)
 requires "uuids#8cb8720b567c6bcb261bd1c0f7491bdb5209ad06"     # 0.1.11 (2021-01-15)
 # To make Nimble use the pinned `isaac` version, we must pin `isaac` after `uuids`


### PR DESCRIPTION
Links:
- https://github.com/treeform/jsony/compare/1.1.1...1.1.3
- https://github.com/treeform/jsony/releases/tag/1.1.2
- https://github.com/treeform/jsony/releases/tag/1.1.3
