### PR TITLE
exec: cloneExercismRepo: clone a single branch by default

### DIFF
--- a/src/exec.nim
+++ b/src/exec.nim
@@ -76,26 +76,24 @@ proc gitCheck*(expectedExitCode: int; args: openArray[string] = [];
   result = execAndCheck(expectedExitCode, "git", args, msg = msg)
 
 proc cloneExercismRepo*(repoName, dest: string; shallow = false) =
-  ## If there is no directory at `dest`, clones the Exercism repo named
-  ## `repoName` to `dest`. Performs a shallow clone if `shallow` is `true`.
+  ## Clones the Exercism repo named `repoName` to `dest`. Performs a shallow
+  ## clone if `shallow` is `true`.
   ##
-  ## Quits if the directory does not already exist and the clone is
-  ## unsuccessful.
-  if not dirExists(dest):
-    let url = &"https://github.com/exercism/{repoName}/"
-    let args =
-      if shallow:
-        @["clone", "--depth", "1", "--", url, dest]
-      else:
-        @["clone", "--", url, dest]
-    stderr.write &"Cloning {url}... "
-    let (outp, exitCode) = git(args)
-    if exitCode == 0:
-      stderr.writeLine "success"
+  ## Quits if the clone is unsuccessful.
+  let url = &"https://github.com/exercism/{repoName}/"
+  let args =
+    if shallow:
+      @["clone", "--depth", "1", "--", url, dest]
     else:
-      stderr.writeLine "failure"
-      stderr.writeLine outp
-      quit 1
+      @["clone", "--", url, dest]
+  stderr.write &"Cloning {url}... "
+  let (outp, exitCode) = git(args)
+  if exitCode == 0:
+    stderr.writeLine "success"
+  else:
+    stderr.writeLine "failure"
+    stderr.writeLine outp
+    quit 1
 
 proc gitCheckout(dir, hash: string) =
   ## Checkout `hash` in the git repo at `dir`, discarding changes to the working
@@ -110,7 +108,8 @@ proc setupExercismRepo*(repoName, dest, hash: string; shallow = false) =
   ## `repoName` to `dest`.
   ##
   ## Then checkout the given `hash` in `dest`.
-  cloneExercismRepo(repoName, dest, shallow)
+  if not dirExists(dest):
+    cloneExercismRepo(repoName, dest, shallow)
   gitCheckout(dest, hash)
 
 func conciseDiff(s: string): string =

--- a/src/exec.nim
+++ b/src/exec.nim
@@ -75,9 +75,11 @@ proc gitCheck*(expectedExitCode: int; args: openArray[string] = [];
   ## Otherwise, prints the output and `msg`, then raises `OSError`.
   result = execAndCheck(expectedExitCode, "git", args, msg = msg)
 
-proc cloneExercismRepo*(repoName, dest: string; shallow = false) =
+proc cloneExercismRepo*(repoName, dest: string; shallow = false;
+                        singleBranch = true) =
   ## Clones the Exercism repo named `repoName` to `dest`. Performs a shallow
-  ## clone if `shallow` is `true`.
+  ## clone if `shallow` is `true`, and clones only the default branch if
+  ## `singleBranch` is `true`.
   ##
   ## Quits if the clone is unsuccessful.
   let url = &"https://github.com/exercism/{repoName}/"
@@ -85,6 +87,8 @@ proc cloneExercismRepo*(repoName, dest: string; shallow = false) =
     var res = @["clone"]
     if shallow:
       res.add ["--depth", "1"]
+    if singleBranch:
+      res.add ["--single-branch"]
     res.add ["--", url, dest]
     res
   stderr.write &"Cloning {url}... "

--- a/src/exec.nim
+++ b/src/exec.nim
@@ -81,11 +81,12 @@ proc cloneExercismRepo*(repoName, dest: string; shallow = false) =
   ##
   ## Quits if the clone is unsuccessful.
   let url = &"https://github.com/exercism/{repoName}/"
-  let args =
+  let args = block:
+    var res = @["clone"]
     if shallow:
-      @["clone", "--depth", "1", "--", url, dest]
-    else:
-      @["clone", "--", url, dest]
+      res.add ["--depth", "1"]
+    res.add ["--", url, dest]
+    res
   stderr.write &"Cloning {url}... "
   let (outp, exitCode) = git(args)
   if exitCode == 0:


### PR DESCRIPTION
Most notably, this means that the cached prob-specs repo contains only the `main` branch.

Also refactor a little. 

We only call `cloneExercismRepo` in these two places, after checking that the directory doesn't exist:

https://github.com/exercism/configlet/blob/eb5282b04a023f197f3241e7e2eb62c857625457/src/exec.nim#L111-L118

https://github.com/exercism/configlet/blob/eb5282b04a023f197f3241e7e2eb62c857625457/src/sync/probspecs.nim#L165-L186
