### PR TITLE
sync(filepaths): sync `editor` field when missing

### DIFF
--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -363,7 +363,8 @@ func filesKeyOrder(val: ConceptExerciseFiles | PracticeExerciseFiles;
 
     # If `editor` is missing and not empty, write it after `example`/`exemplar`.
     if fkEditor notin result and val.editor.len > 0:
-      result.add fkEditor
+      let insertionIndex = result.find(fkEx) + 1
+      result.insert(fkEditor, insertionIndex)
 
 func addFiles(s: var string; val: ConceptExerciseFiles | PracticeExerciseFiles;
               prettyMode: PrettyMode; indentLevel = 1) =

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -361,6 +361,10 @@ func filesKeyOrder(val: ConceptExerciseFiles | PracticeExerciseFiles;
       let insertionIndex = result.find(fkTest) + 1
       result.insert(fkEx, insertionIndex)
 
+    # If `editor` is missing and not empty, write it after `example`/`exemplar`.
+    if fkEditor notin result and val.editor.len > 0:
+      result.add fkEditor
+
 func addFiles(s: var string; val: ConceptExerciseFiles | PracticeExerciseFiles;
               prettyMode: PrettyMode; indentLevel = 1) =
   ## Appends the pretty-printed JSON for a `files` key with value `val` to `s`.


### PR DESCRIPTION
This commit fixes a bug that caused syncing filepaths to not sync
the `editor` filepaths.
