### PR TITLE
completion: add `configlet completion` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,18 @@ Usage:
   configlet [global-options] <command> [command-options]
 
 Commands:
-  fmt       Format the exercise '.meta/config.json' files
-  generate  Generate Concept Exercise 'introduction.md' files from 'introduction.md.tpl' files
-  info      Print some information about the track
-  lint      Check the track configuration for correctness
-  sync      Check or update Practice Exercise docs, metadata, and tests from 'problem-specifications'.
-            Check or populate missing 'files' values for Concept/Practice Exercises from the track 'config.json'.
-  uuid      Output new (version 4) UUIDs, suitable for the value of a 'uuid' key
+  completion  Output completions for a given shell
+  fmt         Format the exercise '.meta/config.json' files
+  generate    Generate Concept Exercise 'introduction.md' files from 'introduction.md.tpl' files
+  info        Print some information about the track
+  lint        Check the track configuration for correctness
+  sync        Check or update Practice Exercise docs, metadata, and tests from 'problem-specifications'.
+              Check or populate missing 'files' values for Concept/Practice Exercises from the track 'config.json'.
+  uuid        Output new (version 4) UUIDs, suitable for the value of a 'uuid' key
+
+Options for completion:
+  -s, --shell <shell>          Choose the shell type (required)
+                               Allowed values: b[ash], f[ish]
 
 Options for fmt:
   -e, --exercise <slug>        Only operate on this exercise

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage:
   configlet [global-options] <command> [command-options]
 
 Commands:
-  completion  Output completions for a given shell
+  completion  Output a completion script for a given shell
   fmt         Format the exercise '.meta/config.json' files
   generate    Generate Concept Exercise 'introduction.md' files from 'introduction.md.tpl' files
   info        Print some information about the track

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -4,12 +4,18 @@ import pkg/cligen/parseopt3
 type
   ActionKind* = enum
     actNil = "nil"
+    actCompletion = "completion"
     actFmt = "fmt"
     actGenerate = "generate"
     actInfo = "info"
     actLint = "lint"
     actSync = "sync"
     actUuid = "uuid"
+
+  Shell* = enum
+    sNil = "nil"
+    sBash = "bash"
+    sFish = "fish"
 
   SyncKind* = enum
     skDocs = "docs"
@@ -26,6 +32,8 @@ type
     case kind*: ActionKind
     of actNil, actGenerate, actLint:
       discard
+    of actCompletion:
+      shell*: Shell
     of actFmt:
       # We can't name these fields `exercise`, `update`, and `yes` because we
       # use those names in `actSync`, and Nim doesn't yet support duplicate
@@ -61,6 +69,9 @@ type
     optVersion = "version"
     optTrackDir = "trackDir"
     optVerbosity = "verbosity"
+
+    # Options for `completion`
+    optCompletionShell = "shell"
 
     # Options for both `fmt` and `sync`
     optFmtSyncExercise = "exercise"
@@ -133,8 +144,10 @@ func genHelpText: string =
     ## Returns a string that describes the allowed values for an enum `T`.
     result = "Allowed values: "
     for val in T:
-      result.add &"{($val)[0]}"
-      result.add &"[{($val)[1 .. ^1]}], "
+      let s = $val
+      if s != "nil":
+        result.add s[0]
+        result.add &"[{s[1 .. ^1]}], "
     setLen(result, result.len - 2)
 
   func genSyntaxStrings: tuple[syntax: array[Opt, string], maxLen: int] =
@@ -147,6 +160,7 @@ func genHelpText: string =
         case opt
         of optTrackDir: "dir"
         of optVerbosity: "verbosity"
+        of optCompletionShell: "shell"
         of optFmtSyncExercise: "slug"
         of optSyncTests: "mode"
         of optUuidNum: "int"
@@ -174,6 +188,7 @@ func genHelpText: string =
 
   const actionDescriptions: array[ActionKind, string] = [
     actNil: "",
+    actCompletion: "Output completions for a given shell",
     actFmt: "Format the exercise '.meta/config.json' files",
     actGenerate: "Generate Concept Exercise 'introduction.md' files from 'introduction.md.tpl' files",
     actInfo: "Print some information about the track",
@@ -199,6 +214,8 @@ func genHelpText: string =
     optTrackDir: "Specify a track directory to use instead of the current directory",
     optVerbosity: &"The verbosity of output.\n" &
                   &"{paddingOpt}{allowedValues(Verbosity)} (default: normal)",
+    optCompletionShell: &"Choose the shell type (required)\n" &
+                        &"{paddingOpt}{allowedValues(Shell)}",
     optFmtSyncExercise: "Only operate on this exercise",
     optFmtSyncUpdate: "Prompt to update the unsynced track data",
     optFmtSyncYes: &"Auto-confirm prompts from --{$optFmtSyncUpdate} for updating docs, filepaths, and metadata",
@@ -330,7 +347,7 @@ func formatOpt(kind: CmdLineKind, key: string, val = ""): string =
 func init*(T: typedesc[Action], actionKind: ActionKind,
            scope: set[SyncKind] = {}): T =
   case actionKind
-  of actNil, actFmt, actGenerate, actInfo, actLint:
+  of actNil, actCompletion, actFmt, actGenerate, actInfo, actLint:
     T(kind: actionKind)
   of actSync:
     T(kind: actionKind, scope: scope)
@@ -463,6 +480,12 @@ proc handleOption(conf: var Conf; kind: CmdLineKind; key, val: string) =
     case conf.action.kind
     of actNil, actGenerate, actLint:
       discard
+    of actCompletion:
+      case opt
+      of optCompletionShell:
+        setActionOpt(shell, parseVal[Shell](kind, key, val))
+      else:
+        discard
     of actFmt:
       case opt
       of optFmtSyncExercise:
@@ -533,6 +556,9 @@ proc processCmdLine*: Conf =
   case result.action.kind
   of actNil:
     showHelp()
+  of actCompletion:
+    if result.action.shell == sNil:
+      showError("Please choose a shell. For example: `configlet completion -s bash`")
   of actFmt, actGenerate, actInfo, actLint, actUuid:
     discard
   of actSync:

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -188,7 +188,7 @@ func genHelpText: string =
 
   const actionDescriptions: array[ActionKind, string] = [
     actNil: "",
-    actCompletion: "Output completions for a given shell",
+    actCompletion: "Output a completion script for a given shell",
     actFmt: "Format the exercise '.meta/config.json' files",
     actGenerate: "Generate Concept Exercise 'introduction.md' files from 'introduction.md.tpl' files",
     actInfo: "Print some information about the track",

--- a/src/completion/completion.nim
+++ b/src/completion/completion.nim
@@ -1,0 +1,12 @@
+import std/[os, strformat]
+import ../cli
+
+proc readCompletions: array[Shell, string] =
+  const repoRootDir = currentSourcePath().parentDir().parentDir().parentDir()
+  const completionsDir = repoRootDir / "completions"
+  for shell in sBash .. result.high:
+    result[shell] = staticRead(completionsDir / &"configlet.{shell}")
+
+proc completion*(shellKind: Shell) =
+  const completions = readCompletions()
+  stdout.write completions[shellKind]

--- a/src/configlet.nim
+++ b/src/configlet.nim
@@ -1,6 +1,6 @@
 import std/posix
-import "."/[cli, fmt/fmt, info/info, generate/generate, lint/lint, logger,
-            sync/sync, uuid/uuid]
+import "."/[cli, completion/completion, fmt/fmt, info/info, generate/generate,
+            lint/lint, logger, sync/sync, uuid/uuid]
 
 proc main =
   onSignal(SIGTERM):
@@ -13,6 +13,8 @@ proc main =
   case conf.action.kind
   of actNil:
     discard
+  of actCompletion:
+    completion(conf.action.shell)
   of actFmt:
     fmt(conf)
   of actLint:

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -935,6 +935,8 @@ proc testsForCompletion(binaryPath: string) =
     for shell in ["bash", "fish"]:
       test shell:
         let c = shell[0]
+        # Convert platform-specific line endings (e.g. CR+LF on Windows) to LF
+        # before comparing. The below `replace` makes the tests pass on Windows.
         let expected = readFile(completionsDir / &"configlet.{shell}").replace("\p", "\n")
         execAndCheck(0, &"{binaryPath} completion --shell {shell}", expected)
         execAndCheck(0, &"{binaryPath} completion --shell {c}", expected)

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -935,7 +935,7 @@ proc testsForCompletion(binaryPath: string) =
     for shell in ["bash", "fish"]:
       test shell:
         let c = shell[0]
-        let expected = readFile(completionsDir / &"configlet.{shell}")
+        let expected = readFile(completionsDir / &"configlet.{shell}").replace("\p", "\n")
         execAndCheck(0, &"{binaryPath} completion --shell {shell}", expected)
         execAndCheck(0, &"{binaryPath} completion --shell {c}", expected)
         execAndCheck(0, &"{binaryPath} completion -s {shell}", expected)

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -949,6 +949,11 @@ proc testsForCompletion(binaryPath: string) =
         check:
           outp.contains(&"invalid value for '-s': '{shell}'")
           exitCode == 1
+    test "the -s option is required":
+      let (outp, exitCode) = execCmdEx(&"{binaryPath} completion")
+      check:
+        outp.contains(&"Please choose a shell. For example: `configlet completion -s bash`")
+        exitCode == 1
 
 proc main =
   const

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -945,7 +945,7 @@ proc testsForCompletion(binaryPath: string) =
       test &"{shell} (produces an error)":
         let (outp, exitCode) = execCmdEx(&"{binaryPath} completion -s {shell}")
         check:
-          outp.startsWith(&"Error: invalid value for '-s': '{shell}'")
+          outp.contains(&"invalid value for '-s': '{shell}'")
           exitCode == 1
 
 proc main =


### PR DESCRIPTION
With this commit, running e.g.

```shell
configlet completion --shell fish
```

will output the fish completion script to stdout. This allows us to
distribute completion scripts to the user without adding them to the
release assets, which avoids cluttering every directory in which the
user runs `fetch-configlet`.

For example, the user can enable completions for fish by running:

```shell
configlet completion -s fish > ~/.config/fish/completions/configlet.fish
```

Closes: #630

---

```console
$ ./configlet completion --shell fish
# global options
complete -c configlet -s h -l help -f -d "Show help"
complete -c configlet      -l version -f -d "Show version info"
complete -c configlet -s t -l track-dir -d "Select a track directory"
complete -c configlet -s v -l verbosity -x -a "quiet normal detailed" -d "Verbose level"

# subcommands with no options
complete -c configlet -n "__fish_use_subcommand" -a lint -f -d "Check the track configuration for correctness"
complete -c configlet -n "__fish_use_subcommand" -a generate -f -d "Generate concept exercise introductions"

# info subcommand
complete -c configlet -n "__fish_use_subcommand" -a info -f -d "Track info"
complete -c configlet -n "__fish_seen_subcommand_from info" -s o -l offline -f -d "Do not update prob-specs cache"

# uuid subcommand
complete -c configlet -n "__fish_use_subcommand" -a uuid -f -d "Output a UUID"
complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -f -d "How many UUIDs"

# fmt subcommand
complete -c configlet -n "__fish_use_subcommand" -a fmt -f -d "Format the exercise '.meta/config.json' files"
complete -c configlet -n "__fish_seen_subcommand_from fmt" -s u -l update -d "Write changes"
complete -c configlet -n "__fish_seen_subcommand_from fmt" -s y -l yes -d "Auto-confirm update"
complete -c configlet -n "__fish_seen_subcommand_from fmt" -s e -l exercise -d "exercise slug" \
  -x -a "(find ./exercises/{concept,practice} -maxdepth 1 -mindepth 1 -type d -printf '%P\n' | sort)"

# sync subcommand
complete -c configlet -n "__fish_use_subcommand" -a sync -d "Check or update Practice Exercise docs, metadata, and tests"
complete -c configlet -n "__fish_seen_subcommand_from sync" -s o -l offline -f -d "Do not update prob-specs cache"
complete -c configlet -n "__fish_seen_subcommand_from sync" -s u -l update -d "Write changes"
complete -c configlet -n "__fish_seen_subcommand_from sync" -s y -l yes -d "Auto-confirm update"
complete -c configlet -n "__fish_seen_subcommand_from sync"      -l docs -d "Sync docs only"
complete -c configlet -n "__fish_seen_subcommand_from sync"      -l filepaths -f -d 'Populate .meta/config.json "files" entry'
complete -c configlet -n "__fish_seen_subcommand_from sync"      -l metadata -d "Sync metadata only"
complete -c configlet -n "__fish_seen_subcommand_from sync"      -l tests -d "For auto-confirming" -x -a "choose include exclude"
complete -c configlet -n "__fish_seen_subcommand_from sync" -s e -l exercise -d "exercise slug" \
  -x -a "(find ./exercises/practice -maxdepth 1 -mindepth 1 -type d -printf '%P\n' | sort)"
```