### PR TITLE
completions: make `uuid -n` expect an argument

### DIFF
--- a/completions/configlet.bash
+++ b/completions/configlet.bash
@@ -58,7 +58,14 @@ _configlet_complete_info_() {
 }
 
 _configlet_complete_uuid_() {
-  _configlet_complete_options_ "-n --num $global_opts"
+  case $prev in
+    '-n' | '--num')
+      return 0 # Don't suggest a global option if -n has no argument.
+      ;;
+    *)
+      _configlet_complete_options_ "-n --num $global_opts"
+      ;;
+  esac
 }
 
 _configlet_complete_fmt_() {

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -14,7 +14,7 @@ complete -c configlet -n "__fish_seen_subcommand_from info" -s o -l offline -f -
 
 # uuid subcommand
 complete -c configlet -n "__fish_use_subcommand" -a uuid -f -d "Output a UUID"
-complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -f -d "How many UUIDs"
+complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -x -d "How many UUIDs"
 
 # fmt subcommand
 complete -c configlet -n "__fish_use_subcommand" -a fmt -f -d "Format the exercise '.meta/config.json' files"


### PR DESCRIPTION
Follow-up PR from #629.

@glennj does this look OK to you?

---

Before this commit, tab completion after `-n` would suggest global
options, even though `-n` without an argument is an error. For the fish
completions:

```console
$ configlet uuid -n[Tab]
-nh  (Show help)  -nt  (Select a track directory)  -nv  (Verbose level)
```

This commit removes that completion for both the bash and fish
completion scripts.

The fish [docs for `complete`](https://fishshell.com/docs/current/cmds/complete.html) describe the relevant options as:

> `-f` or `--no-files`
> This completion may not be followed by a filename.
> 
> `-r` or `--require-parameter`
> This completion must have an option argument, i.e. may not be followed by another option.
> 
> `-x` or `--exclusive`
> Short for `-r` and `-f`.

Closes: #636
