### PR TITLE
completions(bash, fish): tweak formatting

### DIFF
--- a/completions/configlet.bash
+++ b/completions/configlet.bash
@@ -1,7 +1,7 @@
 # completions for the configlet command, bash flavour
 
 # remove any prior completions
-complete -r bin/configlet configlet 2>/dev/null
+complete -r bin/configlet configlet 2> /dev/null
 # and install this one
 complete -F _configlet_completion_ configlet
 

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -17,28 +17,30 @@ complete -c configlet -s v -l verbosity  -d "Verbose level" \
 complete -c configlet -n "__fish_use_subcommand" -a lint -d "Check the track configuration for correctness"
 complete -c configlet -n "__fish_use_subcommand" -a generate -d "Generate concept exercise introductions"
 
-# completion subcommand
+# subcommands with options
 complete -c configlet -n "__fish_use_subcommand" -a completion -d "Output a completion script for a given shell"
+complete -c configlet -n "__fish_use_subcommand" -a info -d "Track info"
+complete -c configlet -n "__fish_use_subcommand" -a uuid -d "Output a UUID"
+complete -c configlet -n "__fish_use_subcommand" -a fmt -d "Format the exercise '.meta/config.json' files"
+complete -c configlet -n "__fish_use_subcommand" -a sync -d "Check or update Practice Exercise docs, metadata, and tests"
+
+# completion subcommand
 complete -c configlet -n "__fish_seen_subcommand_from completion" -s s -l shell -d "Shell type" \
   -x -a "bash fish zsh"
 
 # info subcommand
-complete -c configlet -n "__fish_use_subcommand" -a info -d "Track info"
 complete -c configlet -n "__fish_seen_subcommand_from info" -s o -l offline -d "Do not update prob-specs cache"
 
 # uuid subcommand
-complete -c configlet -n "__fish_use_subcommand" -a uuid -d "Output a UUID"
 complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -x -d "How many UUIDs"
 
 # fmt subcommand
-complete -c configlet -n "__fish_use_subcommand" -a fmt -d "Format the exercise '.meta/config.json' files"
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s u -l update -d "Write changes"
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s y -l yes -d "Auto-confirm update"
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s e -l exercise -d "exercise slug" \
   -x -a '(__fish_configlet_find_dirs ./exercises/{concept,practice})'
 
 # sync subcommand
-complete -c configlet -n "__fish_use_subcommand" -a sync -d "Check or update Practice Exercise docs, metadata, and tests"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s o -l offline -d "Do not update prob-specs cache"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s u -l update -d "Write changes"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s y -l yes -d "Auto-confirm update"

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -14,31 +14,28 @@ complete -c configlet -s v -l verbosity  -d "Verbose level" \
   -x -a "quiet normal detailed"
 
 # subcommands with no options
-complete -c configlet -n "__fish_use_subcommand" -a lint -d "Check the track configuration for correctness"
 complete -c configlet -n "__fish_use_subcommand" -a generate -d "Generate concept exercise introductions"
+complete -c configlet -n "__fish_use_subcommand" -a lint -d "Check the track configuration for correctness"
 
 # subcommands with options
 complete -c configlet -n "__fish_use_subcommand" -a completion -d "Output a completion script for a given shell"
-complete -c configlet -n "__fish_use_subcommand" -a info -d "Track info"
-complete -c configlet -n "__fish_use_subcommand" -a uuid -d "Output a UUID"
 complete -c configlet -n "__fish_use_subcommand" -a fmt -d "Format the exercise '.meta/config.json' files"
+complete -c configlet -n "__fish_use_subcommand" -a info -d "Track info"
 complete -c configlet -n "__fish_use_subcommand" -a sync -d "Check or update Practice Exercise docs, metadata, and tests"
+complete -c configlet -n "__fish_use_subcommand" -a uuid -d "Output a UUID"
 
 # completion subcommand
 complete -c configlet -n "__fish_seen_subcommand_from completion" -s s -l shell -d "Shell type" \
   -x -a "bash fish zsh"
-
-# info subcommand
-complete -c configlet -n "__fish_seen_subcommand_from info" -s o -l offline -d "Do not update prob-specs cache"
-
-# uuid subcommand
-complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -x -d "How many UUIDs"
 
 # fmt subcommand
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s u -l update -d "Write changes"
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s y -l yes -d "Auto-confirm update"
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s e -l exercise -d "exercise slug" \
   -x -a '(__fish_configlet_find_dirs ./exercises/{concept,practice})'
+
+# info subcommand
+complete -c configlet -n "__fish_seen_subcommand_from info" -s o -l offline -d "Do not update prob-specs cache"
 
 # sync subcommand
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s o -l offline -d "Do not update prob-specs cache"
@@ -51,3 +48,6 @@ complete -c configlet -n "__fish_seen_subcommand_from sync"      -l tests -d "Fo
   -x -a "choose include exclude"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s e -l exercise -d "exercise slug" \
   -x -a '(__fish_configlet_find_dirs ./exercises/practice)'
+
+# uuid subcommand
+complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -x -d "How many UUIDs"

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -50,4 +50,4 @@ complete -c configlet -n "__fish_seen_subcommand_from sync"      -l tests -d "Fo
   -xa "choose include exclude"
 
 # uuid subcommand
-complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -x -d "How many UUIDs"
+complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -d "How many UUIDs" -x

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -5,49 +5,49 @@ end
 # disable file completions everywhere
 complete -c configlet -f
 
-# global options
-complete -c configlet -s h -l help -d "Show help"
-complete -c configlet      -l version -d "Show version info"
-complete -c configlet -s t -l track-dir -d "Select a track directory" \
-  -xa "(__fish_complete_directories)"
-complete -c configlet -s v -l verbosity  -d "Verbose level" \
-  -xa "quiet normal detailed"
-
 # subcommands with no options
-complete -c configlet -n "__fish_use_subcommand" -a generate -d "Generate concept exercise introductions"
-complete -c configlet -n "__fish_use_subcommand" -a lint -d "Check the track configuration for correctness"
+complete -c configlet -n "__fish_use_subcommand" -a generate   -d "Generate concept exercise introductions"
+complete -c configlet -n "__fish_use_subcommand" -a lint       -d "Check the track configuration for correctness"
 
 # subcommands with options
 complete -c configlet -n "__fish_use_subcommand" -a completion -d "Output a completion script for a given shell"
-complete -c configlet -n "__fish_use_subcommand" -a fmt -d "Format the exercise '.meta/config.json' files"
-complete -c configlet -n "__fish_use_subcommand" -a info -d "Track info"
-complete -c configlet -n "__fish_use_subcommand" -a sync -d "Check or update Practice Exercise docs, metadata, and tests"
-complete -c configlet -n "__fish_use_subcommand" -a uuid -d "Output a UUID"
+complete -c configlet -n "__fish_use_subcommand" -a fmt        -d "Format the exercise '.meta/config.json' files"
+complete -c configlet -n "__fish_use_subcommand" -a info       -d "Track info"
+complete -c configlet -n "__fish_use_subcommand" -a sync       -d "Check or update Practice Exercise docs, metadata, and tests"
+complete -c configlet -n "__fish_use_subcommand" -a uuid       -d "Output a UUID"
 
 # completion subcommand
-complete -c configlet -n "__fish_seen_subcommand_from completion" -s s -l shell -d "Shell type" \
+complete -c configlet -n "__fish_seen_subcommand_from completion" -s s -l shell     -d "Shell type" \
   -xa "bash fish zsh"
 
 # fmt subcommand
-complete -c configlet -n "__fish_seen_subcommand_from fmt" -s e -l exercise -d "exercise slug" \
+complete -c configlet -n "__fish_seen_subcommand_from fmt"        -s e -l exercise  -d "exercise slug" \
   -xa '(__fish_configlet_find_dirs ./exercises/{concept,practice})'
-complete -c configlet -n "__fish_seen_subcommand_from fmt" -s u -l update -d "Write changes"
-complete -c configlet -n "__fish_seen_subcommand_from fmt" -s y -l yes -d "Auto-confirm update"
+complete -c configlet -n "__fish_seen_subcommand_from fmt"        -s u -l update    -d "Write changes"
+complete -c configlet -n "__fish_seen_subcommand_from fmt"        -s y -l yes       -d "Auto-confirm update"
 
 # info subcommand
-complete -c configlet -n "__fish_seen_subcommand_from info" -s o -l offline -d "Do not update prob-specs cache"
+complete -c configlet -n "__fish_seen_subcommand_from info"       -s o -l offline   -d "Do not update prob-specs cache"
 
 # sync subcommand
-complete -c configlet -n "__fish_seen_subcommand_from sync" -s e -l exercise -d "exercise slug" \
+complete -c configlet -n "__fish_seen_subcommand_from sync"       -s e -l exercise  -d "exercise slug" \
   -xa '(__fish_configlet_find_dirs ./exercises/practice)'
-complete -c configlet -n "__fish_seen_subcommand_from sync" -s o -l offline -d "Do not update prob-specs cache"
-complete -c configlet -n "__fish_seen_subcommand_from sync" -s u -l update -d "Write changes"
-complete -c configlet -n "__fish_seen_subcommand_from sync" -s y -l yes -d "Auto-confirm update"
-complete -c configlet -n "__fish_seen_subcommand_from sync"      -l docs -d "Sync docs only"
-complete -c configlet -n "__fish_seen_subcommand_from sync"      -l filepaths -d 'Populate .meta/config.json "files" entry'
-complete -c configlet -n "__fish_seen_subcommand_from sync"      -l metadata -d "Sync metadata only"
-complete -c configlet -n "__fish_seen_subcommand_from sync"      -l tests -d "For auto-confirming" \
+complete -c configlet -n "__fish_seen_subcommand_from sync"       -s o -l offline   -d "Do not update prob-specs cache"
+complete -c configlet -n "__fish_seen_subcommand_from sync"       -s u -l update    -d "Write changes"
+complete -c configlet -n "__fish_seen_subcommand_from sync"       -s y -l yes       -d "Auto-confirm update"
+complete -c configlet -n "__fish_seen_subcommand_from sync"            -l docs      -d "Sync docs only"
+complete -c configlet -n "__fish_seen_subcommand_from sync"            -l filepaths -d 'Populate .meta/config.json "files" entry'
+complete -c configlet -n "__fish_seen_subcommand_from sync"            -l metadata  -d "Sync metadata only"
+complete -c configlet -n "__fish_seen_subcommand_from sync"            -l tests     -d "For auto-confirming" \
   -xa "choose include exclude"
 
 # uuid subcommand
-complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -d "How many UUIDs" -x
+complete -c configlet -n "__fish_seen_subcommand_from uuid"       -s n -l num       -d "How many UUIDs" -x
+
+# global options
+complete -c configlet                                             -s h -l help      -d "Show help"
+complete -c configlet                                                  -l version   -d "Show version info"
+complete -c configlet                                             -s t -l track-dir -d "Select a track directory" \
+  -xa "(__fish_complete_directories)"
+complete -c configlet                                             -s v -l verbosity -d "Verbose level" \
+  -xa "quiet normal detailed"

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -9,9 +9,9 @@ complete -c configlet -f
 complete -c configlet -s h -l help -d "Show help"
 complete -c configlet      -l version -d "Show version info"
 complete -c configlet -s t -l track-dir -d "Select a track directory" \
-  -x -a "(__fish_complete_directories)"
+  -xa "(__fish_complete_directories)"
 complete -c configlet -s v -l verbosity  -d "Verbose level" \
-  -x -a "quiet normal detailed"
+  -xa "quiet normal detailed"
 
 # subcommands with no options
 complete -c configlet -n "__fish_use_subcommand" -a generate -d "Generate concept exercise introductions"
@@ -26,11 +26,11 @@ complete -c configlet -n "__fish_use_subcommand" -a uuid -d "Output a UUID"
 
 # completion subcommand
 complete -c configlet -n "__fish_seen_subcommand_from completion" -s s -l shell -d "Shell type" \
-  -x -a "bash fish zsh"
+  -xa "bash fish zsh"
 
 # fmt subcommand
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s e -l exercise -d "exercise slug" \
-  -x -a '(__fish_configlet_find_dirs ./exercises/{concept,practice})'
+  -xa '(__fish_configlet_find_dirs ./exercises/{concept,practice})'
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s u -l update -d "Write changes"
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s y -l yes -d "Auto-confirm update"
 
@@ -39,7 +39,7 @@ complete -c configlet -n "__fish_seen_subcommand_from info" -s o -l offline -d "
 
 # sync subcommand
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s e -l exercise -d "exercise slug" \
-  -x -a '(__fish_configlet_find_dirs ./exercises/practice)'
+  -xa '(__fish_configlet_find_dirs ./exercises/practice)'
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s o -l offline -d "Do not update prob-specs cache"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s u -l update -d "Write changes"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s y -l yes -d "Auto-confirm update"
@@ -47,7 +47,7 @@ complete -c configlet -n "__fish_seen_subcommand_from sync"      -l docs -d "Syn
 complete -c configlet -n "__fish_seen_subcommand_from sync"      -l filepaths -d 'Populate .meta/config.json "files" entry'
 complete -c configlet -n "__fish_seen_subcommand_from sync"      -l metadata -d "Sync metadata only"
 complete -c configlet -n "__fish_seen_subcommand_from sync"      -l tests -d "For auto-confirming" \
-  -x -a "choose include exclude"
+  -xa "choose include exclude"
 
 # uuid subcommand
 complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -x -d "How many UUIDs"

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -10,7 +10,8 @@ complete -c configlet -s h -l help -d "Show help"
 complete -c configlet      -l version -d "Show version info"
 complete -c configlet -s t -l track-dir -d "Select a track directory" \
   -x -a "(__fish_complete_directories)"
-complete -c configlet -s v -l verbosity -x -a "quiet normal detailed" -d "Verbose level"
+complete -c configlet -s v -l verbosity  -d "Verbose level" \
+  -x -a "quiet normal detailed"
 
 # subcommands with no options
 complete -c configlet -n "__fish_use_subcommand" -a lint -d "Check the track configuration for correctness"
@@ -44,6 +45,7 @@ complete -c configlet -n "__fish_seen_subcommand_from sync" -s y -l yes -d "Auto
 complete -c configlet -n "__fish_seen_subcommand_from sync"      -l docs -d "Sync docs only"
 complete -c configlet -n "__fish_seen_subcommand_from sync"      -l filepaths -d 'Populate .meta/config.json "files" entry'
 complete -c configlet -n "__fish_seen_subcommand_from sync"      -l metadata -d "Sync metadata only"
-complete -c configlet -n "__fish_seen_subcommand_from sync"      -l tests -d "For auto-confirming" -x -a "choose include exclude"
+complete -c configlet -n "__fish_seen_subcommand_from sync"      -l tests -d "For auto-confirming" \
+  -x -a "choose include exclude"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s e -l exercise -d "exercise slug" \
   -x -a '(__fish_configlet_find_dirs ./exercises/practice)'

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -29,15 +29,17 @@ complete -c configlet -n "__fish_seen_subcommand_from completion" -s s -l shell 
   -x -a "bash fish zsh"
 
 # fmt subcommand
-complete -c configlet -n "__fish_seen_subcommand_from fmt" -s u -l update -d "Write changes"
-complete -c configlet -n "__fish_seen_subcommand_from fmt" -s y -l yes -d "Auto-confirm update"
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s e -l exercise -d "exercise slug" \
   -x -a '(__fish_configlet_find_dirs ./exercises/{concept,practice})'
+complete -c configlet -n "__fish_seen_subcommand_from fmt" -s u -l update -d "Write changes"
+complete -c configlet -n "__fish_seen_subcommand_from fmt" -s y -l yes -d "Auto-confirm update"
 
 # info subcommand
 complete -c configlet -n "__fish_seen_subcommand_from info" -s o -l offline -d "Do not update prob-specs cache"
 
 # sync subcommand
+complete -c configlet -n "__fish_seen_subcommand_from sync" -s e -l exercise -d "exercise slug" \
+  -x -a '(__fish_configlet_find_dirs ./exercises/practice)'
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s o -l offline -d "Do not update prob-specs cache"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s u -l update -d "Write changes"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s y -l yes -d "Auto-confirm update"
@@ -46,8 +48,6 @@ complete -c configlet -n "__fish_seen_subcommand_from sync"      -l filepaths -d
 complete -c configlet -n "__fish_seen_subcommand_from sync"      -l metadata -d "Sync metadata only"
 complete -c configlet -n "__fish_seen_subcommand_from sync"      -l tests -d "For auto-confirming" \
   -x -a "choose include exclude"
-complete -c configlet -n "__fish_seen_subcommand_from sync" -s e -l exercise -d "exercise slug" \
-  -x -a '(__fish_configlet_find_dirs ./exercises/practice)'
 
 # uuid subcommand
 complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -x -d "How many UUIDs"


### PR DESCRIPTION
Currently, the completions aren't auto-generated from a Nim source of
truth. Make it easier to scan the fish completions by making them more
similar to the output of `configlet --help`:

- Group `__fish_use_subcommand` completions.
- Order subcommands and options alphabetically.
- Align `-s`, `-l`, and `-d`.
- Always put `-xa` on its own line.

Also, format the bash completions with [shfmt](https://github.com/mvdan/sh/blob/v3.5.1/cmd/shfmt/shfmt.1.scd):

```shell
shfmt --indent 2 --case-indent --space-redirects --keep-padding
```

---

This PR is a bit bikeshed-y, but I claim that [the new `configlet.fish`](https://github.com/exercism/configlet/blob/27e1da9543333595b1db1f953d90f7d6ea66a846/completions/configlet.fish) is more readable than [the old `configlet.fish`](https://github.com/exercism/configlet/blob/f8547844eafe7ca3d77fca7223c9d365e5ed4497/completions/configlet.fish). So I think this is marginally worthwhile, at least until we close #638.

The extra whitespace doesn't add binary bloat because we compress the completion scripts at compile time and uncompress them at runtime (see https://github.com/exercism/configlet/pull/652).

The configlet help message:

```console
$ configlet --help
[...]
Commands:
  completion  Output a completion script for a given shell
  fmt         Format the exercise '.meta/config.json' files
  generate    Generate Concept Exercise 'introduction.md' files from 'introduction.md.tpl' files
  info        Print some information about the track
  lint        Check the track configuration for correctness
  sync        Check or update Practice Exercise docs, metadata, and tests from 'problem-specifications'.
              Check or populate missing 'files' values for Concept/Practice Exercises from the track 'config.json'.
  uuid        Output new (version 4) UUIDs, suitable for the value of a 'uuid' key

Options for completion:
  -s, --shell <shell>          Choose the shell type (required)
                               Allowed values: b[ash], f[ish], z[sh]

Options for fmt:
  -e, --exercise <slug>        Only operate on this exercise
  -u, --update                 Prompt to write formatted files
  -y, --yes                    Auto-confirm the prompt from --update

Options for info:
  -o, --offline                Do not update the cached 'problem-specifications' data

Options for sync:
  -e, --exercise <slug>        Only operate on this exercise
  -o, --offline                Do not update the cached 'problem-specifications' data
  -u, --update                 Prompt to update the unsynced track data
  -y, --yes                    Auto-confirm prompts from --update for updating docs, filepaths, and metadata
      --docs                   Sync Practice Exercise '.docs/introduction.md' and '.docs/instructions.md' files
      --filepaths              Populate empty 'files' values in Concept/Practice exercise '.meta/config.json' files
      --metadata               Sync Practice Exercise '.meta/config.json' metadata values
      --tests [mode]           Sync Practice Exercise '.meta/tests.toml' files.
                               The mode value specifies how missing tests are handled when using --update.
                               Allowed values: c[hoose], i[nclude], e[xclude] (default: choose)

Options for uuid:
  -n, --num <int>              Number of UUIDs to output

Global options:
  -h, --help                   Show this help message and exit
      --version                Show this tool's version information and exit
  -t, --track-dir <dir>        Specify a track directory to use instead of the current directory
  -v, --verbosity <verbosity>  The verbosity of output.
                               Allowed values: q[uiet], n[ormal], d[etailed] (default: normal)
```