### PR TITLE
lint, sync, fmt: support the `files.invalidator` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ The canonical key order for an exercise `.meta/config.json` file is:
   - exemplar           (Concept Exercises only)
   - example            (Practice Exercises only)
   - [editor]
+  - [invalidator]
 - [language_versions]
 - [forked_from]        (Concept Exercises only)
 - [icon]               (Concept Exercises only)

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -11,6 +11,7 @@ proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
       hasArrayOfFiles(d, "test", path, k, exerciseDir),
       hasArrayOfFiles(d, "exemplar", path, k, exerciseDir),
       hasArrayOfFiles(d, "editor", path, k, exerciseDir, isRequired = false),
+      hasArrayOfFiles(d, "invalidator", path, k, exerciseDir, isRequired = false),
     ]
     result = allTrue(checks)
 

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -11,6 +11,7 @@ proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
       hasArrayOfFiles(d, "test", path, k, exerciseDir),
       hasArrayOfFiles(d, "example", path, k, exerciseDir),
       hasArrayOfFiles(d, "editor", path, k, exerciseDir, isRequired = false),
+      hasArrayOfFiles(d, "invalidator", path, k, exerciseDir, isRequired = false),
     ]
     result = allTrue(checks)
 

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -47,6 +47,9 @@ proc hasValidFiles(data: JsonNode; path: Path): bool =
         hasArrayOfStrings(data[f], "editor", path, context = f,
                           uniqueValues = true, isRequired = false,
                           checkIsFilesPattern = true),
+        hasArrayOfStrings(data[f], "invalidator", path, context = f,
+                          uniqueValues = true, isRequired = false,
+                          checkIsFilesPattern = true),
       ]
       result = allTrue(checks)
   else:

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -340,6 +340,7 @@ type
     example*: seq[string]
     exemplar*: seq[string]
     editor*: seq[string]
+    invalidator*: seq[string]
 
   TrackConfig* = object
     slug*: string
@@ -713,11 +714,16 @@ proc checkFilePatternsOverlap(filePatterns: FilePatterns; trackSlug: string,
     ("solution", "example"),
     ("solution", "exemplar"),
     ("solution", "editor"),
+    ("solution", "invalidator"),
     ("test", "example"),
     ("test", "exemplar"),
     ("test", "editor"),
+    ("test", "invalidator"),
     ("editor", "example"),
     ("editor", "exemplar"),
+    ("editor", "invalidator"),
+    ("invalidator", "example"),
+    ("invalidator", "exemplar"),
   ]
 
   var seenFilePatterns = initTable[string, HashSet[string]](250)

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -372,7 +372,7 @@ func filesKeyOrder(val: ConceptExerciseFiles | PracticeExerciseFiles;
       let insertionIndex = result.find(fkEx) + 1
       result.insert(fkEditor, insertionIndex)
 
-    # If `invalidator` is missing and not empty, write it after `editor`.
+    # If `invalidator` is missing and not empty, write it at the end.
     if fkInvalidator notin result and val.invalidator.len > 0:
       result.add fkInvalidator
 

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -129,6 +129,7 @@ type
   #     solution*: seq[string]
   #     test*: seq[string]
   #     editor*: seq[string]
+  #     invalidator*: seq[string]
   #     case kind*: ExerciseKind
   #     of ekConcept:
   #       exemplar*: seq[string]

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -34,6 +34,7 @@ type
     exemplar*: seq[string]
     example*: seq[string]
     editor*: seq[string]
+    invalidator*: seq[string]
 
   TrackConfig* = object
     exercises*: Exercises
@@ -160,6 +161,7 @@ type
     fkExemplar = "exemplar"
     fkExample = "example"
     fkEditor = "editor"
+    fkInvalidator = "invalidator"
 
   ConceptExerciseFiles* = object
     originalKeyOrder: seq[FilesKey]
@@ -167,6 +169,7 @@ type
     test*: seq[string]
     exemplar*: seq[string]
     editor*: seq[string]
+    invalidator*: seq[string]
 
   PracticeExerciseFiles* = object
     originalKeyOrder: seq[FilesKey]
@@ -174,6 +177,7 @@ type
     test*: seq[string]
     example*: seq[string]
     editor*: seq[string]
+    invalidator*: seq[string]
 
   ConceptExerciseConfig* = object
     originalKeyOrder: seq[ExerciseConfigKey]
@@ -345,6 +349,8 @@ func filesKeyOrder(val: ConceptExerciseFiles | PracticeExerciseFiles;
     result = @[fkSolution, fkTest, fkEx]
     if prettyMode == pmFmt and val.editor.len > 0:
       result.add fkEditor
+    if prettyMode == pmFmt and val.invalidator.len > 0:
+      result.add fkInvalidator
   else:
     result = val.originalKeyOrder
     # If `solution` is missing, write it first.
@@ -365,6 +371,10 @@ func filesKeyOrder(val: ConceptExerciseFiles | PracticeExerciseFiles;
     if fkEditor notin result and val.editor.len > 0:
       let insertionIndex = result.find(fkEx) + 1
       result.insert(fkEditor, insertionIndex)
+
+    # If `invalidator` is missing and not empty, write it after `editor`.
+    if fkInvalidator notin result and val.invalidator.len > 0:
+      result.add fkInvalidator
 
 func addFiles(s: var string; val: ConceptExerciseFiles | PracticeExerciseFiles;
               prettyMode: PrettyMode; indentLevel = 1) =
@@ -389,6 +399,8 @@ func addFiles(s: var string; val: ConceptExerciseFiles | PracticeExerciseFiles;
         s.addArray("example", val.example, indentLevel = inner)
     of fkEditor:
       s.addArray("editor", val.editor, indentLevel = inner)
+    of fkInvalidator:
+      s.addArray("invalidator", val.invalidator, indentLevel = inner)
 
   s.removeComma()
   s.addNewlineAndIndent(indentLevel)

--- a/src/sync/sync_filepaths.nim
+++ b/src/sync/sync_filepaths.nim
@@ -44,6 +44,7 @@ func update(f: var (ConceptExerciseFiles | PracticeExerciseFiles),
   update(f.solution, patterns.solution, slug)
   update(f.test, patterns.test, slug)
   update(f.editor, patterns.editor, slug)
+  update(f.invalidator, patterns.invalidator, slug)
   when f is ConceptExerciseFiles:
     update(f.exemplar, patterns.exemplar, slug)
   when f is PracticeExerciseFiles:
@@ -61,7 +62,7 @@ func isSynced(f: ConceptExerciseFiles | PracticeExerciseFiles,
       genCond(exemplar)
     else:
       genCond(example)
-  uniqueCond and genCond(solution) and genCond(test) and genCond(editor)
+  uniqueCond and genCond(solution) and genCond(test) and genCond(editor) and genCond(invalidator)
 
 type
   ExerciseConfig* = object
@@ -161,8 +162,8 @@ proc checkOrUpdateFilepaths*(seenUnsynced: var set[SyncKind];
   ## Prints a message for each track exercise that:
   ## - lacks a `.meta/config.json` file
   ## - or has a `.meta/config.json` file with an missing/empty
-  ##   `files.solution|test|editor|example|exemplar` array, when that value has
-  ##   a pattern defined in the track-level `config.json` file.
+  ##   `files.solution|test|editor|invalidator|example|exemplar` array, when
+  ##   that value has a pattern defined in the track-level `config.json` file.
   ##
   ## Populates those values if `--update` was passed and the user confirms.
   ##

--- a/tests/test_fmt.nim
+++ b/tests/test_fmt.nim
@@ -323,6 +323,8 @@ proc testFmt =
         delete(j["files"], "originalKeyOrder")
         if j["files"]["editor"].len == 0:
           delete(j["files"], "editor")
+        if j["files"]["invalidator"].len == 0:
+          delete(j["files"], "invalidator")
         when e is ConceptExerciseConfig:
           let val = j["forked_from"]
           if val.kind == JNull or (val.kind == JArray and val.len == 0):


### PR DESCRIPTION
Upstream:
- https://github.com/exercism/docs/commit/322d63ecdbf6
- https://github.com/exercism/website/commit/695307892fd4

---

To-do:
- [x] Merge [#576](https://github.com/exercism/configlet/pull/576) first
- [x] Merge https://github.com/exercism/configlet/pull/585 first