### PR TITLE
github(workflows): use `GITHUB_TOKEN` during Nim installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
         uses: iffy/install-nim@09ef2b9c32a667d88097c8db32158a90a56165d1
         with:
           version: "binary:1.6.4"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,8 @@ jobs:
         uses: iffy/install-nim@09ef2b9c32a667d88097c8db32158a90a56165d1
         with:
           version: "binary:1.6.4"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install musl on Linux
         if: matrix.target.os == 'linux'


### PR DESCRIPTION
After 58b5c03cffe7, we have seen some CI failures due to rate-limiting:

```
API rate limit exceeded
But here's the good news: Authenticated requests get a higher rate limit.
Check out the documentation for more details:
https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
```

This commit should resolve that.

The `iffy/install-nim` action uses the token [only once](https://github.com/iffy/install-nim/blob/09ef2b9c32a6/install-nim.sh#L221-L225), when making an
authenticated request. We can try to restrict the [default permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
later.

Closes: #582