### PR TITLE
sync: cache prob-specs repo, and remove `--prob-specs-dir` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Options for fmt:
 Options for sync:
   -e, --exercise <slug>        Only operate on this exercise
   -o, --offline                Do not update the cached 'problem-specifications' data
-  -u, --update                 Prompt to update the seen data that are unsynced
+  -u, --update                 Prompt to update the seen track data that are unsynced
   -y, --yes                    Auto-confirm prompts from --update for updating docs, filepaths, and metadata
       --docs                   Sync Practice Exercise '.docs/introduction.md' and '.docs/instructions.md' files
       --filepaths              Populate empty 'files' values in Concept/Practice exercise '.meta/config.json' files

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Global options:
   -t, --track-dir <dir>        Specify a track directory to use instead of the current directory
   -v, --verbosity <verbosity>  The verbosity of output.
                                Allowed values: q[uiet], n[ormal], d[etailed] (default: normal)
-
 ```
 
 ## `configlet lint`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Options for fmt:
 Options for sync:
   -e, --exercise <slug>        Only operate on this exercise
   -o, --offline                Do not update the cached 'problem-specifications' data
-  -u, --update                 Prompt to update the seen track data that are unsynced
+  -u, --update                 Prompt to update the unsynced track data
   -y, --yes                    Auto-confirm prompts from --update for updating docs, filepaths, and metadata
       --docs                   Sync Practice Exercise '.docs/introduction.md' and '.docs/instructions.md' files
       --filepaths              Populate empty 'files' values in Concept/Practice exercise '.meta/config.json' files

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Options for fmt:
 
 Options for sync:
   -e, --exercise <slug>        Only operate on this exercise
-  -o, --offline                Do not check that the cached 'problem-specifications' directory is up to date
+  -o, --offline                Do not update the cached 'problem-specifications' data
   -u, --update                 Prompt to update the seen data that are unsynced
   -y, --yes                    Auto-confirm prompts from --update for updating docs, filepaths, and metadata
       --docs                   Sync Practice Exercise '.docs/introduction.md' and '.docs/instructions.md' files

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Options for fmt:
 
 Options for sync:
   -e, --exercise <slug>        Only operate on this exercise
-  -p, --prob-specs-dir <dir>   Use this 'problem-specifications' directory, rather than cloning temporarily
-  -o, --offline                Do not check that the directory specified by --prob-specs-dir is up to date
+  -o, --offline                Do not check that the cached 'problem-specifications' directory is up to date
   -u, --update                 Prompt to update the seen data that are unsynced
   -y, --yes                    Auto-confirm prompts from --update for updating docs, filepaths, and metadata
       --docs                   Sync Practice Exercise '.docs/introduction.md' and '.docs/instructions.md' files
@@ -46,6 +45,7 @@ Global options:
   -t, --track-dir <dir>        Specify a track directory to use instead of the current directory
   -v, --verbosity <verbosity>  The verbosity of output.
                                Allowed values: q[uiet], n[ormal], d[etailed] (default: normal)
+
 ```
 
 ## `configlet lint`

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -197,7 +197,7 @@ func genHelpText: string =
     optVerbosity: &"The verbosity of output.\n" &
                   &"{paddingOpt}{allowedValues(Verbosity)} (default: normal)",
     optFmtSyncExercise: "Only operate on this exercise",
-    optFmtSyncUpdate: "Prompt to update the seen data that are unsynced",
+    optFmtSyncUpdate: "Prompt to update the seen track data that are unsynced",
     optFmtSyncYes: &"Auto-confirm prompts from --{$optFmtSyncUpdate} for updating docs, filepaths, and metadata",
     optSyncOffline: "Do not update the cached 'problem-specifications' data",
     optSyncDocs: "Sync Practice Exercise '.docs/introduction.md' and '.docs/instructions.md' files",

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -197,7 +197,7 @@ func genHelpText: string =
     optVerbosity: &"The verbosity of output.\n" &
                   &"{paddingOpt}{allowedValues(Verbosity)} (default: normal)",
     optFmtSyncExercise: "Only operate on this exercise",
-    optFmtSyncUpdate: "Prompt to update the seen track data that are unsynced",
+    optFmtSyncUpdate: "Prompt to update the unsynced track data",
     optFmtSyncYes: &"Auto-confirm prompts from --{$optFmtSyncUpdate} for updating docs, filepaths, and metadata",
     optSyncOffline: "Do not update the cached 'problem-specifications' data",
     optSyncDocs: "Sync Practice Exercise '.docs/introduction.md' and '.docs/instructions.md' files",

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -199,7 +199,7 @@ func genHelpText: string =
     optFmtSyncExercise: "Only operate on this exercise",
     optFmtSyncUpdate: "Prompt to update the seen data that are unsynced",
     optFmtSyncYes: &"Auto-confirm prompts from --{$optFmtSyncUpdate} for updating docs, filepaths, and metadata",
-    optSyncOffline: "Do not check that the cached 'problem-specifications' directory is up to date",
+    optSyncOffline: "Do not update the cached 'problem-specifications' data",
     optSyncDocs: "Sync Practice Exercise '.docs/introduction.md' and '.docs/instructions.md' files",
     optSyncFilepaths: "Populate empty 'files' values in Concept/Practice exercise '.meta/config.json' files",
     optSyncMetadata: "Sync Practice Exercise '.meta/config.json' metadata values",

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -35,7 +35,6 @@ type
       yesFmt*: bool
     of actSync:
       exercise*: string
-      probSpecsDir*: string
       offline*: bool
       update*: bool
       yes*: bool
@@ -67,7 +66,6 @@ type
     optFmtSyncYes = "yes"
 
     # Options for `sync`
-    optSyncProbSpecsDir = "probSpecsDir"
     optSyncOffline = "offline"
     # Scope to sync
     optSyncDocs = "docs"
@@ -148,7 +146,6 @@ func genHelpText: string =
         of optVerbosity: "verbosity"
         of optFmtSyncExercise: "slug"
         of optSyncTests: "mode"
-        of optSyncProbSpecsDir: "dir"
         of optUuidNum: "int"
         else: ""
 
@@ -202,10 +199,7 @@ func genHelpText: string =
     optFmtSyncExercise: "Only operate on this exercise",
     optFmtSyncUpdate: "Prompt to update the seen data that are unsynced",
     optFmtSyncYes: &"Auto-confirm prompts from --{$optFmtSyncUpdate} for updating docs, filepaths, and metadata",
-    optSyncProbSpecsDir: "Use this 'problem-specifications' directory, " &
-                         "rather than cloning temporarily",
-    optSyncOffline: "Do not check that the directory specified by " &
-                    &"--{camelToKebab($optSyncProbSpecsDir)} is up to date",
+    optSyncOffline: "Do not check that the cached 'problem-specifications' directory is up to date",
     optSyncDocs: "Sync Practice Exercise '.docs/introduction.md' and '.docs/instructions.md' files",
     optSyncFilepaths: "Populate empty 'files' values in Concept/Practice exercise '.meta/config.json' files",
     optSyncMetadata: "Sync Practice Exercise '.meta/config.json' metadata values",
@@ -328,13 +322,13 @@ func formatOpt(kind: CmdLineKind, key: string, val = ""): string =
     else:
       &"'{prefix}{key}'"
 
-func init*(T: typedesc[Action], actionKind: ActionKind, probSpecsDir = "",
+func init*(T: typedesc[Action], actionKind: ActionKind,
            scope: set[SyncKind] = {}): T =
   case actionKind
   of actNil, actFmt, actGenerate, actInfo, actLint:
     T(kind: actionKind)
   of actSync:
-    T(kind: actionKind, probSpecsDir: probSpecsDir, scope: scope)
+    T(kind: actionKind, scope: scope)
   of actUuid:
     T(kind: actionKind, num: 1)
 
@@ -476,8 +470,6 @@ proc handleOption(conf: var Conf; kind: CmdLineKind; key, val: string) =
       of optSyncTests:
         setActionOpt(tests, parseVal[TestsMode](kind, key, val))
         conf.action.scope.incl skTests
-      of optSyncProbSpecsDir:
-        setActionOpt(probSpecsDir, val)
       of optSyncOffline:
         setActionOpt(offline, true)
       of optSyncDocs, optSyncMetadata, optSyncFilepaths:

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -388,7 +388,7 @@ proc parseOption(kind: CmdLineKind, key: string, val: string): Opt =
   except ValueError:
     if keyNormalized in ["p", "probspecsdir"]:
       const msg = """
-        The --prob-specs-dir option was removed in configlet 4.0.0-alpha.38 (April 2022).
+        The --prob-specs-dir option was removed in configlet 4.0.0-beta.1 (April 2022).
         A plain `configlet sync` now caches the cloned problem-specifications locally at
         a fixed location - there is no longer an option to configure the prob-specs location.
         This means that you can use --offline without specifying the prob-specs location,

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -389,11 +389,11 @@ proc parseOption(kind: CmdLineKind, key: string, val: string): Opt =
     if keyNormalized in ["p", "probspecsdir"]:
       const msg = """
         The --prob-specs-dir option was removed in configlet 4.0.0-beta.1 (April 2022).
-        A plain `configlet sync` now caches the cloned problem-specifications locally at
-        a fixed location - there is no longer an option to configure the prob-specs location.
-        This means that you can use --offline without specifying the prob-specs location,
-        as long as you have run a `configlet sync` command without --offline at least once
-        on your machine.""".unindent()
+        A plain `configlet sync` now caches the cloned problem-specifications in your
+        user's cache directory - there is no longer an option to configure the location.
+        Performing an offline sync now requires only one option (--offline), but you
+        must first run a `configlet sync` command without --offline at least once on
+        your machine.""".unindent()
       stderr.writeLine msg
     showError(&"invalid option: {formatOpt(kind, key)}")
 

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -386,6 +386,15 @@ proc parseOption(kind: CmdLineKind, key: string, val: string): Opt =
     if val.len == 0 and result notin optsNoVal and result != optSyncTests:
       showError(&"{formatOpt(kind, key)} was given without a value")
   except ValueError:
+    if keyNormalized in ["p", "probspecsdir"]:
+      const msg = """
+        The --prob-specs-dir option was removed in configlet 4.0.0-alpha.38 (April 2022).
+        A plain `configlet sync` now caches the cloned problem-specifications locally at
+        a fixed location - there is no longer an option to configure the prob-specs location.
+        This means that you can use --offline without specifying the prob-specs location,
+        as long as you have run a `configlet sync` command without --offline at least once
+        on your machine.""".unindent()
+      stderr.writeLine msg
     showError(&"invalid option: {formatOpt(kind, key)}")
 
 proc parseVal[T: enum](kind: CmdLineKind, key: string, val: string): T =

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -128,14 +128,14 @@ proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
                      "problem-specifications working directory is not clean: " &
                      &"'{probSpecsDir}'")
 
-    # Find the name of the remote that points to upstream. Don't assume the
-    # remote is called 'upstream'.
-    # Exit if the repo has no remote that points to upstream.
-    const upstreamHost = "github.com"
-    const upstreamLocation = "exercism/problem-specifications"
-    let remoteName = getNameOfRemote(probSpecsDir, upstreamHost, upstreamLocation)
-
     if not conf.action.offline:
+      # Find the name of the remote that points to upstream. Don't assume the
+      # remote is called 'upstream'.
+      # Exit if the repo has no remote that points to upstream.
+      const upstreamHost = "github.com"
+      const upstreamLocation = "exercism/problem-specifications"
+      let remoteName = getNameOfRemote(probSpecsDir, upstreamHost, upstreamLocation)
+
       # `fetch` and `merge` separately, for better error messages.
       logNormal(&"Running 'git pull' in cached problem-specifications dir...")
       discard gitCheck(0, ["fetch", "--quiet", remoteName, mainBranchName],

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -109,7 +109,7 @@ proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
   ## `problem-specifications` repo that is up-to-date with upstream.
   const mainBranchName = "main"
 
-  logDetailed(&"Using cached problem-specifications dir: {probSpecsDir}")
+  logDetailed(&"Using cached 'problem-specifications' dir: {probSpecsDir}")
 
   withDir probSpecsDir.string:
     # Validate the `problem-specifications` repo by checking the ref of the root
@@ -153,7 +153,7 @@ proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
       let remoteName = getNameOfRemote(probSpecsDir, upstreamHost, upstreamLocation)
 
       # `fetch` and `merge` separately, for better error messages.
-      logNormal(&"Updating cached problem-specifications data...")
+      logNormal(&"Updating cached 'problem-specifications' data...")
       discard gitCheck(0, ["fetch", "--quiet", remoteName, mainBranchName],
                        &"failed to fetch '{mainBranchName}' in " &
                        &"problem-specifications directory: '{probSpecsDir}'")

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -155,7 +155,7 @@ proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
       # `fetch` and `merge` separately, for better error messages.
       logNormal(&"Running 'git pull' in cached problem-specifications dir...")
       discard gitCheck(0, ["fetch", "--quiet", remoteName, mainBranchName],
-                       &"failed to fetch `{mainBranchName}` in " &
+                       &"failed to fetch '{mainBranchName}' in " &
                        &"problem-specifications directory: '{probSpecsDir}'")
 
       discard gitCheck(0, ["merge", "--ff-only", &"{remoteName}/{mainBranchName}"],

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -133,6 +133,7 @@ proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
     if not conf.action.offline:
       # For now, just exit with an error if the HEAD is not up-to-date with
       # upstream, even if it's possible to do a fast-forward merge.
+      logNormal(&"Running 'git pull' in cached problem-specifications dir...")
       discard gitCheck(0, ["fetch", "--quiet", remoteName, mainBranchName],
                        &"failed to fetch `{mainBranchName}` in " &
                        &"problem-specifications directory: '{probSpecsDir}'")

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -145,9 +145,9 @@ proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
                        &"failed to checkout '{mainBranchName}' in the cached " &
                        &"problem-specifications directory: '{probSpecsDir}'")
 
-      # Find the name of the remote that points to upstream. Don't assume the
-      # remote is called 'upstream'.
-      # Exit if the repo has no remote that points to upstream.
+      # Find the name of the remote that points to exercism/problem-specifications.
+      # Don't assume the remote is named 'origin'.
+      # Exit if the repo has no such remote.
       const upstreamHost = "github.com"
       const upstreamLocation = "exercism/problem-specifications"
       let remoteName = getNameOfRemote(probSpecsDir, upstreamHost, upstreamLocation)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -86,8 +86,8 @@ proc getCanonicalTests*(probSpecsDir: ProbSpecsDir,
   if fileExists(probSpecsExerciseDir.canonicalDataFile()):
     result = parseProbSpecsTestCases(probSpecsExerciseDir)
 
-proc getNameOfRemote(probSpecsDir: ProbSpecsDir;
-                     host, location: string): string =
+proc getNameOfRemote*(probSpecsDir: ProbSpecsDir;
+                      host, location: string): string =
   ## Returns the name of the remote in `probSpecsDir` that points to `location`
   ## at `host`.
   ##
@@ -95,7 +95,7 @@ proc getNameOfRemote(probSpecsDir: ProbSpecsDir;
   # There's probably a better way to do this than parsing `git remote -v`.
   let msg = "could not run `git remote -v` in the cached " &
             &"problem-specifications directory: '{probSpecsDir}'"
-  let remotes = gitCheck(0, ["remote", "-v"], msg)
+  let remotes = gitCheck(0, ["-C", probSpecsDir.string, "remote", "-v"], msg)
   var remoteName, remoteUrl: string
   for line in remotes.splitLines():
     discard line.scanf("$s$w$s$+fetch)$.", remoteName, remoteUrl)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -170,7 +170,11 @@ proc init*(T: typedesc[ProbSpecsDir], conf: Conf): T =
     let msg = fmt"""
       Error: --offline was passed, but there is no cached 'problem-specifications' repo at:
         '{result}'
-      Please run once without --offline to clone 'problem-specifications' to that location.""".unindent()
+      Please run once without --offline to clone 'problem-specifications' to that location.
+
+      If you currently have no (or limited) network connectivity, but you do have a local
+      'problem-specifications' elsewhere, you can copy it to the above location and then
+      use it with --offline.""".unindent()
     stderr.writeLine msg
     quit 1
   else:

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -159,5 +159,9 @@ proc init*(T: typedesc[ProbSpecsDir], conf: Conf): T =
     if dirExists(result):
       validate(result, conf)
     else:
-      createDir result.parentDir()
+      try:
+        createDir result.parentDir()
+      except IOError, OSError:
+        stderr.writeLine &"Error: {getCurrentExceptionMsg()}"
+        quit 1
       cloneExercismRepo("problem-specifications", result.string, shallow = false)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -168,9 +168,9 @@ proc init*(T: typedesc[ProbSpecsDir], conf: Conf): T =
     validate(result, conf)
   elif conf.action.offline:
     let msg = fmt"""
-      Error: --offline was passed, but there is no cached problem-specifications
-      repo at '{result}'
-      Please run without --offline once.""".unindent()
+      Error: --offline was passed, but there is no cached 'problem-specifications' repo at:
+        '{result}'
+      Please run once without --offline to clone 'problem-specifications' to that location.""".unindent()
     stderr.writeLine msg
     quit 1
   else:

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -12,7 +12,8 @@ type
 
 proc `$`(dir: ProbSpecsDir): string {.borrow.}
 proc dirExists(dir: ProbSpecsDir): bool {.borrow.}
-proc removeDir*(dir: ProbSpecsDir, checkDir = false) {.borrow.}
+proc createDir(dir: ProbSpecsDir) {.borrow.}
+proc parentDir(path: ProbSpecsDir): string {.borrow.}
 proc `/`*(head: ProbSpecsDir, tail: string): string {.borrow.}
 proc `/`(head: ProbSpecsExerciseDir, tail: string): string {.borrow.}
 proc lastPathPart(path: ProbSpecsExerciseDir): string {.borrow.}
@@ -154,6 +155,9 @@ proc init*(T: typedesc[ProbSpecsDir], conf: Conf): T =
     result = T(conf.action.probSpecsDir)
     validate(result, conf)
   else:
-    result = T(getCurrentDir() / ".problem-specifications")
-    removeDir(result)
-    cloneExercismRepo("problem-specifications", result.string, shallow = true)
+    result = T(getCacheDir() / "exercism" / "configlet" / "problem-specifications")
+    if dirExists(result):
+      validate(result, conf)
+    else:
+      createDir result.parentDir()
+      cloneExercismRepo("problem-specifications", result.string, shallow = false)

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -153,7 +153,7 @@ proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
       let remoteName = getNameOfRemote(probSpecsDir, upstreamHost, upstreamLocation)
 
       # `fetch` and `merge` separately, for better error messages.
-      logNormal(&"Running 'git pull' in cached problem-specifications dir...")
+      logNormal(&"Updating cached problem-specifications data...")
       discard gitCheck(0, ["fetch", "--quiet", remoteName, mainBranchName],
                        &"failed to fetch '{mainBranchName}' in " &
                        &"problem-specifications directory: '{probSpecsDir}'")

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -154,6 +154,13 @@ proc init*(T: typedesc[ProbSpecsDir], conf: Conf): T =
   if conf.action.probSpecsDir.len > 0:
     result = T(conf.action.probSpecsDir)
     validate(result, conf)
+  elif conf.action.offline:
+    let msg = fmt"""
+      Error: --offline was passed, but there is no cached problem-specifications
+      repo at '{result}'
+      Please run without --offline once.""".unindent()
+    stderr.writeLine msg
+    quit 1
   else:
     result = T(getCacheDir() / "exercism" / "configlet" / "problem-specifications")
     if dirExists(result):

--- a/src/sync/probspecs.nim
+++ b/src/sync/probspecs.nim
@@ -111,12 +111,17 @@ proc validate(probSpecsDir: ProbSpecsDir, conf: Conf) =
 
   logDetailed(&"Using cached problem-specifications dir: {probSpecsDir}")
 
-  # Validate the `problem-specifications` repo without checking the ref of the
-  # root commit, allowing the `--prob-specs-dir` location to be a shallow clone.
   withDir probSpecsDir.string:
-    # Exit if the given directory is not a git repo.
-    discard gitCheck(0, ["rev-parse"], "the cached problem-specifications " &
-                     &"directory is not a git repository: '{probSpecsDir}'")
+    # Validate the `problem-specifications` repo by checking the ref of the root
+    # commit. Don't support a shallow clone.
+    let rootCommitRef = gitCheck(0, ["rev-list", "--max-parents=0", "HEAD"],
+                                 "the directory at the cached " &
+                                 "problem-specifications location is not a " &
+                                 &"git repository: '{probSpecsDir}'")
+
+    if rootCommitRef != "8ba81069dab8e96a53630f3e51446487b6ec9212\n":
+      showError("the git repo at the cached problem-specifications location " &
+                &"has an unexpected initial commit: '{probSpecsDir}'")
 
     # Exit if the working directory is not clean (allowing untracked files).
     discard gitCheck(0, ["diff-index", "--quiet", "HEAD"], "the cached " &

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -6,9 +6,6 @@ import "."/[exercises, probspecs, sync_common, sync_docs, sync_filepaths,
 proc validate(conf: Conf) =
   ## Exits with an error message if the given `conf` contains an invalid
   ## combination of options.
-  if conf.action.offline and conf.action.probSpecsDir.len == 0:
-    showError(&"'{list(optSyncOffline)}' was given without passing " &
-              &"'{list(optSyncProbSpecsDir)}'")
   if conf.action.update:
     if conf.action.yes and skTests in conf.action.scope:
       let msg = fmt"""

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -93,41 +93,36 @@ proc syncImpl(conf: Conf): set[SyncKind] =
     else:
       ProbSpecsDir.init(conf)
 
-  try:
-    let psExercisesDir = probSpecsDir / "exercises"
-    let trackExercisesDir = conf.trackDir / "exercises"
-    let trackPracticeExercisesDir = trackExercisesDir / "practice"
+  let psExercisesDir = probSpecsDir / "exercises"
+  let trackExercisesDir = conf.trackDir / "exercises"
+  let trackPracticeExercisesDir = trackExercisesDir / "practice"
 
-    for syncKind in conf.action.scope:
-      case syncKind
-      # Check/update docs
-      of skDocs:
-        checkOrUpdateDocs(result, conf, trackExerciseSlugs.practice,
-                          trackPracticeExercisesDir, psExercisesDir)
+  for syncKind in conf.action.scope:
+    case syncKind
+    # Check/update docs
+    of skDocs:
+      checkOrUpdateDocs(result, conf, trackExerciseSlugs.practice,
+                        trackPracticeExercisesDir, psExercisesDir)
 
-      # Check/update metadata
-      of skMetadata:
-        checkOrUpdateMetadata(result, conf, trackExerciseSlugs.practice,
-                              trackPracticeExercisesDir, psExercisesDir)
+    # Check/update metadata
+    of skMetadata:
+      checkOrUpdateMetadata(result, conf, trackExerciseSlugs.practice,
+                            trackPracticeExercisesDir, psExercisesDir)
 
-      # Check/update filepaths
-      of skFilepaths:
-        let trackConceptExercisesDir = trackExercisesDir / "concept"
-        checkOrUpdateFilepaths(result, conf, trackExerciseSlugs.`concept`,
-                               trackExerciseSlugs.practice, trackConfig.files,
-                               trackPracticeExercisesDir, trackConceptExercisesDir)
+    # Check/update filepaths
+    of skFilepaths:
+      let trackConceptExercisesDir = trackExercisesDir / "concept"
+      checkOrUpdateFilepaths(result, conf, trackExerciseSlugs.`concept`,
+                              trackExerciseSlugs.practice, trackConfig.files,
+                              trackPracticeExercisesDir, trackConceptExercisesDir)
 
-      # Check/update tests
-      of skTests:
-        let exercises = toSeq findExercises(conf, probSpecsDir)
-        if conf.action.update:
-          updateTests(result, conf, exercises)
-        else:
-          checkTests(result, exercises)
-
-  finally:
-    if conf.action.probSpecsDir.len == 0 and conf.action.scope != {skFilepaths}:
-      removeDir(probSpecsDir)
+    # Check/update tests
+    of skTests:
+      let exercises = toSeq findExercises(conf, probSpecsDir)
+      if conf.action.update:
+        updateTests(result, conf, exercises)
+      else:
+        checkTests(result, exercises)
 
 func explain(syncKind: SyncKind): string =
   case syncKind

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -81,7 +81,6 @@ proc syncImpl(conf: Conf): set[SyncKind] =
   logDetailed(&"Found {trackExerciseSlugs.`concept`.len} Concept Exercises " &
               &"and {trackExerciseSlugs.practice.len} Practice Exercises in " &
                trackConfigPath)
-  logNormal("Checking exercises...")
 
   # Don't clone problem-specifications if only `--filepaths` is given
   let probSpecsDir =
@@ -93,6 +92,8 @@ proc syncImpl(conf: Conf): set[SyncKind] =
   let psExercisesDir = probSpecsDir / "exercises"
   let trackExercisesDir = conf.trackDir / "exercises"
   let trackPracticeExercisesDir = trackExercisesDir / "practice"
+
+  logNormal("Checking exercises...")
 
   for syncKind in conf.action.scope:
     case syncKind


### PR DESCRIPTION
Before this commit, the default behavior of `configlet sync` was to
clone `exercism/problem-specifications` and delete it afterwards. The
`-p, --prob-specs-dir` and `-o, --offline` options influenced the
behavior as shown in the below table, where an `x` in one of the first
two columns means the corresponding option was given.

| -p | -o | Behavior                                              |
| -- | -- | ----------------------------------------------------- |
|    |    | Clone prob-specs, and delete it afterwards            |
| x  |    | Use the given prob-specs dir; error if outdated       |
| x  | x  | Use the given prob-specs dir; don't check if outdated |
|    | x  | Error: `-p` must be provided when `-o` is given       |

This was simple and robust, but slow in the zero-option case. Most track
maintainers would probably want to use both `--offline` and
`--prob-specs-dir` nearly all the time, especially because we often want
to run several `configlet sync` commands in quick succession.

With this commit, `configlet sync` now looks for a cached
problem-specifications on the user's machine, behaving as follows:

| Cache hit? | -o | Behavior                                           |
| ---------- | -- | -------------------------------------------------- |
|            |    | Clone prob-specs, and don't delete it afterwards   |
|     x      |    | Use cached prob-specs, and `git pull` in it        |
|     x      | x  | Use cached prob-specs, and don't `git pull` in it  |
|            | x  | Error: local prob-specs not found, and won't clone |

This optimizes for the convenience of `configlet sync` and
`configlet sync --offline` - to perform an offline sync, the user no
longer needs to also write a path to a prob-specs directory.

In fact, this commit also removes the `--prob-specs-dir` option
entirely; its remaining usefulness is not worth the added complexity in
the help message (or the code).

Despite the `--prob-specs-dir` removal, note that you can still:
- Sync from an older prob-specs commit, by checking out that commit in
  the cached repo and then using `--offline`. We require the commit
  to exist on the upstream `main` branch.
- Sync using `--offline` when your only copy of problem-specifications
  is outside the cache directory (by copying to the cached location). 

The path to the cached prob-specs is:
    
    $PATHSTART/exercism/configlet/problem-specifications

where the value of `$PATHSTART` is given by this table:

| Platform | $PATHSTART                                                  |
| -------- | ----------------------------------------------------------- |
| Windows  | getEnv("LOCALAPPDATA")                                      |
| macOS    | getEnv("XDG_CACHE_HOME", getEnv("HOME") / "Library/Caches") |
| Other    | getEnv("XDG_CACHE_HOME", getEnv("HOME") / ".cache")         |

and `getEnv` returns the value of the environment variable with the name
of the first parameter (or if that does not exist, the value of the
second parameter).

For example, on Linux, the cached path is typically:

    ~/.cache/exercism/configlet/problem-specifications

Closes: #477

---

To-do:
- [x] Allow `-o, --offline` without `--prob-specs-dir`, since that now makes sense.
- [x] Remove `--prob-specs-dir`.
- [x] Automatically `git pull` in the cached dir when `--offline` is not given.
- [x] Make online sync test runnable outside CI.