### PR TITLE
build: upload checksums file

### DIFF
--- a/.github/bin/upload-checksums-file
+++ b/.github/bin/upload-checksums-file
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+set -e
+
+build_tag="$(echo "${REF}" | cut -d'/' -f3)"
+
+# Download every release asset
+download_dir="releases/${build_tag}"
+gh release download "${build_tag}" --dir "${download_dir}"
+
+# Write checksums file
+cd "${download_dir}" || exit
+checksums_file="configlet_${build_tag}_checksums_sha256.txt"
+sha256sum -- * > "${checksums_file}"
+
+# Upload checksums file
+gh release upload "${build_tag}" "${checksums_file}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,3 +72,6 @@ jobs:
 
       - name: Upload checksums file
         run: ./.github/bin/upload-checksums-file
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,3 +61,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF: ${{ github.ref }}
+
+  checksums:
+    needs: [build]
+    runs-on: ubuntu-20.04
+    name: Upload checksums file
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+
+      - name: Upload checksums file
+        run: ./.github/bin/upload-checksums-file


### PR DESCRIPTION
For the configlet 4.0.0-alpha.37 release, this file would contain:

```
64e801c83569759a0f877791fe0138fecbb3386eeb7167fd25a5e8f9624dda49  configlet-linux-64bit.tgz
6ad208cd881c048e42146dfc183cf4772b3ce4609460062b3ff4c67d856df81d  configlet-mac-64bit.tgz
48c521bb514ea8af2bb91c1129e68c9e90dfa2218b732ddce5c34372a99013b1  configlet-windows-64bit.zip
```

A user can download the checksum file and a release archive, and then
verify the archive was downloaded correctly. For example, on Linux:

```console
$ sha256sum --check --ignore-missing configlet_4.0.0-alpha.37_checksums_sha256.txt
configlet-linux-64bit.tgz: OK
```

In the future, we can consider signing this file (see #548).

Closes: #457

---

Tested on my fork (triggered by pushing a tag named `build-upload-checksums.3` to my fork):
- https://github.com/ee7/exercism-configlet/releases/tag/untagged-d42873b5c0609625ea1f
- https://github.com/ee7/exercism-configlet/actions/runs/2155526773

Verifying by downloading the assets:
```console
$ gh -R ee7/configlet release download build-upload-checksums.3 -D /tmp/ee7configletchecksums
$ cd /tmp/ee7configletchecksums
$ cat configlet_build-upload-checksums.3_checksums_sha256.txt
ce87c87c1b161a3b7f44576939589ed8b05a91b44ce911839aa27bfd3ff5c2a4  configlet-linux-64bit.tgz
7b9ed4806a322c24bc435092dfa36e2057af78379e1839313a5a957441b6f86c  configlet-mac-64bit.tgz
6ed7eee8efc31cd1bffe4db571acb5df502b250f575c301f17bbef4aa2257092  configlet-windows-64bit.zip
$ sha256sum -c configlet_build-upload-checksums.3_checksums_sha256.txt
configlet-linux-64bit.tgz: OK
configlet-mac-64bit.tgz: OK
configlet-windows-64bit.zip: OK
```