### PR TITLE
info: show whether unimplemented exercises have canonical data

### DIFF
--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -95,15 +95,14 @@ func getSlugs(practiceExercises: seq[PracticeExercise]): HashSet[string] =
 proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
                                      foregone: HashSet[string],
                                      probSpecsExercises: ProbSpecsExercises): string =
-  let practiceExerciseSlugs = getSlugs(practiceExercises)
-  let uWith = probSpecsExercises.withCanonicalData -
-              practiceExerciseSlugs - foregone
-  let uWithout = probSpecsExercises.withoutCanonicalData -
-                 practiceExerciseSlugs - foregone
-  let header =
-    &"There are {uWith.len + uWithout.len} non-deprecated exercises " &
-     "in `exercism/problem-specifications` that\n" &
-     "are both unimplemented and not in the track config `exercises.foregone` array:"
+  let
+    practiceExerciseSlugs = getSlugs(practiceExercises)
+    uWith = probSpecsExercises.withCanonicalData - practiceExerciseSlugs - foregone
+    uWithout = probSpecsExercises.withoutCanonicalData - practiceExerciseSlugs - foregone
+    header =
+      &"There are {uWith.len + uWithout.len} non-deprecated exercises " &
+      "in `exercism/problem-specifications` that\n" &
+      "are both unimplemented and not in the track config `exercises.foregone` array:"
   result = header(header)
   if uWith.len > 0 or uWithout.len > 0:
     for (u, s) in [(uWith, "With"), (uWithout, "Without")]:

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -101,22 +101,15 @@ proc show(unimplementedSlugs: HashSet[string],
   if unimplementedSlugs.len > 0:
     var u = toSeq(unimplementedSlugs)
     sort u
-    let (slugsWith, slugsWithout) = block:
-      var slugsWith = newSeq[string]()
-      var slugsWithout = newSeq[string]()
-      for slug in u:
-        if slug in probSpecsExercises.withoutCanonicalData:
-          slugsWithout.add slug
-        else:
-          slugsWith.add slug
-      (slugsWith, slugsWithout)
-    if slugsWith.len > 0:
-      result.add "\nWith canonical data:\n"
-      for slug in slugsWith:
+    for slug in u:
+      if slug in probSpecsExercises.withCanonicalData:
+        once:
+          result.add "\nWith canonical data:\n"
         result.add &"{slug}\n"
-    if slugsWithout.len > 0:
-      result.add "\nWithout canonical data:\n"
-      for slug in slugsWithout:
+    for slug in u:
+      if slug in probSpecsExercises.withoutCanonicalData:
+        once:
+          result.add "\nWithout canonical data:\n"
         result.add &"{slug}\n"
   else:
     result.add "none\n"

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -92,6 +92,26 @@ func getSlugs(practiceExercises: seq[PracticeExercise]): HashSet[string] =
   for practiceExercise in practiceExercises:
     result.incl practiceExercise.slug
 
+proc show(unimplementedSlugs: HashSet[string],
+          probSpecsExercises: ProbSpecsExercises, header: string): string =
+  ## Returns a string containing a colorized (when appropriate) `header`, and
+  ## then the elements of `unimplementedSlugs` in alphabetical order, indicating
+  ## the slugs that lack canonical data.
+  result = header(header)
+  result.add "(\"NC\" means the exercise lacks canonical data)\n"
+  if unimplementedSlugs.len > 0:
+    var elements = toSeq(unimplementedSlugs)
+    sort elements
+    for item in elements:
+      if item in probSpecsExercises.withoutCanonicalData:
+        result.add "NC"
+      else:
+        result.add "  "
+      result.add &"  {item}\n"
+  else:
+    result.add "none\n"
+  result.add "\n"
+
 proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
                                      foregone: HashSet[string],
                                      probSpecsExercises: ProbSpecsExercises): string =
@@ -103,7 +123,7 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
     &"There are {unimplementedProbSpecsSlugs.len} non-deprecated exercises " &
      "in `exercism/problem-specifications` that\n" &
      "are both unimplemented and not in the track config `exercises.foregone` array:"
-  result = show(unimplementedProbSpecsSlugs, msg)
+  result = show(unimplementedProbSpecsSlugs, probSpecsExercises, msg)
 
   stripLineEnd(result)
 

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -97,19 +97,15 @@ proc show(uWith, uWithout: HashSet[string], header: string): string =
   ## then the elements of `uWith` and `uWithout` in alphabetical order,
   ## indicating whether slugs have canonical data.
   result = header(header)
-  if uWith.len > 0:
-    var u = toSeq(uWith)
-    sort u
-    result.add "\nWith canonical data:\n"
-    for slug in u:
-      result.add &"{slug}\n"
-  if uWithout.len > 0:
-    var u = toSeq(uWithout)
-    sort u
-    result.add "\nWithout canonical data:\n"
-    for slug in u:
-      result.add &"{slug}\n"
-  if uWith.len == 0 and uWithout.len == 0:
+  if uWith.len > 0 or uWithout.len > 0:
+    for (u, s) in [(uWith, "With"), (uWithout, "Without")]:
+      if u.len > 0:
+        result.add &"\n{s} canonical data:\n"
+        var u = toSeq(u)
+        sort u
+        for slug in u:
+          result.add &"{slug}\n"
+  else:
     result.add "none\n"
   result.add "\n"
 

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -117,11 +117,11 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
               practiceExerciseSlugs - foregone
   let uWithout = probSpecsExercises.withoutCanonicalData -
                  practiceExerciseSlugs - foregone
-  let msg =
+  let header =
     &"There are {uWith.len + uWithout.len} non-deprecated exercises " &
      "in `exercism/problem-specifications` that\n" &
      "are both unimplemented and not in the track config `exercises.foregone` array:"
-  result = show(uWith, uWithout, msg)
+  result = show(uWith, uWithout, header)
 
   stripLineEnd(result)
 

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -98,16 +98,26 @@ proc show(unimplementedSlugs: HashSet[string],
   ## then the elements of `unimplementedSlugs` in alphabetical order, indicating
   ## the slugs that lack canonical data.
   result = header(header)
-  result.add "(\"NC\" means the exercise lacks canonical data)\n"
   if unimplementedSlugs.len > 0:
-    var elements = toSeq(unimplementedSlugs)
-    sort elements
-    for item in elements:
-      if item in probSpecsExercises.withoutCanonicalData:
-        result.add "NC"
-      else:
-        result.add "  "
-      result.add &"  {item}\n"
+    var u = toSeq(unimplementedSlugs)
+    sort u
+    let (slugsWith, slugsWithout) = block:
+      var slugsWith = newSeq[string]()
+      var slugsWithout = newSeq[string]()
+      for slug in u:
+        if slug in probSpecsExercises.withoutCanonicalData:
+          slugsWithout.add slug
+        else:
+          slugsWith.add slug
+      (slugsWith, slugsWithout)
+    if slugsWith.len > 0:
+      result.add "\nWith canonical data:\n"
+      for slug in slugsWith:
+        result.add &"{slug}\n"
+    if slugsWithout.len > 0:
+      result.add "\nWithout canonical data:\n"
+      for slug in slugsWithout:
+        result.add &"{slug}\n"
   else:
     result.add "none\n"
   result.add "\n"

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -107,7 +107,6 @@ proc show(uWith, uWithout: HashSet[string], header: string): string =
           result.add &"{slug}\n"
   else:
     result.add "none\n"
-  result.add "\n"
 
 proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
                                      foregone: HashSet[string],
@@ -122,8 +121,6 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
      "in `exercism/problem-specifications` that\n" &
      "are both unimplemented and not in the track config `exercises.foregone` array:"
   result = show(uWith, uWithout, header)
-
-  stripLineEnd(result)
 
 func count(exercises: seq[ConceptExercise] |
                       seq[PracticeExercise]): tuple[visible: int, wip: int] =

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -92,22 +92,6 @@ func getSlugs(practiceExercises: seq[PracticeExercise]): HashSet[string] =
   for practiceExercise in practiceExercises:
     result.incl practiceExercise.slug
 
-proc show(uWith, uWithout: HashSet[string], header: string): string =
-  ## Returns a string containing a colorized (when appropriate) `header`, and
-  ## then the elements of `uWith` and `uWithout` in alphabetical order,
-  ## indicating whether slugs have canonical data.
-  result = header(header)
-  if uWith.len > 0 or uWithout.len > 0:
-    for (u, s) in [(uWith, "With"), (uWithout, "Without")]:
-      if u.len > 0:
-        result.add &"\n{s} canonical data:\n"
-        var u = toSeq(u)
-        sort u
-        for slug in u:
-          result.add &"{slug}\n"
-  else:
-    result.add "none\n"
-
 proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
                                      foregone: HashSet[string],
                                      probSpecsExercises: ProbSpecsExercises): string =
@@ -120,7 +104,17 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
     &"There are {uWith.len + uWithout.len} non-deprecated exercises " &
      "in `exercism/problem-specifications` that\n" &
      "are both unimplemented and not in the track config `exercises.foregone` array:"
-  result = show(uWith, uWithout, header)
+  result = header(header)
+  if uWith.len > 0 or uWithout.len > 0:
+    for (u, s) in [(uWith, "With"), (uWithout, "Without")]:
+      if u.len > 0:
+        result.add &"\n{s} canonical data:\n"
+        var u = toSeq(u)
+        sort u
+        for slug in u:
+          result.add &"{slug}\n"
+  else:
+    result.add "none\n"
 
 func count(exercises: seq[ConceptExercise] |
                       seq[PracticeExercise]): tuple[visible: int, wip: int] =

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -20,11 +20,10 @@ proc getPsState(path: static string): ProbSpecsState =
   let contents = staticRead(path)
   contents.fromJson(ProbSpecsState)
 
-proc getProbSpecsSlugs: HashSet[string] =
+proc init(T: typedesc[ProbSpecsExercises]): T =
   # TODO: automatically update this at build-time?
   const slugsPath = currentSourcePath().parentDir() / "prob_specs_exercises.json"
-  let psExercises = getPsState(slugsPath).exercises
-  result = psExercises.withCanonicalData + psExercises.withoutCanonicalData
+  getPsState(slugsPath).exercises
 
 func getConceptSlugs(concepts: Concepts): HashSet[string] =
   ## Returns the `slug` of every concept in `concepts`.
@@ -95,9 +94,11 @@ func getSlugs(practiceExercises: seq[PracticeExercise]): HashSet[string] =
 
 proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
                                      foregone: HashSet[string],
-                                     probSpecsSlugs: HashSet[string]): string =
+                                     probSpecsExercises: ProbSpecsExercises): string =
   let practiceExerciseSlugs = getSlugs(practiceExercises)
-  let unimplementedProbSpecsSlugs = probSpecsSlugs - practiceExerciseSlugs - foregone
+  let unimplementedProbSpecsSlugs = probSpecsExercises.withCanonicalData +
+                                    probSpecsExercises.withoutCanonicalData -
+                                    practiceExerciseSlugs - foregone
   let msg =
     &"There are {unimplementedProbSpecsSlugs.len} non-deprecated exercises " &
      "in `exercism/problem-specifications` that\n" &
@@ -147,8 +148,8 @@ proc info*(conf: Conf) =
     let concepts = trackConfig.concepts
 
     echo conceptsInfo(practiceExercises, concepts)
-    const probSpecsSlugs = getProbSpecsSlugs()
-    echo unimplementedProbSpecsExercises(practiceExercises, foregone, probSpecsSlugs)
+    const probSpecsExercises = ProbSpecsExercises.init()
+    echo unimplementedProbSpecsExercises(practiceExercises, foregone, probSpecsExercises)
     echo trackSummary(conceptExercises, practiceExercises, concepts)
   else:
     var msg = &"file does not exist: {trackConfigPath}"


### PR DESCRIPTION
Closes: #481

To illustrate, let's consider the output of `configlet info` for the Elixir track.

Before this PR (and with #566):

```
[...]

There are 8 non-deprecated exercises in `exercism/problem-specifications` that
are both unimplemented and not in the track config `exercises.foregone` array:
error-handling
hangman
killer-sudoku-helper
ledger
lens-person
paasio
state-of-tic-tac-toe
tree-building

[...]
```

With this PR:

```
[...]

There are 8 non-deprecated exercises in `exercism/problem-specifications` that
are both unimplemented and not in the track config `exercises.foregone` array:
("NC" means the exercise lacks canonical data)
NC  error-handling
NC  hangman
    killer-sudoku-helper
NC  ledger
NC  lens-person
NC  paasio
    state-of-tic-tac-toe
NC  tree-building

[...]
```

Feel free to suggest improvements to the display format. Pinging @angelikatyborska as the feature requester - see https://github.com/exercism/configlet/issues/180#issuecomment-934344148.

I think I prefer:
- Indicating the status in the left column, because the indications will be further from the slug if we align on the right using the longest slug length.
- Indicating the lack of canonical data, rather than the presence of it. A track is more likely to implement every exercise with canonical data than every exercise without canonical data - so, this way round, that track doesn't get a confusing blank column.

But there are some other options in https://github.com/exercism/configlet/issues/481#issuecomment-997251455.