### PR TITLE
build(publish-release): upload first asset at release creation time

### DIFF
--- a/.github/bin/publish-release
+++ b/.github/bin/publish-release
@@ -3,6 +3,7 @@
 build_tag="$(echo "${REF}" | cut -d'/' -f3)"
 
 if ! gh release view "${build_tag}"; then
-  gh release create --draft "${build_tag}"
+  gh release create --draft "${build_tag}" "${ARTIFACT_FILE}"
+else
+  gh release upload "${build_tag}" "${ARTIFACT_FILE}"
 fi
-gh release upload "${build_tag}" "${ARTIFACT_FILE}"


### PR DESCRIPTION
It seems that the first build job to finish (usually the Linux one)
would sometimes fail in the `gh release upload` step, saying that the
release was not found. To address this race condition, upload the first
asset during the release creation.

From [the docs for `gh release create`](https://cli.github.com/manual/gh_release_create):

    gh release create [<tag>] [<files>...]

    Create a new GitHub Release for a repository.

    A list of asset files may be given to upload to the new release.

Note that we still have another race condition: a separate job can
create a release in the time between `gh release view` indicating
"there is no such release" and `gh release create` running. We should
address that later, but it hasn't caused a problem yet - the Linux job
consistently finishes significantly faster than the others. And if we
encounter such a failure in the meantime, the workaround is simple: just
restart the failing job.

---

[This job on my fork](https://github.com/ee7/exercism-configlet/runs/5978965511) uses the same `publish-release` as the current `main`, but failed .

Maybe there's a race condition, with an error from the first `gh release upload` command running before GitHub knows the release is created? The Linux build is almost always the first to finish. 

It seems like I'm missing something, because it seems like we'd have run into this earlier. But this change should be safe.