### PR TITLE
github(workflows): bump `windows-2019` to `windows-2022`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
             builder: macos-11
           - target:
               os: windows
-            builder: windows-2019
+            builder: windows-2022
 
     name: "${{ matrix.target.os }}-${{ matrix.target.arch }}"
     runs-on: ${{ matrix.builder }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
             builder: macos-11
           - target:
               os: windows
-            builder: windows-2019
+            builder: windows-2022
 
     name: "${{ matrix.target.os }}-${{ matrix.target.arch }}"
     runs-on: ${{ matrix.builder }}


### PR DESCRIPTION
A job that uses `windows-latest` now runs on Windows Server 2022, so 
let's bump our Windows version accordingly.

This does not change the Mingw-w64 version - it stays at 8.1.0.

With the configlet `4.0.0-beta.1` release binary:

```console
$ strings configlet.exe | grep gcc
GCC: (x86_64-posix-seh-rev0, Built by MinGW-W64 project) 8.1.0
```

Links:
- https://github.blog/changelog/2022-01-11-github-actions-jobs-running-on-windows-latest-are-now-running-on-windows-server-2022/
- https://github.com/actions/virtual-environments/blob/97fd5e03b48a/images/win/Windows2019-Readme.md
- https://github.com/actions/virtual-environments/blob/97fd5e03b48a/images/win/Windows2022-Readme.md
- https://github.com/actions/virtual-environments/commit/fcb8a9ca81fc
- https://github.com/actions/virtual-environments/commit/019311423176
- https://www.mingw-w64.org/changelog/
- https://gcc.gnu.org/releases.html
- https://gcc.gnu.org/git/gcc.git

---

With this PR:

```console
$ git grep --heading --break 'windows' -- .github/workflows
.github/workflows/build.yml
19:          - os: windows
29:              os: windows
30:            builder: windows-2022

.github/workflows/tests.yml
24:          - os: windows
34:              os: windows
35:            builder: windows-2022
```