### PR TITLE
info: refactor

### DIFF
--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -129,8 +129,9 @@ proc info*(conf: Conf) =
   let trackConfigPath = conf.trackDir / "config.json"
 
   if fileExists(trackConfigPath):
-    let trackConfigContents = readFile(trackConfigPath)
-    let trackConfig = TrackConfig.init(trackConfigContents)
+    let trackConfig = block:
+      let trackConfigContents = readFile(trackConfigPath)
+      TrackConfig.init(trackConfigContents)
 
     let exercises = trackConfig.exercises
     let conceptExercises = exercises.`concept`

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -13,6 +13,7 @@ func toStringSorted(s: HashSet[string]): string =
   var elements = toSeq(s)
   sort elements
   result = elements.join("\n")
+  result.add '\n'
 
 proc show(s: HashSet[string], header: string): string =
   ## Returns a string containing a colorized (when appropriate) `header`, and
@@ -21,8 +22,8 @@ proc show(s: HashSet[string], header: string): string =
   if s.len > 0:
     result.add toStringSorted(s)
   else:
-    result.add "none"
-  result.add "\n\n"
+    result.add "none\n"
+  result.add "\n"
 
 proc conceptsInfo(practiceExercises: seq[PracticeExercise],
                   concepts: seq[Concept]): string =
@@ -92,8 +93,7 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
         result.add &"\n{s} canonical data:\n"
         result.add toStringSorted(u)
   else:
-    result.add "none"
-  result.add '\n'
+    result.add "none\n"
 
 func count(exercises: seq[ConceptExercise] |
                       seq[PracticeExercise]): tuple[visible: int, wip: int] =

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -13,7 +13,6 @@ func toStringSorted(s: HashSet[string]): string =
   var elements = toSeq(s)
   sort elements
   result = elements.join("\n")
-  result.add '\n'
 
 proc show(s: HashSet[string], header: string): string =
   ## Returns a string containing a colorized (when appropriate) `header`, and
@@ -22,8 +21,8 @@ proc show(s: HashSet[string], header: string): string =
   if s.len > 0:
     result.add toStringSorted(s)
   else:
-    result.add "none\n"
-  result.add "\n"
+    result.add "none"
+  result.add "\n\n"
 
 proc conceptsInfo(practiceExercises: seq[PracticeExercise],
                   concepts: seq[Concept]): string =
@@ -93,7 +92,8 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
         result.add &"\n{s} canonical data:\n"
         result.add toStringSorted(u)
   else:
-    result.add "none\n"
+    result.add "none"
+  result.add '\n'
 
 func count(exercises: seq[ConceptExercise] |
                       seq[PracticeExercise]): tuple[visible: int, wip: int] =

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -28,10 +28,12 @@ proc conceptsInfo(practiceExercises: seq[PracticeExercise],
   let conceptSlugs = collect:
     for con in concepts:
       {con.slug}
+
   let prereqs = collect:
     for p in practiceExercises:
       for prereq in p.prerequisites:
         {prereq}
+
   let practices = collect:
     for p in practiceExercises:
       for prac in p.practices:

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -9,18 +9,18 @@ proc header(s: string): string =
   else:
     &"{s}\n"
 
-func toStringSorted(s: HashSet[string]): string =
-  var elements = toSeq(s)
+func toStringSorted(x: HashSet[string]): string =
+  var elements = toSeq(x)
   sort elements
   result = elements.join("\n")
   result.add '\n'
 
-proc show(s: HashSet[string], header: string): string =
+proc show(x: HashSet[string], header: string): string =
   ## Returns a string containing a colorized (when appropriate) `header`, and
-  ## then the elements of `s` in alphabetical order
+  ## then the elements of `x` in alphabetical order
   result = header(header)
-  if s.len > 0:
-    result.add toStringSorted(s)
+  if x.len > 0:
+    result.add toStringSorted(x)
   else:
     result.add "none\n"
   result.add "\n"

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -26,16 +26,16 @@ proc show[A](s: SomeSet[A], header: string): string =
 proc conceptsInfo(practiceExercises: seq[PracticeExercise],
                   concepts: seq[Concept]): string =
   let conceptSlugs = collect:
-    for item in concepts:
-      {item.slug}
+    for con in concepts:
+      {con.slug}
   let prereqs = collect:
     for p in practiceExercises:
       for prereq in p.prerequisites:
         {prereq}
   let practices = collect:
     for p in practiceExercises:
-      for item in p.practices:
-        {item}
+      for prac in p.practices:
+        {prac}
 
   let conceptsThatArentAPrereq = conceptSlugs - prereqs
   result = show(conceptsThatArentAPrereq,

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -118,7 +118,7 @@ proc trackSummary(conceptExercises: seq[ConceptExercise],
     {numConceptExercises:>3} Concept Exercises (plus {numConceptExercisesWip} work-in-progress)
     {numPracticeExercises:>3} Practice Exercises (plus {numPracticeExercisesWip} work-in-progress)
     {numExercises:>3} Exercises in total (plus {numExercisesWip} work-in-progress)
-    {numConcepts:>3} Concepts""".unindent(4)
+    {numConcepts:>3} Concepts""".unindent(4) # Preserve right-alignment of digits.
 
 proc info*(conf: Conf) =
   let trackConfigPath = conf.trackDir / "config.json"

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -21,7 +21,6 @@ proc init(T: typedesc[ProbSpecsState], path: static string): T =
   contents.fromJson(T)
 
 proc init(T: typedesc[ProbSpecsExercises]): T =
-  # TODO: automatically update this at build-time?
   const slugsPath = currentSourcePath().parentDir() / "prob_specs_exercises.json"
   ProbSpecsState.init(slugsPath).exercises
 

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -73,8 +73,8 @@ proc init(T: typedesc[ProbSpecsExercises]): T =
   contents.fromJson(ProbSpecsState).exercises
 
 proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
-                                     foregone: HashSet[string],
-                                     probSpecsExercises: ProbSpecsExercises): string =
+                                     foregone: HashSet[string]): string =
+  const probSpecsExercises = ProbSpecsExercises.init()
   let
     practiceExerciseSlugs = collect:
       for p in practiceExercises:
@@ -130,9 +130,7 @@ proc info*(conf: Conf) =
   if fileExists(trackConfigPath):
     let t = TrackConfig.init trackConfigPath.readFile()
     echo conceptsInfo(t.exercises.practice, t.concepts)
-    const probSpecsExercises = ProbSpecsExercises.init()
-    echo unimplementedProbSpecsExercises(t.exercises.practice, t.exercises.foregone,
-                                         probSpecsExercises)
+    echo unimplementedProbSpecsExercises(t.exercises.practice, t.exercises.foregone)
     echo trackSummary(t.exercises.`concept`, t.exercises.practice, t.concepts)
   else:
     var msg = &"file does not exist: {trackConfigPath}"

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -129,9 +129,8 @@ proc info*(conf: Conf) =
   let trackConfigPath = conf.trackDir / "config.json"
 
   if fileExists(trackConfigPath):
-    let trackConfig = TrackConfig.init trackConfigPath.readFile()
-
     let (conceptExercises, practiceExercises, foregone, concepts) = block:
+      let trackConfig = TrackConfig.init trackConfigPath.readFile()
       let exercises = trackConfig.exercises
       (exercises.`concept`, exercises.practice, exercises.foregone, trackConfig.concepts)
 

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -9,19 +9,20 @@ proc header(s: string): string =
   else:
     &"{s}\n"
 
-func toSeqSorted(s: HashSet[string]): seq[string] =
-  result = toSeq(s)
-  sort result
+func toStringSorted(s: HashSet[string]): string =
+  var elements = toSeq(s)
+  sort elements
+  result = ""
+  for item in elements:
+    result.add item
+    result.add '\n'
 
 proc show(s: HashSet[string], header: string): string =
   ## Returns a string containing a colorized (when appropriate) `header`, and
   ## then the elements of `s` in alphabetical order
   result = header(header)
   if s.len > 0:
-    let sorted = toSeqSorted(s)
-    for item in sorted:
-      result.add item
-      result.add "\n"
+    result.add toStringSorted(s)
   else:
     result.add "none\n"
   result.add "\n"
@@ -92,9 +93,7 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
     for (u, s) in [(uWith, "With"), (uWithout, "Without")]:
       if u.len > 0:
         result.add &"\n{s} canonical data:\n"
-        let uSorted = toSeqSorted(u)
-        for slug in uSorted:
-          result.add &"{slug}\n"
+        result.add toStringSorted(u)
   else:
     result.add "none\n"
 

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -25,12 +25,6 @@ proc init(T: typedesc[ProbSpecsExercises]): T =
   const slugsPath = currentSourcePath().parentDir() / "prob_specs_exercises.json"
   getPsState(slugsPath).exercises
 
-func getConceptSlugs(concepts: Concepts): HashSet[string] =
-  ## Returns the `slug` of every concept in `concepts`.
-  collect:
-    for item in concepts:
-      {item.slug}
-
 func getPrereqs(practiceExercises: seq[PracticeExercise]): HashSet[string] =
   ## Returns the concepts that appear at least once in the `prerequisites` array
   ## of a Practice Exercise in `practiceExercises`.
@@ -70,7 +64,9 @@ proc show[A](s: SomeSet[A], header: string): string =
 
 proc conceptsInfo(practiceExercises: seq[PracticeExercise],
                   concepts: seq[Concept]): string =
-  let conceptSlugs = getConceptSlugs(concepts)
+  let conceptSlugs = collect:
+    for item in concepts:
+      {item.slug}
   let prereqs = getPrereqs(practiceExercises)
   let practices = getPractices(practiceExercises)
 

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -2,24 +2,6 @@ import std/[algorithm, os, sequtils, sets, strformat, strutils, sugar, terminal]
 import pkg/jsony
 import ".."/[cli, types_track_config]
 
-type
-  ProbSpecsExercises = object
-    withCanonicalData: HashSet[string]
-    withoutCanonicalData: HashSet[string]
-    deprecated: HashSet[string]
-
-  ProbSpecsState = object
-    lastUpdated: string
-    problemSpecificationsCommitRef: string
-    exercises: ProbSpecsExercises
-
-proc init(T: typedesc[ProbSpecsExercises]): T =
-  ## Reads the prob-specs data at compile-time, and returns an object containing
-  ## every exercise in `exercism/problem-specifications`, grouped by kind.
-  const slugsPath = currentSourcePath().parentDir() / "prob_specs_exercises.json"
-  let contents = staticRead(slugsPath)
-  contents.fromJson(ProbSpecsState).exercises
-
 proc header(s: string): string =
   if colorStdout:
     const ansi = ansiForegroundColorCode(fgBlue)
@@ -67,6 +49,24 @@ proc conceptsInfo(practiceExercises: seq[PracticeExercise],
   result.add show(conceptsThatAreAPrereqButArentPracticed,
       "Concepts that are a prerequisite, but aren't practiced by any Practice Exercise:")
   stripLineEnd(result)
+
+type
+  ProbSpecsExercises = object
+    withCanonicalData: HashSet[string]
+    withoutCanonicalData: HashSet[string]
+    deprecated: HashSet[string]
+
+  ProbSpecsState = object
+    lastUpdated: string
+    problemSpecificationsCommitRef: string
+    exercises: ProbSpecsExercises
+
+proc init(T: typedesc[ProbSpecsExercises]): T =
+  ## Reads the prob-specs data at compile-time, and returns an object containing
+  ## every exercise in `exercism/problem-specifications`, grouped by kind.
+  const slugsPath = currentSourcePath().parentDir() / "prob_specs_exercises.json"
+  let contents = staticRead(slugsPath)
+  contents.fromJson(ProbSpecsState).exercises
 
 proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
                                      foregone: HashSet[string],

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -9,11 +9,11 @@ proc header(s: string): string =
   else:
     &"{s}\n"
 
-func toSeqSorted[A](s: SomeSet[A]): seq[A] =
+func toSeqSorted(s: HashSet[string]): seq[string] =
   result = toSeq(s)
   sort result
 
-proc show[A](s: SomeSet[A], header: string): string =
+proc show(s: HashSet[string], header: string): string =
   ## Returns a string containing a colorized (when appropriate) `header`, and
   ## then the elements of `s` in alphabetical order
   result = header(header)

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -83,6 +83,7 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
       &"There are {uWith.len + uWithout.len} non-deprecated exercises " &
       "in `exercism/problem-specifications` that\n" &
       "are both unimplemented and not in the track config `exercises.foregone` array:"
+
   result = header(header)
   if uWith.len > 0 or uWithout.len > 0:
     for (u, s) in [(uWith, "With"), (uWithout, "Without")]:
@@ -116,6 +117,7 @@ proc trackSummary(conceptExercises: seq[ConceptExercise],
     numExercises = numConceptExercises + numPracticeExercises
     numExercisesWip = numConceptExercisesWip + numPracticeExercisesWip
     numConcepts = concepts.len
+
   result = header("Track summary:")
   result.add fmt"""
     {numConceptExercises:>3} Concept Exercises (plus {numConceptExercisesWip} work-in-progress)

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -25,23 +25,24 @@ proc show[A](s: SomeSet[A], header: string): string =
 
 proc conceptsInfo(practiceExercises: seq[PracticeExercise],
                   concepts: seq[Concept]): string =
-  let conceptSlugs = collect:
-    for con in concepts:
-      {con.slug}
+  let
+    conceptSlugs = collect:
+      for con in concepts:
+        {con.slug}
 
-  let prereqs = collect:
-    for p in practiceExercises:
-      for prereq in p.prerequisites:
-        {prereq}
+    prereqs = collect:
+      for p in practiceExercises:
+        for prereq in p.prerequisites:
+          {prereq}
 
-  let practices = collect:
-    for p in practiceExercises:
-      for prac in p.practices:
-        {prac}
+    practices = collect:
+      for p in practiceExercises:
+        for prac in p.practices:
+          {prac}
 
-  let conceptsThatArentAPrereq = conceptSlugs - prereqs
-  let conceptsThatArentPracticed = conceptSlugs - practices
-  let conceptsThatAreAPrereqButArentPracticed = prereqs - practices
+    conceptsThatArentAPrereq = conceptSlugs - prereqs
+    conceptsThatArentPracticed = conceptSlugs - practices
+    conceptsThatAreAPrereqButArentPracticed = prereqs - practices
 
   result = show(conceptsThatArentAPrereq,
       "Concepts that aren't a prerequisite for any Practice Exercise:")

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -13,17 +13,17 @@ type
     problemSpecificationsCommitRef: string
     exercises: ProbSpecsExercises
 
-proc getPsState(path: static string): ProbSpecsState =
+proc init(T: typedesc[ProbSpecsState], path: static string): T =
   ## Reads the slugs file at `path` at compile-time, and returns an object
   ## containing every exercise in `exercism/problem-specifications`, grouped by
   ## kind.
   let contents = staticRead(path)
-  contents.fromJson(ProbSpecsState)
+  contents.fromJson(T)
 
 proc init(T: typedesc[ProbSpecsExercises]): T =
   # TODO: automatically update this at build-time?
   const slugsPath = currentSourcePath().parentDir() / "prob_specs_exercises.json"
-  getPsState(slugsPath).exercises
+  ProbSpecsState.init(slugsPath).exercises
 
 proc header(s: string): string =
   if colorStdout:

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -129,9 +129,7 @@ proc info*(conf: Conf) =
   let trackConfigPath = conf.trackDir / "config.json"
 
   if fileExists(trackConfigPath):
-    let trackConfig = block:
-      let trackConfigContents = readFile(trackConfigPath)
-      TrackConfig.init(trackConfigContents)
+    let trackConfig = TrackConfig.init trackConfigPath.readFile()
 
     let exercises = trackConfig.exercises
     let conceptExercises = exercises.`concept`

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -12,10 +12,8 @@ proc header(s: string): string =
 func toStringSorted(s: HashSet[string]): string =
   var elements = toSeq(s)
   sort elements
-  result = ""
-  for item in elements:
-    result.add item
-    result.add '\n'
+  result = elements.join("\n")
+  result.add '\n'
 
 proc show(s: HashSet[string], header: string): string =
   ## Returns a string containing a colorized (when appropriate) `header`, and

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -13,16 +13,12 @@ type
     problemSpecificationsCommitRef: string
     exercises: ProbSpecsExercises
 
-proc init(T: typedesc[ProbSpecsState], path: static string): T =
-  ## Reads the slugs file at `path` at compile-time, and returns an object
-  ## containing every exercise in `exercism/problem-specifications`, grouped by
-  ## kind.
-  let contents = staticRead(path)
-  contents.fromJson(T)
-
 proc init(T: typedesc[ProbSpecsExercises]): T =
+  ## Reads the prob-specs data at compile-time, and returns an object containing
+  ## every exercise in `exercism/problem-specifications`, grouped by kind.
   const slugsPath = currentSourcePath().parentDir() / "prob_specs_exercises.json"
-  ProbSpecsState.init(slugsPath).exercises
+  let contents = staticRead(slugsPath)
+  contents.fromJson(ProbSpecsState).exercises
 
 proc header(s: string): string =
   if colorStdout:

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -25,14 +25,6 @@ proc init(T: typedesc[ProbSpecsExercises]): T =
   const slugsPath = currentSourcePath().parentDir() / "prob_specs_exercises.json"
   getPsState(slugsPath).exercises
 
-func getPrereqs(practiceExercises: seq[PracticeExercise]): HashSet[string] =
-  ## Returns the concepts that appear at least once in the `prerequisites` array
-  ## of a Practice Exercise in `practiceExercises`.
-  collect:
-    for practiceExercise in practiceExercises:
-      for prereq in practiceExercise.prerequisites:
-        {prereq}
-
 func getPractices(practiceExercises: seq[PracticeExercise]): HashSet[string] =
   ## Returns the concepts that appear at least once in the `practices` array
   ## of a Practice Exercise in `practiceExercises`.
@@ -67,7 +59,10 @@ proc conceptsInfo(practiceExercises: seq[PracticeExercise],
   let conceptSlugs = collect:
     for item in concepts:
       {item.slug}
-  let prereqs = getPrereqs(practiceExercises)
+  let prereqs = collect:
+    for practiceExercise in practiceExercises:
+      for prereq in practiceExercise.prerequisites:
+        {prereq}
   let practices = getPractices(practiceExercises)
 
   let conceptsThatArentAPrereq = conceptSlugs - prereqs

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -25,14 +25,6 @@ proc init(T: typedesc[ProbSpecsExercises]): T =
   const slugsPath = currentSourcePath().parentDir() / "prob_specs_exercises.json"
   getPsState(slugsPath).exercises
 
-func getPractices(practiceExercises: seq[PracticeExercise]): HashSet[string] =
-  ## Returns the concepts that appear at least once in the `practices` array
-  ## of a Practice Exercise in `practiceExercises`.
-  collect:
-    for practiceExercise in practiceExercises:
-      for item in practiceExercise.practices:
-        {item}
-
 proc header(s: string): string =
   if colorStdout:
     const ansi = ansiForegroundColorCode(fgBlue)
@@ -63,7 +55,10 @@ proc conceptsInfo(practiceExercises: seq[PracticeExercise],
     for practiceExercise in practiceExercises:
       for prereq in practiceExercise.prerequisites:
         {prereq}
-  let practices = getPractices(practiceExercises)
+  let practices = collect:
+    for practiceExercise in practiceExercises:
+      for item in practiceExercise.practices:
+        {item}
 
   let conceptsThatArentAPrereq = conceptSlugs - prereqs
   result = show(conceptsThatArentAPrereq,

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -128,15 +128,12 @@ proc info*(conf: Conf) =
   let trackConfigPath = conf.trackDir / "config.json"
 
   if fileExists(trackConfigPath):
-    let (conceptExercises, practiceExercises, foregone, concepts) = block:
-      let trackConfig = TrackConfig.init trackConfigPath.readFile()
-      let exercises = trackConfig.exercises
-      (exercises.`concept`, exercises.practice, exercises.foregone, trackConfig.concepts)
-
-    echo conceptsInfo(practiceExercises, concepts)
+    let t = TrackConfig.init trackConfigPath.readFile()
+    echo conceptsInfo(t.exercises.practice, t.concepts)
     const probSpecsExercises = ProbSpecsExercises.init()
-    echo unimplementedProbSpecsExercises(practiceExercises, foregone, probSpecsExercises)
-    echo trackSummary(conceptExercises, practiceExercises, concepts)
+    echo unimplementedProbSpecsExercises(t.exercises.practice, t.exercises.foregone,
+                                         probSpecsExercises)
+    echo trackSummary(t.exercises.`concept`, t.exercises.practice, t.concepts)
   else:
     var msg = &"file does not exist: {trackConfigPath}"
     if conf.trackDir == getCurrentDir():

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -131,11 +131,9 @@ proc info*(conf: Conf) =
   if fileExists(trackConfigPath):
     let trackConfig = TrackConfig.init trackConfigPath.readFile()
 
-    let exercises = trackConfig.exercises
-    let conceptExercises = exercises.`concept`
-    let practiceExercises = exercises.practice
-    let foregone = exercises.foregone
-    let concepts = trackConfig.concepts
+    let (conceptExercises, practiceExercises, foregone, concepts) = block:
+      let exercises = trackConfig.exercises
+      (exercises.`concept`, exercises.practice, exercises.foregone, trackConfig.concepts)
 
     echo conceptsInfo(practiceExercises, concepts)
     const probSpecsExercises = ProbSpecsExercises.init()

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -110,11 +110,12 @@ func count(exercises: seq[ConceptExercise] |
 proc trackSummary(conceptExercises: seq[ConceptExercise],
                   practiceExercises: seq[PracticeExercise],
                   concepts: seq[Concept]): string =
-  let (numConceptExercises, numConceptExercisesWip) = count(conceptExercises)
-  let (numPracticeExercises, numPracticeExercisesWip) = count(practiceExercises)
-  let numExercises = numConceptExercises + numPracticeExercises
-  let numExercisesWip = numConceptExercisesWip + numPracticeExercisesWip
-  let numConcepts = concepts.len
+  let
+    (numConceptExercises, numConceptExercisesWip) = count(conceptExercises)
+    (numPracticeExercises, numPracticeExercisesWip) = count(practiceExercises)
+    numExercises = numConceptExercises + numPracticeExercises
+    numExercisesWip = numConceptExercisesWip + numPracticeExercisesWip
+    numConcepts = concepts.len
   result = header("Track summary:")
   result.add fmt"""
     {numConceptExercises:>3} Concept Exercises (plus {numConceptExercisesWip} work-in-progress)

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -83,16 +83,13 @@ proc conceptsInfo(practiceExercises: seq[PracticeExercise],
       "Concepts that are a prerequisite, but aren't practiced by any Practice Exercise:")
   stripLineEnd(result)
 
-func getSlugs(practiceExercises: seq[PracticeExercise]): HashSet[string] =
-  collect:
-    for practiceExercise in practiceExercises:
-      {practiceExercise.slug.`$`}
-
 proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
                                      foregone: HashSet[string],
                                      probSpecsExercises: ProbSpecsExercises): string =
   let
-    practiceExerciseSlugs = getSlugs(practiceExercises)
+    practiceExerciseSlugs = collect:
+      for practiceExercise in practiceExercises:
+        {practiceExercise.slug.`$`}
     uWith = probSpecsExercises.withCanonicalData - practiceExerciseSlugs - foregone
     uWithout = probSpecsExercises.withoutCanonicalData - practiceExerciseSlugs - foregone
     header =

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -29,12 +29,12 @@ proc conceptsInfo(practiceExercises: seq[PracticeExercise],
     for item in concepts:
       {item.slug}
   let prereqs = collect:
-    for practiceExercise in practiceExercises:
-      for prereq in practiceExercise.prerequisites:
+    for p in practiceExercises:
+      for prereq in p.prerequisites:
         {prereq}
   let practices = collect:
-    for practiceExercise in practiceExercises:
-      for item in practiceExercise.practices:
+    for p in practiceExercises:
+      for item in p.practices:
         {item}
 
   let conceptsThatArentAPrereq = conceptSlugs - prereqs
@@ -73,8 +73,8 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
                                      probSpecsExercises: ProbSpecsExercises): string =
   let
     practiceExerciseSlugs = collect:
-      for practiceExercise in practiceExercises:
-        {practiceExercise.slug.`$`}
+      for p in practiceExercises:
+        {p.slug.`$`}
     uWith = probSpecsExercises.withCanonicalData - practiceExerciseSlugs - foregone
     uWithout = probSpecsExercises.withoutCanonicalData - practiceExerciseSlugs - foregone
     header =

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -9,14 +9,17 @@ proc header(s: string): string =
   else:
     &"{s}\n"
 
+func toSeqSorted[A](s: SomeSet[A]): seq[A] =
+  result = toSeq(s)
+  sort result
+
 proc show[A](s: SomeSet[A], header: string): string =
   ## Returns a string containing a colorized (when appropriate) `header`, and
   ## then the elements of `s` in alphabetical order
   result = header(header)
   if s.len > 0:
-    var elements = toSeq(s)
-    sort elements
-    for item in elements:
+    let sorted = toSeqSorted(s)
+    for item in sorted:
       result.add item
       result.add "\n"
   else:
@@ -89,9 +92,8 @@ proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
     for (u, s) in [(uWith, "With"), (uWithout, "Without")]:
       if u.len > 0:
         result.add &"\n{s} canonical data:\n"
-        var u = toSeq(u)
-        sort u
-        for slug in u:
+        let uSorted = toSeqSorted(u)
+        for slug in uSorted:
           result.add &"{slug}\n"
   else:
     result.add "none\n"

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -38,14 +38,13 @@ proc conceptsInfo(practiceExercises: seq[PracticeExercise],
         {prac}
 
   let conceptsThatArentAPrereq = conceptSlugs - prereqs
+  let conceptsThatArentPracticed = conceptSlugs - practices
+  let conceptsThatAreAPrereqButArentPracticed = prereqs - practices
+
   result = show(conceptsThatArentAPrereq,
       "Concepts that aren't a prerequisite for any Practice Exercise:")
-
-  let conceptsThatArentPracticed = conceptSlugs - practices
   result.add show(conceptsThatArentPracticed,
       "Concepts that aren't practiced by any Practice Exercise:")
-
-  let conceptsThatAreAPrereqButArentPracticed = prereqs - practices
   result.add show(conceptsThatAreAPrereqButArentPracticed,
       "Concepts that are a prerequisite, but aren't practiced by any Practice Exercise:")
   stripLineEnd(result)

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -1,4 +1,4 @@
-import std/[algorithm, os, sequtils, sets, strformat, strutils, terminal]
+import std/[algorithm, os, sequtils, sets, strformat, strutils, sugar, terminal]
 import pkg/jsony
 import ".."/[cli, types_track_config]
 
@@ -27,25 +27,25 @@ proc init(T: typedesc[ProbSpecsExercises]): T =
 
 func getConceptSlugs(concepts: Concepts): HashSet[string] =
   ## Returns the `slug` of every concept in `concepts`.
-  result = initHashSet[string](concepts.len)
-  for item in concepts:
-    result.incl item.slug
+  collect:
+    for item in concepts:
+      {item.slug}
 
 func getPrereqs(practiceExercises: seq[PracticeExercise]): HashSet[string] =
   ## Returns the concepts that appear at least once in the `prerequisites` array
   ## of a Practice Exercise in `practiceExercises`.
-  result = initHashSet[string]()
-  for practiceExercise in practiceExercises:
-    for prereq in practiceExercise.prerequisites:
-      result.incl prereq
+  collect:
+    for practiceExercise in practiceExercises:
+      for prereq in practiceExercise.prerequisites:
+        {prereq}
 
 func getPractices(practiceExercises: seq[PracticeExercise]): HashSet[string] =
   ## Returns the concepts that appear at least once in the `practices` array
   ## of a Practice Exercise in `practiceExercises`.
-  result = initHashSet[string]()
-  for practiceExercise in practiceExercises:
-    for item in practiceExercise.practices:
-      result.incl item
+  collect:
+    for practiceExercise in practiceExercises:
+      for item in practiceExercise.practices:
+        {item}
 
 proc header(s: string): string =
   if colorStdout:
@@ -88,9 +88,9 @@ proc conceptsInfo(practiceExercises: seq[PracticeExercise],
   stripLineEnd(result)
 
 func getSlugs(practiceExercises: seq[PracticeExercise]): HashSet[string] =
-  result = initHashSet[string](practiceExercises.len)
-  for practiceExercise in practiceExercises:
-    result.incl $practiceExercise.slug
+  collect:
+    for practiceExercise in practiceExercises:
+      {practiceExercise.slug.`$`}
 
 proc unimplementedProbSpecsExercises(practiceExercises: seq[PracticeExercise],
                                      foregone: HashSet[string],


### PR DESCRIPTION
I find this more readable overall. See the commit messages for more details.

I've checked that this PR keeps the output of `configlet info` the same on every track.

---

Summary:
- Inline the procedures that are only called once, which can reduce
  cognitive load when reading. We can refactor to common procs later for
  functionality that we need more than once (e.g. in another command).
- Start using `sugar.collect` - it also helps the above inlining.
- Remove a TODO: `configlet info` will soon use the prob-specs cache.
- Remove unneeded generic in `show[A]`. This makes it immediately
  obvious that we only operate on `HashSet[string]`, and fixes the doc
  comment - it said that elements are returned "in alphabetical order",
  which wouldn't be true for e.g. `HashSet[int]`.
- Use a new `toStringSorted` common proc.
- Avoid `s` as name of `HashSet` parameter - reserve `s` for `string`.
- Move type and `init` declarations: make declaration order match usage
  order.
- Move `probSpecsExercises` declaration to the innermost possible scope.