### PR TITLE
exec: remove trailing slash from to-be-cloned URL

### DIFF
--- a/src/exec.nim
+++ b/src/exec.nim
@@ -82,7 +82,7 @@ proc cloneExercismRepo*(repoName, dest: string; shallow = false;
   ## `singleBranch` is `true`.
   ##
   ## Quits if the clone is unsuccessful.
-  let url = &"https://github.com/exercism/{repoName}/"
+  let url = &"https://github.com/exercism/{repoName}"
   let args = block:
     var res = @["clone"]
     if shallow:


### PR DESCRIPTION
Under some circumstances, it seems that a trailing slash can cause
`configlet sync` to fail during the `git clone` part:

```console
$ bin/configlet sync -e clock
Cloning https://github.com/exercism/problem-specifications/... failure
Cloning into '/Users/mark/Library/Caches/exercism/configlet/problem-specifications'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

The same user saw `git clone` fail with the trailing slash:

```console
$ git clone https://github.com/exercism/problem-specifications/
Cloning into 'problem-specifications'...
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

but succeed without the trailing slash:

```console
$ git clone https://github.com/exercism/problem-specifications
Cloning into 'problem-specifications'...
remote: Enumerating objects: 12177, done.
remote: Counting objects: 100% (1125/1125), done.
remote: Compressing objects: 100% (354/354), done.
remote: Total 12177 (delta 911), reused 843 (delta 769), pack-reused 11052
Receiving objects: 100% (12177/12177), 2.69 MiB | 3.23 MiB/s, done.
Resolving deltas: 100% (7363/7363), done.
```

There's no advantage from the trailing slash anyway. Let's remove it.

Fixes: #599
Refs: https://github.com/exercism/crystal/pull/273

---

I believe it is more correct here for the URL not to end in `.git`.