### PR TITLE
sync: remove "Updating tests..." message

### DIFF
--- a/src/sync/sync_tests.nim
+++ b/src/sync/sync_tests.nim
@@ -135,8 +135,6 @@ proc syncIfNeeded(exercise: Exercise, conf: Conf): bool =
 
 proc updateTests*(seenUnsynced: var set[SyncKind], conf: Conf,
                   exercises: seq[Exercise]) =
-  logNormal("Updating tests...")
-
   var everyExerciseIsSynced = true
 
   for exercise in exercises:

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -57,7 +57,6 @@ proc testsForSync(binaryPath: static string) =
     syncOfflineUpdateTests = &"{syncOfflineUpdate} --tests"
 
     header = "Checking exercises..."
-    headerUpdateTests = "Updating tests..."
     footerUnsyncedDocs = "[warn] some exercises have unsynced docs"
     # footerUnsyncedFilepaths = "[warn] some exercises have unsynced filepaths"
     footerUnsyncedMetadata = "[warn] some exercises have unsynced metadata"
@@ -524,14 +523,12 @@ proc testsForSync(binaryPath: static string) =
     const
       expectedOutputAnagramInclude = fmt"""
         {header}
-        {headerUpdateTests}
         [info] anagram: included 1 missing test case
         The `anagram` exercise has up-to-date tests!
       """.unindent()
 
       expectedOutputAnagramExclude = fmt"""
         {header}
-        {headerUpdateTests}
         [info] anagram: excluded 1 missing test case
         The `anagram` exercise has up-to-date tests!
       """.unindent()
@@ -611,7 +608,6 @@ proc testsForSync(binaryPath: static string) =
     test "--tests include: includes every missing test case when not specifying an exercise, and exits with 0":
       const expectedOutput = fmt"""
         {header}
-        {headerUpdateTests}
         [info] anagram: included 1 missing test case
         [info] diffie-hellman: included 1 missing test case
         [info] grade-school: included 1 missing test case
@@ -821,7 +817,6 @@ proc testsForSync(binaryPath: static string) =
     test "after updating tests, another tests update using --tests include performs no changes, and exits with 0":
       const expectedOutput = fmt"""
         {header}
-        {headerUpdateTests}
         {footerSyncedTests}
       """.unindent()
       execAndCheck(0, &"{syncOfflineUpdateTests} include", expectedOutput)


### PR DESCRIPTION
It was confusing that configlet always printed "Updating tests" when
tests were part of the syncing scope, even if every test was up to date.

Before this commit:

```console
$ configlet sync -o -e hello-world -u
Checking exercises...
Updating tests...
The `hello-world` exercise has up-to-date docs, filepaths, metadata, and tests!
```

With this commit:

```console
$ configlet sync -o -e hello-world -u
Checking exercises...
The `hello-world` exercise has up-to-date docs, filepaths, metadata, and tests!
```

The "Updating tests..." message was trying to say "OK, we'll start
checking tests now, and if we find anything, we'll prompt to update".
But because all the tests encountered are up to date, there is no
further output to ask "Do you want to include this test case?".

Furthermore, configlet doesn't print things like

```text
Checking docs...
Checking filepaths...
Checking metadata...
```

as it enters the other syncing scopes, and the "Updating tests..."
message is a leftover from the `canoncial_data_syncer` days when the
application only did syncing, was destructive by default (we had
--check, not --update), and only operated on tests. So let's remove the
message. But later we could consider adding a "Checking foo..." message
for each syncing scope at the highest verbosity level.

Closes: #622