### PR TITLE
nimble: set version from `configlet.version` file

### DIFF
--- a/configlet.nimble
+++ b/configlet.nimble
@@ -1,7 +1,16 @@
 import std/[hashes, os, strutils]
 
+proc getVersionStart: string =
+  # Returns the `major.minor.patch` version in the `configlet.version` file
+  # (that is, omitting any pre-release version information).
+  result = staticRead("configlet.version")
+  for i, c in result:
+    if c notin {'0'..'9', '.'}:
+      result.setLen(i)
+      return result
+
 # Package
-version       = "4.0.0"
+version       = getVersionStart() # Must consist only of digits and '.'
 author        = "ee7"
 description   = "A tool for managing Exercism language track repositories"
 license       = "AGPL-3.0-only"


### PR DESCRIPTION
Configlet has been using prerelease semantic versions (which contain a
hyphen) like `4.0.0-beta.1`. However, such a version is currently
not allowed in the nimble file:

```console
$ nimble check
     Error: Version may only consist of numbers and the '.' character but found '-'.
   Failure: Validation failed
```

As a workaround, we have been specifying the configlet version in a
custom `configlet.version` file (see commit e90c5ec19be6) that can
contain anything.

Let's use that file to set the nimble file `version`. This will allow
future major/minor/patch version bumps to occur only in a dedicated
file, like the prerelease ones.

This commit does not change the version string:

```console
$ nimble dump | grep version
version: "4.0.0"
```

---

Just some DRYing that's nice to have before `4.0.0` stable. This will also simplify the version bumping script because the place to bump will be the same regardless of whether it's a pre-release version or not.