### PR TITLE
generate: make interface consistent with sync and fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Options for fmt:
   -u, --update                    Prompt to write formatted files
   -y, --yes                       Auto-confirm the prompt from --update
 
+Options for generate:
+  -e, --exercise <slug>           Only operate on this exercise
+  -u, --update                    Prompt to write generated files
+  -y, --yes                       Auto-confirm the prompt from --update
+
 Options for info:
   -o, --offline                   Do not update the cached 'problem-specifications' data
 

--- a/completions/configlet.bash
+++ b/completions/configlet.bash
@@ -61,7 +61,14 @@ _configlet_complete_lint_() {
 }
 
 _configlet_complete_generate_() {
-  _configlet_complete_options_ "$global_opts"
+  case $prev in
+    '-e' | '--exercise')
+      _configlet_complete_slugs_ "practice" "concept"
+      ;;
+    *)
+      _configlet_complete_options_ "-e --exercise -u --update -y --yes $global_opts"
+      ;;
+  esac
 }
 
 _configlet_complete_info_() {

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -6,7 +6,6 @@ end
 complete -c configlet -f
 
 # subcommands with no options
-complete -c configlet -n "__fish_use_subcommand" -a generate   -d "Generate concept exercise introductions"
 complete -c configlet -n "__fish_use_subcommand" -a lint       -d "Check the track configuration for correctness"
 
 # subcommands with options
@@ -36,6 +35,12 @@ complete -c configlet -n "__fish_seen_subcommand_from fmt"        -s e -l exerci
   -xa '(__fish_configlet_find_dirs ./exercises/{concept,practice})'
 complete -c configlet -n "__fish_seen_subcommand_from fmt"        -s u -l update    -d "Write changes"
 complete -c configlet -n "__fish_seen_subcommand_from fmt"        -s y -l yes       -d "Auto-confirm update"
+
+# generate subcommand
+complete -c configlet -n "__fish_seen_subcommand_from generate"   -s e -l exercise  -d "exercise slug" \
+  -xa '(__fish_configlet_find_dirs ./exercises/{concept,practice})'
+complete -c configlet -n "__fish_seen_subcommand_from generate"   -s u -l update    -d "Write changes"
+complete -c configlet -n "__fish_seen_subcommand_from generate"   -s y -l yes       -d "Auto-confirm update"
 
 # info subcommand
 complete -c configlet -n "__fish_seen_subcommand_from info"       -s o -l offline   -d "Do not update prob-specs cache"

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -67,6 +67,9 @@ _configlet() {
     (generate)
       _arguments "${_arguments_options[@]}" \
           "$_configlet_global_opts[@]" \
+          '(-e --exercise)'{-e+,--exercise=}'[exercise slug]:slug:_configlet_complete_any_exercise_slug' \
+          {-u,--update}'[Write changes]' \
+          {-y,--yes}'[Auto-confirm update]' \
       ;;
     (lint)
       _arguments "${_arguments_options[@]}" \

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -95,6 +95,7 @@ proc fileExists*(path: Path): bool {.borrow.}
 proc readFile*(path: Path): string {.borrow.}
 proc writeFile*(path: Path; content: string) {.borrow.}
 proc parentDir*(path: Path): string {.borrow.}
+proc splitFile*(path: Path): tuple[dir, name: Path, ext: string] {.borrow.}
 
 func toLineAndCol(s: string; offset: Natural): tuple[line: int; col: int] =
   ## Returns the line and column number corresponding to the `offset` in `s`.

--- a/tests/test_binary_generate.nim
+++ b/tests/test_binary_generate.nim
@@ -23,13 +23,18 @@ proc main =
   suite "generate":
     const trackDir = testsDir / ".test_elixir_track_repo"
     let generateCmd = &"{binaryPath} -t {trackDir} generate"
+    let generateCmdUpdate = &"{generateCmd} --update"
+    let generateCmdUpdateYes = &"{generateCmdUpdate} --yes"
 
     # Setup: clone a track repo, and checkout a known state
     setupExercismRepo("elixir", trackDir,
                       "91ccf91940f32aff3726c772695b2de167d8192a") # 2022-06-12
 
     test "`configlet generate` exits with 0 when there are no `.md.tpl` files":
-      execAndCheck(0, generateCmd, "")
+      const expectedOutput = fmt"""
+        Every introduction file is up-to-date!
+      """.unindent().replace("\p", "\n")
+      execAndCheck(0, generateCmdUpdateYes, expectedOutput)
 
     test "and does not make a change":
       checkNoDiff(trackDir)
@@ -39,7 +44,7 @@ proc main =
                              removeIntro = false)
 
     test "`configlet generate` exits with 1 for an invalid placeholder usage":
-      execAndCheckExitCode(1, generateCmd)
+      execAndCheckExitCode(1, generateCmdUpdateYes)
 
     test "and does not make a change":
       checkNoDiff(trackDir)
@@ -49,7 +54,11 @@ proc main =
                              removeIntro = true)
 
     test "`configlet generate` exits with 0 for a valid `.md.tpl` file":
-      execAndCheck(0, generateCmd, "")
+      const expectedOutput = fmt"""
+        Outdated: {"exercises"/"concept"/"bird-count"/".docs"/"introduction.md"}
+        Generated 1 file
+      """.unindent().replace("\p", "\n")
+      execAndCheck(0, generateCmdUpdateYes, expectedOutput)
 
     test "and writes the `introduction.md` file as expected":
       checkNoDiff(trackDir)
@@ -59,7 +68,11 @@ proc main =
                              removeIntro = true)
 
     test "`configlet generate` exits with 0 for valid placeholder usage with spaces":
-      execAndCheck(0, generateCmd, "")
+      const expectedOutput = fmt"""
+        Outdated: {"exercises"/"concept"/"bird-count"/".docs"/"introduction.md"}
+        Generated 1 file
+      """.unindent().replace("\p", "\n")
+      execAndCheck(0, generateCmdUpdateYes, expectedOutput)
 
     test "and writes the `introduction.md` file as expected":
       checkNoDiff(trackDir)


### PR DESCRIPTION
To-do:
- [x] Merge #618 
- [x] Merge #620
- [x] Make `generate.nim` non-destructive by default, and support `-u`, `-y` and `-e`
- [ ] Update integration tests for `generate`
- [x] Update completion scripts

Closes: #334
Closes: #542