### PR TITLE
cli: add missing dot in help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage:
   configlet [global-options] <command> [command-options]
 
 Commands:
-  fmt       Format the exercise 'meta/config.json' files
+  fmt       Format the exercise '.meta/config.json' files
   generate  Generate Concept Exercise 'introduction.md' files from 'introduction.md.tpl' files
   info      Print some information about the track
   lint      Check the track configuration for correctness

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -174,7 +174,7 @@ func genHelpText: string =
 
   const actionDescriptions: array[ActionKind, string] = [
     actNil: "",
-    actFmt: "Format the exercise 'meta/config.json' files",
+    actFmt: "Format the exercise '.meta/config.json' files",
     actGenerate: "Generate Concept Exercise 'introduction.md' files from 'introduction.md.tpl' files",
     actInfo: "Print some information about the track",
     actLint: "Check the track configuration for correctness",


### PR DESCRIPTION
The help text for `fmt` was previously missing a dot before `meta`:

```console
$ configlet --help | grep 'meta/'
  fmt       Format the exercise 'meta/config.json' files
      --filepaths              Populate empty 'files' values in Concept/Practice exercise '.meta/config.json' files
      --metadata               Sync Practice Exercise '.meta/config.json' metadata values
      --tests [mode]           Sync Practice Exercise '.meta/tests.toml' files.
```