### PR TITLE
github(workflows), nimble: bump Nim from 1.6.4 to 1.6.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@7dd1812db4916d00b984d1c43339346a76e05487
         with:
-          version: "binary:1.6.4"
+          version: "binary:1.6.6"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@7dd1812db4916d00b984d1c43339346a76e05487
         with:
-          version: "binary:1.6.4"
+          version: "binary:1.6.6"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -9,7 +9,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 1.6.4"
+requires "nim >= 1.6.6"
 requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"    # 1.5.19 (2021-09-13)
 requires "jsony#2a2cc4331720b7695c8b66529dbfea6952727e7b"     # 1.1.3  (2022-01-03)
 requires "parsetoml#9cdeb3f65fd10302da157db8a8bac5c42f055249" # 0.6.0  (2021-06-07)


### PR DESCRIPTION
Links:
- https://nim-lang.org/blog/2022/05/05/version-166-released.html
- https://github.com/nim-lang/Nim/compare/v1.6.4...v1.6.6
- https://forum.nim-lang.org/t/9144

There are no changes in `lib/pure/{json,parsejson}.nim` for us to port.

Previous Nim bump: #514 

---

~The first Nim `1.6.6` release candidate was released - see [forum post](https://forum.nim-lang.org/t/9100).~

~CI is expected to fail until `1.6.6` is actually released.~

To-do:
- [x] Before merging this PR, merge https://github.com/exercism/configlet/pull/586