### PR TITLE
fetch-configlet: print instructions for installing completions

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -70,7 +70,8 @@ emit_completion_command() {
   file="bin/completions/configlet.$(basename "${shell}")"
   if [[ -f "${file}" && -r "${file}" ]]; then
     case "${shell}" in
-      bash | fish) echo "Enable tab completions: source ${file}" ;;
+      bash | fish)
+        echo "Enable tab completions: source ${file}" ;;
       zsh)
         : # is there more to do here than the above?
         ;;

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -70,9 +70,15 @@ emit_completion_command() {
   file="bin/completions/configlet.$(basename "${shell}")"
   if [[ -f "${file}" && -r "${file}" ]]; then
     case "${shell}" in
-      bash | fish)
+      bash)
         echo "To enable tab completions, run:"
         echo "    configlet completion -s ${shell} | source"
+        ;;
+      fish)
+        echo "To enable tab completions for the current session, run:"
+        echo "    configlet completion -s ${shell} | source"
+        echo "To enable tab completions for every session, run:"
+        echo "    configlet completion -s ${shell} > ~/.config/fish/completions/configlet.fish"
         ;;
       zsh)
         : # is there more to do here than the above?

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -54,9 +54,9 @@ get_download_url() {
 emit_completion_command() {
   local shell file
 
-  if command -v getent >/dev/null; then
+  if command -v getent > /dev/null; then
     shell=$(getent passwd "${USER}" | cut -d: -f7)
-  elif command -v finger >/dev/null; then
+  elif command -v finger > /dev/null; then
     shell=$(finger "${USER}" | sed -nE '/.*Shell: / { s///; s/ .*//; p; }')
   elif [[ -f /etc/passwd ]]; then
     shell=$(awk -F: -v u="${USER}" '$1 == u {print $7}' /etc/passwd)

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -49,6 +49,35 @@ get_download_url() {
     cut -d'"' -f4
 }
 
+# get the user's shell (as portably as possible)
+# and print out the command to enable tab completion
+emit_completion_command() {
+  local shell file
+
+  if command -v getent >/dev/null; then
+    shell=$(getent passwd "${USER}" | cut -d: -f7)
+  elif command -v finger >/dev/null; then
+    shell=$(finger "${USER}" | sed -nE '/.*Shell: / { s///; s/ .*//; p; }')
+  elif [[ -f /etc/passwd ]]; then
+    shell=$(awk -F: -v u="${USER}" '$1 == u {print $7}' /etc/passwd)
+  fi
+
+  if [[ -z "${shell}" ]]; then
+    # could not detect the shell
+    return
+  fi
+
+  file="bin/completions/configlet.$(basename "${shell}")"
+  if [[ -f "${file}" && -r "${file}" ]]; then
+    case "${shell}" in
+      bash | fish) echo "Enable tab completions: source ${file}" ;;
+      zsh)
+        : # is there more to do here than the above?
+        ;;
+    esac
+  fi
+}
+
 main() {
   if [[ -d ./bin ]]; then
     output_dir="./bin"
@@ -69,6 +98,8 @@ main() {
   esac
 
   rm -f "${output_path}"
+
+  emit_completion_command
 }
 
 main

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -71,7 +71,9 @@ emit_completion_command() {
   if [[ -f "${file}" && -r "${file}" ]]; then
     case "${shell}" in
       bash | fish)
-        echo "Enable tab completions: source ${file}" ;;
+        echo "To enable tab completions, run:"
+        echo "    configlet completion -s ${shell} | source"
+        ;;
       zsh)
         : # is there more to do here than the above?
         ;;


### PR DESCRIPTION
Closes: #635

---

@glennj I've taken the liberty of taking your commit from https://github.com/glennj/exercism-configlet/commit/e55d7757efca6371be0fcd0541d3416d4e7f9104 to begin this PR, which should be attributed to you.

The first commit in this PR is just that commit, but rebased on `main`. Feel free to push to this PR's branch.

This PR is a follow-up to https://github.com/exercism/configlet/pull/629, where these changes were originally.