### PR TITLE
github(bin, workflows): bump GCC from 9.4 to 10.3

### DIFF
--- a/.github/bin/linux-install-build-tools
+++ b/.github/bin/linux-install-build-tools
@@ -1,3 +1,11 @@
 #!/usr/bin/env sh
 
+# Switch to GCC 10
+sudo update-alternatives --install \
+    /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-10 \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+sudo update-alternatives --set gcc /usr/bin/gcc-10
+
+# Install musl
 sudo apt-get install musl-dev musl-tools

--- a/.github/bin/linux-install-build-tools
+++ b/.github/bin/linux-install-build-tools
@@ -1,10 +1,7 @@
 #!/usr/bin/env sh
 
 # Switch to GCC 10
-sudo update-alternatives --install \
-    /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-10 \
-    --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
 sudo update-alternatives --set gcc /usr/bin/gcc-10
 
 # Install musl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,16 +35,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: On Linux, switch to GCC 10 and install musl
+        if: matrix.target.os == 'linux'
+        run: ./.github/bin/linux-install-build-tools
+
       - name: Install Nim
         uses: iffy/install-nim@7dd1812db4916d00b984d1c43339346a76e05487
         with:
           version: "binary:1.6.6"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install musl on Linux
-        if: matrix.target.os == 'linux'
-        run: ./.github/bin/linux-install-build-tools
 
       - name: Build binary
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,16 +40,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: On Linux, switch to GCC 10 and install musl
+        if: matrix.target.os == 'linux'
+        run: ./.github/bin/linux-install-build-tools
+
       - name: Install Nim
         uses: iffy/install-nim@7dd1812db4916d00b984d1c43339346a76e05487
         with:
           version: "binary:1.6.6"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install musl on Linux
-        if: matrix.target.os == 'linux'
-        run: ./.github/bin/linux-install-build-tools
 
       - name: Install our Nimble dependencies
         run: nimble --accept install --depsOnly


### PR DESCRIPTION
The Linux jobs currently use `ubuntu-20.04`, which currently uses
GCC 9.4 by default. However, GCC 10.3 is also [already installed](https://github.com/actions/virtual-environments/blob/5a2cb18a48bc/images/linux/Ubuntu2004-Readme.md#language-and-runtime), and
we can use via [`update-alternatives`](https://manpages.ubuntu.com/manpages/focal/en/man1/update-alternatives.1.html). It is not sufficient to only
set the `CC` environment variable.

At the time of writing, the `ubuntu-22.04` label is available as a
public beta, and it [adds GCC 11.2](https://github.com/actions/virtual-environments/blob/5a2cb18a48bc/images/linux/Ubuntu2204-Readme.md#language-and-runtime). The latest release is GCC 12.1.

Since GCC 5.1 (2015), GCC receives a major version bump once per year
(in late April or early May). Before that, ["the GCC major number carried
little to no useful information"](https://gcc.gnu.org/develop.html).

Here is an abridged history of recent [GCC releases](https://gcc.gnu.org/releases.html):

| Version | Date       |  
| ------: | ---------- |
|    12.1 | 2022-05-06 |
|    11.3 | 2022-04-21 |
|    11.2 | 2021-07-28 |
|     9.4 | 2021-06-01 |
|    11.1 | 2021-04-27 |
|    10.3 | 2021-04-08 |
|    10.2 | 2020-07-23 |
|    10.1 | 2020-05-07 |
|     9.3 | 2020-03-12 |
|     9.2 | 2019-08-12 |
|     9.1 | 2019-05-03 |
|     8.1 | 2018-05-02 |
|     7.1 | 2017-05-02 |
|     6.1 | 2016-04-27 |
|     5.1 | 2015-04-22 | 

With the configlet `4.0.0-beta.2` Linux release binary:

```console
$ readelf -p .comment configlet

String dump of section '.comment':
  [     0]  GCC: (Ubuntu 9.2.1-12ubuntu1) 9.2.1 20191022
  [    2d]  GCC: (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
```

With a configlet built in the GitHub Actions environment using this
commit:

```console
$ readelf -p .comment configlet

String dump of section '.comment':
  [     0]  GCC: (Ubuntu 9.2.1-12ubuntu1) 9.2.1 20191022
  [    2d]  GCC: (Ubuntu 10.3.0-1ubuntu1~20.04) 10.3.0
```

```console
$ file configlet
configlet: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```

The release notes for GCC 10 are [here](https://gcc.gnu.org/gcc-10/changes.html).

Closes: #193