### PR TITLE
github(workflows): bump Ubuntu from 20.04 to 22.04

### DIFF
--- a/.github/bin/linux-install-build-tools
+++ b/.github/bin/linux-install-build-tools
@@ -1,8 +1,4 @@
 #!/usr/bin/env sh
 
-# Switch to GCC 10
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
-sudo update-alternatives --set gcc /usr/bin/gcc-10
-
 # Install musl
 sudo apt-get install musl-dev musl-tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-20.04
+            builder: ubuntu-22.04
           - target:
               os: mac
             builder: macos-11
@@ -66,7 +66,7 @@ jobs:
 
   checksums:
     needs: [build]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Upload checksums file
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - name: On Linux, switch to GCC 10 and install musl
+      - name: On Linux, install musl
         if: matrix.target.os == 'linux'
         run: ./.github/bin/linux-install-build-tools
 

--- a/.github/workflows/lint-whitespace.yml
+++ b/.github/workflows/lint-whitespace.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   lint_whitespace:
     name: Lint whitespace
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   markdownlint:
     name: Lint markdown files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   shellcheck:
     name: Run shellcheck on scripts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-20.04
+            builder: ubuntu-22.04
           - target:
               os: mac
             builder: macos-11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - name: On Linux, switch to GCC 10 and install musl
+      - name: On Linux, install musl
         if: matrix.target.os == 'linux'
         run: ./.github/bin/linux-install-build-tools
 


### PR DESCRIPTION
This commit also bumps:

- musl from to 1.1.24 to 1.2.2. This is good, because the 1.1 series was
  end-of-life.
- GCC from 10.3 to 11.2 (GCC 12 is not installed by default).

With the configlet 4.0.0-beta.5 (2022-07-02) Linux release binary:

```console
$ readelf -p .comment configlet

String dump of section '.comment':
  [     0]  GCC: (Ubuntu 9.2.1-12ubuntu1) 9.2.1 20191022
  [    2d]  GCC: (Ubuntu 10.3.0-1ubuntu1~20.04) 10.3.0
```

With a configlet built in the GitHub Actions environment using the
changes in this commit:

```console
$ readelf -p .comment configlet

String dump of section '.comment':
  [     0]  GCC: (Ubuntu 11.2.0-7ubuntu2) 11.2.0
  [    25]  GCC: (Ubuntu 11.2.0-19ubuntu1) 11.2.0
```

Links:

- [actions/runner-images#5490](https://github-redirect.dependabot.com/actions/runner-images/issues/5490)
- https://github.com/actions/runner-images/tree/c22e0f8ec89e#github-actions-runner-images
- https://github.com/actions/runner-images/blob/c22e0f8ec89e/images/linux/Ubuntu2204-Readme.md
- https://musl.libc.org/releases.html
- https://git.musl-libc.org/cgit/musl/log/
- https://gcc.gnu.org/gcc-11/changes.html
- https://gcc.gnu.org/releases.html
- https://github.blog/changelog/2022-05-10-github-actions-beta-of-ubuntu-22-04-for-github-hosted-runners-is-now-available/
- https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/

Closes: #194
Closes: #568
Closes: #607

---

With this PR:
```console
$ git grep --break --heading --ignore-case 'ubuntu'
.github/workflows/build.yml
24:            builder: ubuntu-22.04
69:    runs-on: ubuntu-22.04

.github/workflows/lint:whitespace.yml
8:    runs-on: ubuntu-22.04

.github/workflows/markdownlint.yml
8:    runs-on: ubuntu-22.04

.github/workflows/shellcheck.yml
8:    runs-on: ubuntu-22.04

.github/workflows/tests.yml
29:            builder: ubuntu-22.04
```