### PR TITLE
github(workflows): bump macOS from 11 to 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
             builder: ubuntu-22.04
           - target:
               os: mac
-            builder: macos-11
+            builder: macos-12
           - target:
               os: windows
             builder: windows-2022

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
             builder: ubuntu-22.04
           - target:
               os: mac
-            builder: macos-11
+            builder: macos-12
           - target:
               os: windows
             builder: windows-2022


### PR DESCRIPTION
We shouldn't merge until it's announced as stable.

---

This bumps Clang [from](https://github.com/actions/runner-images/blob/b4c27dac058a/images/macos/macos-11-Readme.md) 13.0.0 [to](https://github.com/actions/runner-images/blob/b4c27dac058a/images/macos/macos-12-Readme.md) 13.1.6.

`macos-12` has been available as a [public beta since 2022-04-25](https://github.blog/changelog/2022-04-25-github-actions-public-beta-of-macos-12-for-github-hosted-runners-is-now-available/) and
[exited beta on 2022-06-13](https://github.blog/changelog/2022-06-13-github-actions-macos-12-for-github-hosted-runners-is-now-generally-available/).

`macos-latest` [does not yet use](https://github.com/actions/runner-images/tree/b4c27dac058a#available-images) macOS 12.

Closes: #569