### PR TITLE
generate: refactor slightly

### DIFF
--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -23,7 +23,7 @@ proc conceptIntroduction(trackDir: Path, slug: string,
       # Strip the top-level heading (if any)
       if scanp(result, i, *{' ', '\t', '\v', '\c', '\n', '\f'}, "#", +' ',
                +(~'\n')):
-        result = result[i..^1]
+        result.setSlice(i..result.high)
       strip result
     else:
       writeError(&"File {path} not found for concept '{slug}'", templatePath)

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -18,14 +18,12 @@ proc conceptIntroduction(trackDir: Path, slug: string,
   if dirExists(conceptDir):
     let path = conceptDir / "introduction.md"
     if fileExists(path):
-      let content = readFile(path)
+      result = readFile(path)
       var i = 0
       # Strip the top-level heading (if any)
-      if scanp(content, i, *{' ', '\t', '\v', '\c', '\n', '\f'}, "#", +' ',
+      if scanp(result, i, *{' ', '\t', '\v', '\c', '\n', '\f'}, "#", +' ',
                +(~'\n')):
-        result = content[i..^1]
-      else:
-        result = content
+        result = result[i..^1]
       strip result
     else:
       writeError(&"File {path} not found for concept '{slug}'", templatePath)

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -37,6 +37,7 @@ proc generateIntroduction(trackDir: Path, templatePath: Path): string =
   ## Reads the file at `templatePath` and returns the content of the
   ## corresponding `introduction.md` file.
   let content = readFile(templatePath)
+  result = newStringOfCap(1024)
 
   var i = 0
   while i < content.len:

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -23,7 +23,7 @@ proc conceptIntroduction(trackDir: Path, slug: string,
       # Strip the top-level heading (if any)
       if scanp(content, i, *{' ', '\t', '\v', '\c', '\n', '\f'}, "#", +' ',
                +(~'\n')):
-        result = content.substr(i).strip
+        result = content[i..^1].strip
       else:
         result = content.strip
     else:

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -1,4 +1,4 @@
-import std/[strformat, strscans, strutils, terminal]
+import std/[strbasics, strformat, strscans, terminal]
 import ".."/[cli, helpers]
 
 proc writeError(description: string, path: Path) =
@@ -23,9 +23,10 @@ proc conceptIntroduction(trackDir: Path, slug: string,
       # Strip the top-level heading (if any)
       if scanp(content, i, *{' ', '\t', '\v', '\c', '\n', '\f'}, "#", +' ',
                +(~'\n')):
-        result = content[i..^1].strip
+        result = content[i..^1]
       else:
-        result = content.strip
+        result = content
+      strip result
     else:
       writeError(&"File {path} not found for concept '{slug}'", templatePath)
       quit(1)

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -19,11 +19,11 @@ proc conceptIntroduction(trackDir: Path, slug: string,
     let path = conceptDir / "introduction.md"
     if fileExists(path):
       let content = readFile(path)
-      var idx = 0
+      var i = 0
       # Strip the top-level heading (if any)
-      if scanp(content, idx, *{' ', '\t', '\v', '\c', '\n', '\f'}, "#", +' ',
+      if scanp(content, i, *{' ', '\t', '\v', '\c', '\n', '\f'}, "#", +' ',
                +(~'\n')):
-        result = content.substr(idx).strip
+        result = content.substr(i).strip
       else:
         result = content.strip
     else:
@@ -39,19 +39,19 @@ proc generateIntroduction(trackDir: Path, templatePath: Path): string =
   ## corresponding `introduction.md` file.
   let content = readFile(templatePath)
 
-  var idx = 0
-  while idx < content.len:
+  var i = 0
+  while i < content.len:
     var conceptSlug = ""
     # Here, we implement the syntax for a placeholder as %{concept:some-slug}
     # where we allow spaces after the opening brace, around the colon,
     # and before the closing brace. The slug must be in kebab-case.
-    if scanp(content, idx,
+    if scanp(content, i,
              "%{", *{' '}, "concept", *{' '}, ':', *{' '},
              +{'a'..'z', '-'} -> conceptSlug.add($_), *{' '}, '}'):
       result.add conceptIntroduction(trackDir, conceptSlug, templatePath)
     else:
-      result.add content[idx]
-      inc idx
+      result.add content[i]
+      inc i
 
 proc generate*(conf: Conf) =
   ## For every Concept Exercise in `conf.trackDir` with an `introduction.md.tpl`

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -64,5 +64,5 @@ proc generate*(conf: Conf) =
       let introductionTemplatePath = conceptExerciseDir / ".docs" / "introduction.md.tpl"
       if fileExists(introductionTemplatePath):
         let introduction = generateIntroduction(trackDir, introductionTemplatePath)
-        let introductionPath = conceptExerciseDir / ".docs" / "introduction.md"
+        let introductionPath = introductionTemplatePath.string[0..^5] # Removes `.tpl`
         writeFile(introductionPath, introduction)


### PR DESCRIPTION
Summary:

- Rename index variable to `i`

- Prefer in-place `strip` and slice

- Remove an `else` branch

- Explicitly initialize `result` - the previous pattern of `result.add`
  before setting `result` may become an error in a future version of Nim

- DRY filename setting

---

Just splitting outsome tiny refactorings I did while working on the generate code.

I had some other refactorings here, but I'll leave them for later.