### PR TITLE
github(workflows): install Nim from pre-built binaries on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Install Nim
-        uses: jiro4989/setup-nim-action@dae95c07ab8ffdf736af17d2214f926877e28ad8
+        uses: iffy/install-nim@09ef2b9c32a667d88097c8db32158a90a56165d1
         with:
-          nim-version: "1.6.4"
+          version: "binary:1.6.4"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Install Nim
-        uses: jiro4989/setup-nim-action@dae95c07ab8ffdf736af17d2214f926877e28ad8
+        uses: iffy/install-nim@09ef2b9c32a667d88097c8db32158a90a56165d1
         with:
-          nim-version: "1.6.4"
+          version: "binary:1.6.4"
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'


### PR DESCRIPTION
Check out the macOS job duration.

Both `iffy/install-nim` and `jiro4989/setup-nim-action` use `choosenim` by default, which installs prebuilt binaries only for Linux and Windows. On macOS, `choosenim` builds Nim from source, which is why each macOS job took a long time.

To resolve this, we can either:
- Use `actions/cache` to cache the binary we build on macOS (although the cache is cleared after 7 days of no use), or
- Download the prebuilt binaries from `nim-lang/nightlies`, which include macOS - e.g. the 1.6.4 ones are [here](https://github.com/nim-lang/nightlies/releases/tag/2022-02-09-version-1-6-7994556f3804c217035c44b453a3feec64405758).

This PR does the latter. `iffy/install-nim` hardcodes a lookup of release binaries in its [nightlies.txt](https://github.com/iffy/install-nim/blob/master/nightlies.txt).

Note that the pre-built binaries from https://nim-lang.org/install.html are from the nightlies:
```console
$ curl -sSfL -o nim-from-nightlies.tar.xz https://github.com/nim-lang/nightlies/releases/download/2022-02-09-version-1-6-7994556f3804c217035c44b453a3feec64405758/nim-1.6.4-linux_x64.tar.xz
$ curl -sSfL -o nim-from-nim-website.tar.xz https://nim-lang.org/download/nim-1.6.4-linux_x64.tar.xz
$ diff -s nim-from-nightlies.tar.xz nim-from-nim-website.tar.xz
Files nim-from-nightlies.tar.xz and nim-from-nim-website.tar.xz are identical
```

That's because release candidates start as nightlies - see e.g. https://forum.nim-lang.org/t/9100#59572

This change shouldn't produce more failures due to rate-limiting - although we'll now download Nim release tarballs from GitHub (not nim-lang.org), we'll no longer be downloading `choosenim` from GitHub.

Also note that CI for `nim-lang/nimble` [uses this action](https://github.com/nim-lang/nimble/blob/d68b2cb6efe8ce298cb5021fe84d3814d755322f/.github/workflows/test.yml#L23).

Closes: #222