### PR TITLE
sync(tests): improve error for invalid TOML

### DIFF
--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -77,6 +77,9 @@ proc init(T: typedesc[PracticeExerciseTests], testsPath: string): T =
           The expected 'tests.toml' format is documented in
           https://exercism.org/docs/building/configlet/sync#h-tests""".unindent()
         quit 1
+      except CatchableError:
+        stderr.writeLine "Error: " & getCurrentExceptionMsg()
+        quit 1
 
     for uuid, val in tests.getTable():
       if val.hasKey("include"):

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -1,4 +1,4 @@
-import std/[algorithm, json, os, sets]
+import std/[algorithm, json, os, sets, strformat, strutils]
 import pkg/parsetoml
 import ".."/cli
 
@@ -65,7 +65,18 @@ proc init(T: typedesc[PracticeExerciseTests], testsPath: string): T =
   ## included and excluded test case UUIDs.
   result = PracticeExerciseTests.init()
   if fileExists(testsPath):
-    let tests = parsetoml.parseFile(testsPath)
+    let tests =
+      try:
+        parsetoml.parseFile(testsPath)
+      except TomlError: # Note that `TomlError` inherits from `Defect`.
+        stderr.writeLine fmt"""
+
+          Error: A 'tests.toml' file contains invalid TOML:
+          {getCurrentExceptionMsg()}
+
+          The expected 'tests.toml' format is documented in
+          https://exercism.org/docs/building/configlet/sync#h-tests""".unindent()
+        quit 1
 
     for uuid, val in tests.getTable():
       if val.hasKey("include"):


### PR DESCRIPTION
A `tests.toml` file might contain invalid TOML. For example:

```toml
[2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a]
description = encode yes
```

where `encode yes` is [invalid because it is unquoted](https://toml.io/en/v1.0.0#string).

Before this commit, `configlet sync` would not handle the TOML parsing
exception:

```console
$ cd /tmp
$ git clone --quiet https://github.com/exercism/common-lisp
$ cd common-lisp
$ git checkout f521b1fb0f04ffc2d5baa6cf0bba37c231cc1bd7
$ bin/fetch-configlet
$ bin/configlet sync --tests
Updating cached 'problem-specifications' data...
Checking exercises...
parsetoml.nim(908)       parseValue
Error: unhandled exception: /tmp/common-lisp/exercises/practice/affine-cipher/.meta/tests.toml(6:16) unexpected character "e" [TomlError]
```

With this commit, configlet still exits immediately, but handles the
exception:

```console
$ configlet sync --tests
Updating cached 'problem-specifications' data...
Checking exercises...

Error: A 'tests.toml' file contains invalid TOML:
/tmp/common-lisp/exercises/practice/affine-cipher/.meta/tests.toml(6:16) unexpected character "e"

The expected 'tests.toml' format is documented in
https://exercism.org/docs/building/configlet/sync#h-tests
```

Note that `configlet lint` does not yet lint `tests.toml` files, and so
invalid TOML does not yet cause `configlet lint` to indicate an error.

Closes: #613