### PR TITLE
generate: demote headings, and group link reference definitions

### DIFF
--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -5,8 +5,8 @@ proc getConceptSlugLookup(trackDir: Path): Table[string, string] =
   ## Returns a `Table` that maps each concept's `slug` to its `name`.
   let concepts = TrackConfig.init(readFile(trackDir / "config.json")).concepts
   result = initTable[string, string](concepts.len)
-  for `concept` in concepts:
-    result[`concept`.slug] = `concept`.name
+  for con in concepts:
+    result[con.slug] = con.name
 
 func alterHeadings(s: string, linkDefs: var seq[string], h2 = ""): string =
   result = newStringOfCap(s.len)

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -7,15 +7,6 @@ proc getConceptSlugLookup(trackDir: Path): Table[string, string] =
   for `concept` in concepts:
     result[`concept`.slug] = `concept`.name
 
-proc writeError(description: string, path: Path) =
-  let descriptionPrefix = description & ":"
-  if colorStderr:
-    stderr.styledWriteLine(fgRed, descriptionPrefix)
-  else:
-    stderr.writeLine(descriptionPrefix)
-  stderr.writeLine(path)
-  stderr.write "\n"
-
 func alterHeadings(s: string, title: string, headingLevel: int,
                    links: var seq[string]): string =
   # Markdown implementations differ on whether a space is required after the
@@ -58,6 +49,15 @@ func alterHeadings(s: string, title: string, headingLevel: int,
       inCommentBlock = false
     inc i
   strip result
+
+proc writeError(description: string, path: Path) =
+  let descriptionPrefix = description & ":"
+  if colorStderr:
+    stderr.styledWriteLine(fgRed, descriptionPrefix)
+  else:
+    stderr.writeLine(descriptionPrefix)
+  stderr.writeLine(path)
+  stderr.write "\n"
 
 proc conceptIntroduction(trackDir: Path, slug: string, title: string,
                          templatePath: Path, headingLevel: int,

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -1,7 +1,7 @@
 import std/[parseutils, strbasics, strformat, strscans, strutils, tables, terminal]
 import ".."/[cli, helpers, types_track_config]
 
-proc getSlugLookup(trackDir: Path): Table[string, string] =
+proc getConceptSlugLookup(trackDir: Path): Table[string, string] =
   let concepts = TrackConfig.init(readFile(trackDir / "config.json")).concepts
   result = initTable[string, string](concepts.len)
   for `concept` in concepts:
@@ -127,7 +127,7 @@ proc generate*(conf: Conf) =
 
   let conceptExercisesDir = trackDir / "exercises" / "concept"
   if dirExists(conceptExercisesDir):
-    let slugLookup = getSlugLookup(trackDir)
+    let slugLookup = getConceptSlugLookup(trackDir)
     for conceptExerciseDir in getSortedSubdirs(conceptExercisesDir):
       let introductionTemplatePath = conceptExerciseDir / ".docs" / "introduction.md.tpl"
       if fileExists(introductionTemplatePath):

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -1,10 +1,6 @@
-import std/[hashes, parseutils, strbasics, strformat, strscans, strutils, sugar,
-            tables, terminal]
+import std/[parseutils, strbasics, strformat, strscans, strutils, sugar, tables,
+            terminal]
 import ".."/[cli, helpers, types_track_config]
-
-proc hash(slug: Slug): Hash {.borrow.}
-proc `==`(x, y: Slug): bool {.borrow.}
-proc add(s: var Slug, c: char) {.borrow.}
 
 proc getConceptSlugLookup(trackDir: Path): Table[Slug, string] =
   ## Returns a `Table` that maps each concept's `slug` to its `name`.

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -2,6 +2,7 @@ import std/[parseutils, strbasics, strformat, strscans, strutils, tables, termin
 import ".."/[cli, helpers, types_track_config]
 
 proc getConceptSlugLookup(trackDir: Path): Table[string, string] =
+  ## Returns a `Table` that maps each concept's `slug` to its `name`.
   let concepts = TrackConfig.init(readFile(trackDir / "config.json")).concepts
   result = initTable[string, string](concepts.len)
   for `concept` in concepts:

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -113,6 +113,8 @@ proc generateIntroduction(trackDir: Path, templatePath: Path,
         headingLevel = content.skipWhile({'#'}, i+1)
       result.add content[i]
       inc i
+  result.strip()
+  result.add '\n'
   if linkDefs.len > 0:
     result.add '\n'
     for linkDef in linkDefs:

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -66,9 +66,9 @@ proc conceptIntroduction(trackDir: Path, slug: Slug, templatePath: Path,
   ## - Adding a starting a second-level heading containing `h2`.
   ## - Demoting the level of any other heading.
   ## - Without any leading/trailing whitespace.
-  ## - Without any reference link definitions.
+  ## - Without any link reference definitions.
   ##
-  ## Appends reference link definitions to `linkDefs`.
+  ## Appends link reference definitions to `linkDefs`.
   let conceptDir = trackDir / "concepts" / slug.string
   if dirExists(conceptDir):
     let path = conceptDir / "introduction.md"

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -20,10 +20,17 @@ func alterHeaders(s: string): string =
   if i < s.len and s[i] == '#' and i+1 < s.len and s[i+1] == ' ':
     i += s.skipUntil('\n', i)
   # Demote other headers
+  var inFencedCodeBlock = false
   while i < s.len:
     result.add s[i]
-    if s[i] == '\n' and i+1 < s.len and s[i+1] == '#':
-      result.add '#'
+    if s[i] == '\n':
+      # When inside a fenced code block, don't alter a line that begins with '#'
+      if i+1 < s.len and s[i+1] == '#' and not inFencedCodeBlock:
+        result.add '#'
+      elif i+3 < s.len and s[i+1] == '`' and s[i+2] == '`' and s[i+3] == '`':
+        inFencedCodeBlock = not inFencedCodeBlock
+        result.add "```"
+        i += 3
     inc i
   strip result
 

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -29,17 +29,21 @@ func alterHeaders(s: string, title: string, headerLevel: int): string =
     result.add &"## {title}"
   # Demote other headers
   var inFencedCodeBlock = false
+  var inFencedCodeBlockTildes = false
   var inCommentBlock = false
   while i < s.len:
     result.add s[i]
     if s[i] == '\n':
       # Add a '#' to a line that begins with '#', unless inside a code or HTML block.
-      if s.continuesWith("#", i+1) and not (inFencedCodeBlock or inCommentBlock):
+      if s.continuesWith("#", i+1) and not (inFencedCodeBlock or
+                                            inFencedCodeBlockTildes or inCommentBlock):
         let demotionAmount = if headerLevel in [1, 2]: 1 else: headerLevel - 1
         for _ in 1..demotionAmount:
           result.add '#'
       elif s.continuesWith("```", i+1):
         inFencedCodeBlock = not inFencedCodeBlock
+      elif s.continuesWith("~~~", i+1):
+        inFencedCodeBlockTildes = not inFencedCodeBlockTildes
       elif s.continuesWith("<!--", i+1):
         inCommentBlock = true
     elif inCommentBlock and s.continuesWith("-->", i):

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -10,17 +10,18 @@ proc getConceptSlugLookup(trackDir: Path): Table[string, string] =
 
 func alterHeadings(s: string, title: string, headingLevel: int,
                    linkDefs: var seq[string]): string =
-  # Markdown implementations differ on whether a space is required after the
-  # final '#' character that begins the heading.
   result = newStringOfCap(s.len)
   var i = 0
   i += s.skipWhitespace()
-  # Skip the top-level heading (if any)
+  # Skip the top-level heading (if any).
+  # The CommonMark Spec requires that an ATX heading has a a space, tab, or
+  # newline after the opening sequence of '#' characters.
+  # For now, support only spaces.
   if s.continuesWith("# ", i):
     i += s.skipUntil('\n', i)
   if headingLevel == 1:
     result.add &"## {title}"
-  # Demote other headings
+  # Demote other headings.
   var inFencedCodeBlock = false
   var inFencedCodeBlockTildes = false
   var inCommentBlock = false

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -84,9 +84,14 @@ proc generateIntroduction(trackDir: Path, templatePath: Path,
     if scanp(content, i,
              "%{", *{' '}, "concept", *{' '}, ':', *{' '},
              +{'a'..'z', '-'} -> conceptSlug.add($_), *{' '}, '}'):
-      let title = slugLookup[conceptSlug]
-      result.add conceptIntroduction(trackDir, conceptSlug, title, templatePath,
-                                     headerLevel)
+      if conceptSlug in slugLookup:
+        let title = slugLookup[conceptSlug]
+        result.add conceptIntroduction(trackDir, conceptSlug, title,
+                                       templatePath, headerLevel)
+      else:
+        writeError(&"Concept '{conceptSlug}' does not exist in track config.json",
+                   templatePath)
+        quit(1)
     else:
       if content.continuesWith("\n#", i):
         headerLevel = content.skipWhile({'#'}, i+1)

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -8,7 +8,7 @@ proc getConceptSlugLookup(trackDir: Path): Table[string, string] =
   for `concept` in concepts:
     result[`concept`.slug] = `concept`.name
 
-func alterHeadings(s: string, title: string, headingLevel: int,
+func alterHeadings(s: string, h2: string, headingLevel: int,
                    linkDefs: var seq[string]): string =
   result = newStringOfCap(s.len)
   var i = 0
@@ -20,7 +20,7 @@ func alterHeadings(s: string, title: string, headingLevel: int,
   if s.continuesWith("# ", i):
     i += s.skipUntil('\n', i)
   if headingLevel == 1:
-    result.add &"## {title}"
+    result.add &"## {h2}"
   # Demote other headings.
   var inFencedCodeBlock = false
   var inFencedCodeBlockTildes = false
@@ -61,12 +61,12 @@ proc writeError(description: string, path: Path) =
   stderr.writeLine(path)
   stderr.write "\n"
 
-proc conceptIntroduction(trackDir: Path, slug: string, title: string,
+proc conceptIntroduction(trackDir: Path, slug: string, h2: string,
                          templatePath: Path, headingLevel: int,
                          linkDefs: var seq[string]): string =
   ## Returns the contents of the `introduction.md` file for a `slug`, but:
   ## - Without a first top-level heading.
-  ## - Adding a starting a second-level heading containing `title`.
+  ## - Adding a starting a second-level heading containing `h2`.
   ## - Demoting the level of any other heading.
   ## - Without any leading/trailing whitespace.
   ## - Without any reference link definitions.
@@ -76,7 +76,7 @@ proc conceptIntroduction(trackDir: Path, slug: string, title: string,
   if dirExists(conceptDir):
     let path = conceptDir / "introduction.md"
     if fileExists(path):
-      result = path.readFile().alterHeadings(title, headingLevel, linkDefs)
+      result = path.readFile().alterHeadings(h2, headingLevel, linkDefs)
     else:
       writeError(&"File {path} not found for concept '{slug}'", templatePath)
       quit(1)
@@ -104,8 +104,8 @@ proc generateIntroduction(trackDir: Path, templatePath: Path,
              "%{", *{' '}, "concept", *{' '}, ':', *{' '},
              +{'a'..'z', '-'} -> conceptSlug.add($_), *{' '}, '}'):
       if conceptSlug in slugLookup:
-        let title = slugLookup[conceptSlug]
-        result.add conceptIntroduction(trackDir, conceptSlug, title,
+        let h2 = slugLookup[conceptSlug]
+        result.add conceptIntroduction(trackDir, conceptSlug, h2,
                                        templatePath, headingLevel, linkDefs)
       else:
         writeError(&"Concept '{conceptSlug}' does not exist in track config.json",

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -28,14 +28,19 @@ func alterHeaders(s: string, title: string): string =
   result.add &"## {title}"
   # Demote other headers
   var inFencedCodeBlock = false
+  var inCommentBlock = false
   while i < s.len:
     result.add s[i]
     if s[i] == '\n':
-      # When inside a fenced code block, don't alter a line that begins with '#'
-      if s.continuesWith("#", i+1) and not inFencedCodeBlock:
+      # Add a '#' to a line that begins with '#', unless inside a code or HTML block.
+      if s.continuesWith("#", i+1) and not (inFencedCodeBlock or inCommentBlock):
         result.add '#'
       elif s.continuesWith("```", i+1):
         inFencedCodeBlock = not inFencedCodeBlock
+      elif s.continuesWith("<!--", i+1):
+        inCommentBlock = true
+    elif inCommentBlock and s.continuesWith("-->", i):
+      inCommentBlock = false
     inc i
   strip result
 

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -1,4 +1,4 @@
-import std/[parseutils, strbasics, strformat, strscans, tables, terminal]
+import std/[parseutils, strbasics, strformat, strscans, strutils, tables, terminal]
 import ".."/[cli, helpers, types_track_config]
 
 proc getSlugLookup(trackDir: Path): Table[string, string] =
@@ -23,7 +23,7 @@ func alterHeaders(s: string, title: string): string =
   var i = 0
   i += s.skipWhitespace()
   # Skip the top-level header (if any)
-  if i < s.len and s[i] == '#' and i+1 < s.len and s[i+1] == ' ':
+  if s.continuesWith("# ", i):
     i += s.skipUntil('\n', i)
   result.add &"## {title}"
   # Demote other headers
@@ -32,9 +32,9 @@ func alterHeaders(s: string, title: string): string =
     result.add s[i]
     if s[i] == '\n':
       # When inside a fenced code block, don't alter a line that begins with '#'
-      if i+1 < s.len and s[i+1] == '#' and not inFencedCodeBlock:
+      if s.continuesWith("#", i+1) and not inFencedCodeBlock:
         result.add '#'
-      elif i+3 < s.len and s[i+1] == '`' and s[i+2] == '`' and s[i+3] == '`':
+      elif s.continuesWith("```", i+1):
         inFencedCodeBlock = not inFencedCodeBlock
     inc i
   strip result

--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -36,8 +36,6 @@ func alterHeaders(s: string, title: string): string =
         result.add '#'
       elif i+3 < s.len and s[i+1] == '`' and s[i+2] == '`' and s[i+3] == '`':
         inFencedCodeBlock = not inFencedCodeBlock
-        result.add "```"
-        i += 3
     inc i
   strip result
 

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -25,17 +25,12 @@ proc postHook*(e: ConceptExercise | PracticeExercise) =
     stderr.writeLine msg
     quit 1
 
-func `==`*(x, y: Slug): bool {.borrow.}
-func `<`*(x, y: Slug): bool {.borrow.}
-
 func getSlugs*(e: seq[ConceptExercise] | seq[PracticeExercise]): seq[Slug] =
   ## Returns a seq of the slugs in `e`, in alphabetical order.
   result = newSeq[Slug](e.len)
   for i, item in e:
     result[i] = item.slug
   sort result
-
-func len*(slug: Slug): int {.borrow.}
 
 func truncateAndAdd*(s: var string, truncateLen: int, slug: Slug) =
   ## Truncates `s` to `truncateLen`, then appends `slug`.

--- a/src/types_track_config.nim
+++ b/src/types_track_config.nim
@@ -1,4 +1,4 @@
-import std/sets
+import std/[hashes, sets]
 import pkg/jsony
 import "."/[cli, helpers]
 
@@ -58,6 +58,11 @@ type
     ekPractice = "practice"
 
 func `$`*(slug: Slug): string {.borrow.}
+func `==`*(x, y: Slug): bool {.borrow.}
+func `<`*(x, y: Slug): bool {.borrow.}
+func len*(slug: Slug): int {.borrow.}
+func hash*(slug: Slug): Hash {.borrow.}
+func add*(s: var Slug, c: char) {.borrow.}
 
 proc init*(T: typedesc[TrackConfig]; trackConfigContents: string): T =
   ## Deserializes `trackConfigContents` using `jsony` to a `TrackConfig` object.

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -1,6 +1,7 @@
 import "."/[
   test_binary,
   test_fmt,
+  test_generate,
   test_json,
   test_lint,
   test_probspecs,

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -872,17 +872,16 @@ proc testsForSync(binaryPath: static string) =
                          &"failed to merge '{mainBranchName}' in " &
                          &"problem-specifications directory: '{probSpecsDir}'")
 
-proc prepareIntroductionFiles(trackDir, header, placeholder: string;
-                              removeIntro: bool) =
+proc prepareIntroductionFiles(trackDir, placeholder: string; removeIntro: bool) =
   # Writes an `introduction.md.tpl` file for the `bird-count` Concept Exercise,
-  # containing the given `header` and `placeholder`. Also removes the
-  # `introduction.md` file if `removeIntro` is `true`.
+  # containing the given `placeholder`. Also removes the `introduction.md` file
+  # if `removeIntro` is `true`.
   let
     docsPath = trackDir / "exercises" / "concept" / "bird-count" / ".docs"
     introPath = docsPath / "introduction.md"
     templatePath = introPath & ".tpl"
     templateContents = fmt"""
-      # {header}
+      # Introduction
 
       {placeholder}
     """.unindent()
@@ -897,7 +896,7 @@ proc testsForGenerate(binaryPath: string) =
 
     # Setup: clone a track repo, and checkout a known state
     setupExercismRepo("elixir", trackDir,
-                      "f3974abf6e0d4a434dfe3494d58581d399c18edb") # 2021-05-09
+                      "91ccf91940f32aff3726c772695b2de167d8192a") # 2022-06-12
 
     test "`configlet generate` exits with 0 when there are no `.md.tpl` files":
       execAndCheck(0, generateCmd, "")
@@ -906,8 +905,7 @@ proc testsForGenerate(binaryPath: string) =
       checkNoDiff(trackDir)
 
     # Valid placeholder syntax without spaces, and invalid slug
-    prepareIntroductionFiles(trackDir, "Recursion",
-                             "%{concept:not-a-real-concept-slug}",
+    prepareIntroductionFiles(trackDir, "%{concept:not-a-real-concept-slug}",
                              removeIntro = false)
 
     test "`configlet generate` exits with 1 for an invalid placeholder usage":
@@ -917,7 +915,7 @@ proc testsForGenerate(binaryPath: string) =
       checkNoDiff(trackDir)
 
     # Valid placeholder syntax without spaces, and valid slug
-    prepareIntroductionFiles(trackDir, "Recursion", "%{concept:recursion}",
+    prepareIntroductionFiles(trackDir, "%{concept:recursion}",
                              removeIntro = true)
 
     test "`configlet generate` exits with 0 for a valid `.md.tpl` file":
@@ -927,7 +925,7 @@ proc testsForGenerate(binaryPath: string) =
       checkNoDiff(trackDir)
 
     # Valid placeholder syntax with spaces, and valid slug
-    prepareIntroductionFiles(trackDir, "Recursion", "%{ concept : recursion }",
+    prepareIntroductionFiles(trackDir, "%{ concept : recursion }",
                              removeIntro = true)
 
     test "`configlet generate` exits with 0 for valid placeholder usage with spaces":

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -63,11 +63,10 @@ proc testGenerate =
 
         The five boxing wizards jump quickly.""".unindent() # No final newline
 
-      check alterHeaders(s, "Operator Overloading", 1) == "## Operator Overloading\n\n" &
-                                                          expected
-      check alterHeaders(s, "Operator Overloading", 2) == expected
-      check alterHeaders(s, "Operator Overloading", 3) == expected.replace("### ", "#### ")
-      check alterHeaders(s, "Operator Overloading", 4) == expected.replace("### ", "##### ")
+      check alterHeaders(s, "Maps", 1) == "## Maps\n\n" & expected
+      check alterHeaders(s, "Maps", 2) == expected
+      check alterHeaders(s, "Maps", 3) == expected.replace("### ", "#### ")
+      check alterHeaders(s, "Maps", 4) == expected.replace("### ", "##### ")
 
 proc main =
   testGenerate()

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -21,7 +21,10 @@ proc testGenerate =
 
         The quick brown fox jumps over a lazy dog.
 
-        The five boxing wizards jump quickly.
+        ```nim
+        # This line is not a header
+        echo "hi"
+        ```
 
         ## Header 4
 
@@ -45,7 +48,10 @@ proc testGenerate =
 
         The quick brown fox jumps over a lazy dog.
 
-        The five boxing wizards jump quickly.
+        ```nim
+        # This line is not a header
+        echo "hi"
+        ```
 
         ### Header 4
 

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -69,12 +69,12 @@ proc testGenerate =
         echo "hi"
         ~~~""".unindent() # No final newline
 
-      var links = newSeq[string]()
-      check alterHeadings(s, "Maps", 1, links) == "## Maps\n\n" & expected
-      check alterHeadings(s, "Maps", 2, links) == expected
-      check alterHeadings(s, "Maps", 3, links) == expected.replace("### ", "#### ")
-      check alterHeadings(s, "Maps", 4, links) == expected.replace("### ", "##### ")
-      check links.len == 0
+      var linkDefs = newSeq[string]()
+      check alterHeadings(s, "Maps", 1, linkDefs) == "## Maps\n\n" & expected
+      check alterHeadings(s, "Maps", 2, linkDefs) == expected
+      check alterHeadings(s, "Maps", 3, linkDefs) == expected.replace("### ", "#### ")
+      check alterHeadings(s, "Maps", 4, linkDefs) == expected.replace("### ", "##### ")
+      check linkDefs.len == 0
 
 proc main =
   testGenerate()

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -34,6 +34,8 @@ proc testGenerate =
       """.unindent()
 
       const expected = """
+        ## Operator Overloading
+
         The quick brown fox jumps over a lazy dog.
 
         The five boxing wizards jump quickly.
@@ -59,7 +61,7 @@ proc testGenerate =
 
         The five boxing wizards jump quickly.""".unindent() # No final newline
 
-      check alterHeaders(s) == expected
+      check alterHeaders(s, "Operator Overloading") == expected
 
 proc main =
   testGenerate()

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -69,10 +69,12 @@ proc testGenerate =
         echo "hi"
         ~~~""".unindent() # No final newline
 
-      check alterHeaders(s, "Maps", 1) == "## Maps\n\n" & expected
-      check alterHeaders(s, "Maps", 2) == expected
-      check alterHeaders(s, "Maps", 3) == expected.replace("### ", "#### ")
-      check alterHeaders(s, "Maps", 4) == expected.replace("### ", "##### ")
+      var links = newSeq[string]()
+      check alterHeaders(s, "Maps", 1, links) == "## Maps\n\n" & expected
+      check alterHeaders(s, "Maps", 2, links) == expected
+      check alterHeaders(s, "Maps", 3, links) == expected.replace("### ", "#### ")
+      check alterHeaders(s, "Maps", 4, links) == expected.replace("### ", "##### ")
+      check links.len == 0
 
 proc main =
   testGenerate()

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -32,7 +32,10 @@ proc testGenerate =
 
         The quick brown fox jumps over a lazy dog.
 
-        The five boxing wizards jump quickly.
+        ~~~nim
+        # This line is not a header
+        echo "hi"
+        ~~~
       """.unindent()
 
       const expected = """
@@ -61,7 +64,10 @@ proc testGenerate =
 
         The quick brown fox jumps over a lazy dog.
 
-        The five boxing wizards jump quickly.""".unindent() # No final newline
+        ~~~nim
+        # This line is not a header
+        echo "hi"
+        ~~~""".unindent() # No final newline
 
       check alterHeaders(s, "Maps", 1) == "## Maps\n\n" & expected
       check alterHeaders(s, "Maps", 2) == expected

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -36,8 +36,6 @@ proc testGenerate =
       """.unindent()
 
       const expected = """
-        ## Operator Overloading
-
         The quick brown fox jumps over a lazy dog.
 
         The five boxing wizards jump quickly.
@@ -65,7 +63,11 @@ proc testGenerate =
 
         The five boxing wizards jump quickly.""".unindent() # No final newline
 
-      check alterHeaders(s, "Operator Overloading") == expected
+      check alterHeaders(s, "Operator Overloading", 1) == "## Operator Overloading\n\n" &
+                                                          expected
+      check alterHeaders(s, "Operator Overloading", 2) == expected
+      check alterHeaders(s, "Operator Overloading", 3) == expected.replace("### ", "#### ")
+      check alterHeaders(s, "Operator Overloading", 4) == expected.replace("### ", "##### ")
 
 proc main =
   testGenerate()

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -1,39 +1,39 @@
 import std/[strutils, unittest]
-from "."/generate/generate {.all.} import alterHeaders
+from "."/generate/generate {.all.} import alterHeadings
 
 proc testGenerate =
   suite "generate":
-    test "alterHeaders":
+    test "alterHeadings":
       const s = """
-        # Header 1
+        # Heading 1
 
         The quick brown fox jumps over a lazy dog.
 
         The five boxing wizards jump quickly.
 
-        ## Header 2
+        ## Heading 2
 
         The quick brown fox jumps over a lazy dog.
 
         <!--
-        # This line is not a header
+        # This line is not a heading
         This line is in an HTML comment block -->
 
-        ### Header 3
+        ### Heading 3
 
         The quick brown fox jumps over a lazy dog.
 
         ```nim
-        # This line is not a header
+        # This line is not a heading
         echo "hi"
         ```
 
-        ## Header 4
+        ## Heading 4
 
         The quick brown fox jumps over a lazy dog.
 
         ~~~nim
-        # This line is not a header
+        # This line is not a heading
         echo "hi"
         ~~~
       """.unindent()
@@ -43,37 +43,37 @@ proc testGenerate =
 
         The five boxing wizards jump quickly.
 
-        ### Header 2
+        ### Heading 2
 
         The quick brown fox jumps over a lazy dog.
 
         <!--
-        # This line is not a header
+        # This line is not a heading
         This line is in an HTML comment block -->
 
-        #### Header 3
+        #### Heading 3
 
         The quick brown fox jumps over a lazy dog.
 
         ```nim
-        # This line is not a header
+        # This line is not a heading
         echo "hi"
         ```
 
-        ### Header 4
+        ### Heading 4
 
         The quick brown fox jumps over a lazy dog.
 
         ~~~nim
-        # This line is not a header
+        # This line is not a heading
         echo "hi"
         ~~~""".unindent() # No final newline
 
       var links = newSeq[string]()
-      check alterHeaders(s, "Maps", 1, links) == "## Maps\n\n" & expected
-      check alterHeaders(s, "Maps", 2, links) == expected
-      check alterHeaders(s, "Maps", 3, links) == expected.replace("### ", "#### ")
-      check alterHeaders(s, "Maps", 4, links) == expected.replace("### ", "##### ")
+      check alterHeadings(s, "Maps", 1, links) == "## Maps\n\n" & expected
+      check alterHeadings(s, "Maps", 2, links) == expected
+      check alterHeadings(s, "Maps", 3, links) == expected.replace("### ", "#### ")
+      check alterHeadings(s, "Maps", 4, links) == expected.replace("### ", "##### ")
       check links.len == 0
 
 proc main =

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -15,7 +15,9 @@ proc testGenerate =
 
         The quick brown fox jumps over a lazy dog.
 
-        The five boxing wizards jump quickly.
+        <!--
+        # This line is not a header
+        This line is in an HTML comment block -->
 
         ### Header 3
 
@@ -44,7 +46,9 @@ proc testGenerate =
 
         The quick brown fox jumps over a lazy dog.
 
-        The five boxing wizards jump quickly.
+        <!--
+        # This line is not a header
+        This line is in an HTML comment block -->
 
         #### Header 3
 

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -1,0 +1,62 @@
+import std/[strutils, unittest]
+from "."/generate/generate {.all.} import alterHeaders
+
+proc testGenerate =
+  suite "generate":
+    test "alterHeaders":
+      const s = """
+        # Header 1
+
+        The quick brown fox jumps over a lazy dog.
+
+        The five boxing wizards jump quickly.
+
+        ## Header 2
+
+        The quick brown fox jumps over a lazy dog.
+
+        The five boxing wizards jump quickly.
+
+        ### Header 3
+
+        The quick brown fox jumps over a lazy dog.
+
+        The five boxing wizards jump quickly.
+
+        ## Header 4
+
+        The quick brown fox jumps over a lazy dog.
+
+        The five boxing wizards jump quickly.
+      """.unindent()
+
+      const expected = """
+        The quick brown fox jumps over a lazy dog.
+
+        The five boxing wizards jump quickly.
+
+        ### Header 2
+
+        The quick brown fox jumps over a lazy dog.
+
+        The five boxing wizards jump quickly.
+
+        #### Header 3
+
+        The quick brown fox jumps over a lazy dog.
+
+        The five boxing wizards jump quickly.
+
+        ### Header 4
+
+        The quick brown fox jumps over a lazy dog.
+
+        The five boxing wizards jump quickly.""".unindent() # No final newline
+
+      check alterHeaders(s) == expected
+
+proc main =
+  testGenerate()
+
+main()
+{.used.}

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -70,10 +70,8 @@ proc testGenerate =
         ~~~""".unindent() # No final newline
 
       var linkDefs = newSeq[string]()
-      check alterHeadings(s, "Maps", 1, linkDefs) == "## Maps\n\n" & expected
-      check alterHeadings(s, "Maps", 2, linkDefs) == expected
-      check alterHeadings(s, "Maps", 3, linkDefs) == expected.replace("### ", "#### ")
-      check alterHeadings(s, "Maps", 4, linkDefs) == expected.replace("### ", "##### ")
+      check alterHeadings(s, linkDefs) == expected
+      check alterHeadings(s, linkDefs, "Maps") == "## Maps\n\n" & expected
       check linkDefs.len == 0
 
 proc main =


### PR DESCRIPTION
To-do:
- [x] Decide on desired behavior.
- [x] Implement it.
- [x] Move reference links to the bottom, ordering by usage, and deduplicating them.
- [x] Support `~~~` code blocks?

As an example of something that isn't supported, GFM multi-line block quotes:

```markdown
>>>
This line is part of a multi-line block quote
### This is not a heading in GFM
>>>
```

Closes: #328
Closes: #626

---

This PR will also demote the level of a line that lacks a whitespace after the final `#` character, like:

```markdown
###Some heading
```

But previously we only removed a first top-level heading if the separating space was present.

Edge case that I don't expect to be important: the current implementation will demote a level-6 heading (beginning with `######`) to "a level-7 heading". But a line beginning with 7 `#` characters is actually no longer a heading.

