### PR TITLE
completions: support `completion` subcommand

### DIFF
--- a/completions/configlet.bash
+++ b/completions/configlet.bash
@@ -21,13 +21,13 @@ _configlet_completion_() {
 
   local i
   for ((i = 1; i < COMP_CWORD; i++)); do
-    if [[ ${COMP_WORDS[i]} == @(lint|generate|info|uuid|fmt|sync) ]]; then
+    if [[ ${COMP_WORDS[i]} == @(completion|lint|generate|info|uuid|fmt|sync) ]]; then
       "_configlet_complete_${COMP_WORDS[i]}_"
       return
     fi
   done
 
-  _configlet_complete_options_ "fmt generate info lint sync uuid $global_opts"
+  _configlet_complete_options_ "completion fmt generate info lint sync uuid $global_opts"
 }
 
 _configlet_complete_global_option_() {
@@ -43,6 +43,17 @@ _configlet_complete_global_option_() {
       ;;
   esac
   return 1
+}
+
+_configlet_complete_completion_() {
+  case $prev in
+    '-s' | '--shell')
+      _configlet_complete_options_ "bash fish"
+      ;;
+    *)
+      _configlet_complete_options_ "-s --shell $global_opts"
+      ;;
+  esac
 }
 
 _configlet_complete_lint_() {

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -8,6 +8,11 @@ complete -c configlet -s v -l verbosity -x -a "quiet normal detailed" -d "Verbos
 complete -c configlet -n "__fish_use_subcommand" -a lint -f -d "Check the track configuration for correctness"
 complete -c configlet -n "__fish_use_subcommand" -a generate -f -d "Generate concept exercise introductions"
 
+# completion subcommand
+complete -c configlet -n "__fish_use_subcommand" -a completion -f -d "Output a completion script for a given shell"
+complete -c configlet -n "__fish_seen_subcommand_from completion" -s s -l shell -d "Shell type" \
+  -x -a "bash fish"
+
 # info subcommand
 complete -c configlet -n "__fish_use_subcommand" -a info -f -d "Track info"
 complete -c configlet -n "__fish_seen_subcommand_from info" -s o -l offline -f -d "Do not update prob-specs cache"


### PR DESCRIPTION
Make the completion scripts support the new `configlet completion`
subcommand from commit https://github.com/exercism/configlet/commit/d10dcd6ddf19b9f5441c0c944bc6f3486a2052f5, so that tab completion works for
things like:

```text
 $ configlet comp[Tab]
```

and

```text
$ configlet completion -s [Tab]
```

Closes: #648