### PR TITLE
github(workflows): bump `iffy/install-nim` from 4.1.2 to 4.1.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Install Nim
-        uses: iffy/install-nim@09ef2b9c32a667d88097c8db32158a90a56165d1
+        uses: iffy/install-nim@7dd1812db4916d00b984d1c43339346a76e05487
         with:
           version: "binary:1.6.4"
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Install Nim
-        uses: iffy/install-nim@09ef2b9c32a667d88097c8db32158a90a56165d1
+        uses: iffy/install-nim@7dd1812db4916d00b984d1c43339346a76e05487
         with:
           version: "binary:1.6.4"
         env:


### PR DESCRIPTION
This is required to support today's release of Nim 1.6.6.

Links:
- https://github.com/iffy/install-nim/releases/tag/v4.1.3
- https://github.com/iffy/install-nim/compare/v4.1.2...v4.1.3