### PR TITLE
completion: add zsh

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,4 +11,6 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9
+        uses: ludeeus/action-shellcheck@203a3fd018dfe73f8ae7e3aa8da2c149a5f41c33
+        with:
+          ignore_names: configlet.zsh

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Commands:
 
 Options for completion:
   -s, --shell <shell>          Choose the shell type (required)
-                               Allowed values: b[ash], f[ish]
+                               Allowed values: b[ash], f[ish], z[sh]
 
 Options for fmt:
   -e, --exercise <slug>        Only operate on this exercise

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -49,7 +49,7 @@ _configlet() {
     (fmt)
       _arguments "${_arguments_options[@]}" \
           "$_configlet_global_opts[@]" \
-          {-e,--exercise}'+:[exercise slug]' \
+          '(-e --exercise)'{-e+,--exercise=}'[exercise slug]:' \
           {-u,--update}'[Write changes]' \
           {-y,--yes}'[Auto-confirm update]' \
       ;;
@@ -61,7 +61,7 @@ _configlet() {
     (sync)
       _arguments "${_arguments_options[@]}" \
           "$_configlet_global_opts[@]" \
-          {-e,--exercise}'+:[exercise slug]' \
+          '(-e --exercise)'{-e+,--exercise=}'[exercise slug]:' \
           {-o,--offline}'[Do not update prob-specs cache]' \
           {-u,--update}'[Write changes]' \
           {-y,--yes}'[Auto-confirm update]' \

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -73,7 +73,7 @@ _configlet() {
     (uuid)
       _arguments "${_arguments_options[@]}" \
           "$_configlet_global_opts[@]" \
-          {-n,--num}'+:[How many UUIDs]' \
+          '(-n --num)'{-n+,--num=}'[How many UUIDs]:' \
       ;;
   esac
 }

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -14,11 +14,15 @@ _configlet() {
   local line
   local curcontext="$curcontext"
 
+  _configlet_global_opts=(
+    {-h,--help}'[Show help]'
+    '--version[Show version information]'
+    {-t,--track-dir}'+:[Select a track directory]'
+    {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)'
+  )
+
   _arguments "${_arguments_options[@]}" \
-      {-h,--help}'[Show help]' \
-      '--version[Show version information]' \
-      {-t,--track-dir}'+:[Select a track directory]' \
-      {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+      "$_configlet_global_opts[@]" \
       ":: :_configlet_commands" \
       "*::: :->configlet"
 
@@ -30,51 +34,33 @@ _configlet() {
     # subcommands with no options
     (generate)
       _arguments "${_arguments_options[@]}" \
-          {-h,--help}'[Show help]' \
-          '--version[Show version information]' \
-          {-t,--track-dir}'+:[Select a track directory]' \
-          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+          "$_configlet_global_opts[@]" \
       ;;
     (lint)
       _arguments "${_arguments_options[@]}" \
-          {-h,--help}'[Show help]' \
-          '--version[Show version information]' \
-          {-t,--track-dir}'+:[Select a track directory]' \
-          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+         "$_configlet_global_opts[@]" \
       ;;
     # subcommands with options
     (completion)
       _arguments "${_arguments_options[@]}" \
-          {-h,--help}'[Show help]' \
-          '--version[Show version information]' \
-          {-t,--track-dir}'+:[Select a track directory]' \
-          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+          "$_configlet_global_opts[@]" \
           {-s,--shell}'[Select the shell type]: :(bash fish zsh)' \
       ;;
     (fmt)
       _arguments "${_arguments_options[@]}" \
-          {-h,--help}'[Show help]' \
-          '--version[Show version information]' \
-          {-t,--track-dir}'+:[Select a track directory]' \
-          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+          "$_configlet_global_opts[@]" \
           {-e,--exercise}'+:[exercise slug]' \
           {-u,--update}'[Write changes]' \
           {-y,--yes}'[Auto-confirm update]' \
       ;;
     (info)
       _arguments "${_arguments_options[@]}" \
-          {-h,--help}'[Show help]' \
-          '--version[Show version information]' \
-          {-t,--track-dir}'+:[Select a track directory]' \
-          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+          "$_configlet_global_opts[@]" \
           {-o,--offline}'[Do not update prob-specs cache]' \
       ;;
     (sync)
       _arguments "${_arguments_options[@]}" \
-          {-h,--help}'[Show help]' \
-          '--version[Show version information]' \
-          {-t,--track-dir}'+:[Select a track directory]' \
-          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+          "$_configlet_global_opts[@]" \
           {-e,--exercise}'+:[exercise slug]' \
           {-o,--offline}'[Do not update prob-specs cache]' \
           {-u,--update}'[Write changes]' \
@@ -86,10 +72,7 @@ _configlet() {
       ;;
     (uuid)
       _arguments "${_arguments_options[@]}" \
-          {-h,--help}'[Show help]' \
-          '--version[Show version information]' \
-          {-t,--track-dir}'+:[Select a track directory]' \
-          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+          "$_configlet_global_opts[@]" \
           {-n,--num}'+:[How many UUIDs]' \
       ;;
   esac

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -17,7 +17,7 @@ _configlet() {
   _configlet_global_opts=(
     {-h,--help}'[Show help]'
     '--version[Show version information]'
-    {-t,--track-dir}'+:[Select a track directory]'
+    '(-t --track-dir)'{-t+,--track-dir=}'[Select a track directory]:'
     {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)'
   )
 

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -47,6 +47,13 @@ _configlet() {
   (( CURRENT += 1 ))
   curcontext="${curcontext%:*:*}:configlet-command-$line[1]:"
 
+  _configlet_complete_practice_exercise_slug() {
+    local -a cmd slugs slug_paths
+    slug_paths=(./exercises/practice/*(/))
+    slugs=( ${${slug_paths#./exercises/practice/}%-*-*} )
+    compadd "$@" -a slugs
+  }
+
   case $line[1] in
     # subcommands with no options
     (generate)
@@ -78,7 +85,7 @@ _configlet() {
     (sync)
       _arguments "${_arguments_options[@]}" \
           "$_configlet_global_opts[@]" \
-          '(-e --exercise)'{-e+,--exercise=}'[exercise slug]:' \
+          '(-e --exercise)'{-e+,--exercise=}'[exercise slug]:slug:_configlet_complete_practice_exercise_slug' \
           {-o,--offline}'[Do not update prob-specs cache]' \
           {-u,--update}'[Write changes]' \
           {-y,--yes}'[Auto-confirm update]' \

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -47,6 +47,15 @@ _configlet() {
   (( CURRENT += 1 ))
   curcontext="${curcontext%:*:*}:configlet-command-$line[1]:"
 
+  _configlet_complete_any_exercise_slug() {
+    local -a cmd slugs slug_paths
+    slug_paths=(./exercises/concept/*(/))
+    slugs=( ${${slug_paths#./exercises/concept/}%-*-*} )
+    slug_paths=(./exercises/practice/*(/))
+    slugs+=( ${${slug_paths#./exercises/practice/}%-*-*} )
+    compadd "$@" -a slugs
+  }
+
   _configlet_complete_practice_exercise_slug() {
     local -a cmd slugs slug_paths
     slug_paths=(./exercises/practice/*(/))
@@ -73,7 +82,7 @@ _configlet() {
     (fmt)
       _arguments "${_arguments_options[@]}" \
           "$_configlet_global_opts[@]" \
-          '(-e --exercise)'{-e+,--exercise=}'[exercise slug]:' \
+          '(-e --exercise)'{-e+,--exercise=}'[exercise slug]:slug:_configlet_complete_any_exercise_slug' \
           {-u,--update}'[Write changes]' \
           {-y,--yes}'[Auto-confirm update]' \
       ;;

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -2,6 +2,23 @@
 
 autoload -U is-at-least
 
+(( $+functions[_configlet_commands] )) ||
+_configlet_commands() {
+  local commands
+  commands=(
+    # subcommands with no options
+    "generate:Generate concept exercise introductions" \
+    "lint:Check the track configuration for correctness" \
+    # subcommands with options
+    "completion:Output a completion script for a given shell" \
+    "fmt:Format the exercise '.meta/config.json' files" \
+    "info:Print track information" \
+    "sync:Check or update Practice Exercise docs, metadata, and tests" \
+    "uuid:Output a version 4 UUID" \
+  )
+  _describe -t commands 'configlet commands' commands "$@"
+}
+
 _configlet() {
   typeset -a _arguments_options
 
@@ -76,23 +93,6 @@ _configlet() {
           '(-n --num)'{-n+,--num=}'[How many UUIDs]:' \
       ;;
   esac
-}
-
-(( $+functions[_configlet_commands] )) ||
-_configlet_commands() {
-  local commands
-  commands=(
-    # subcommands with no options
-    "generate:Generate concept exercise introductions" \
-    "lint:Check the track configuration for correctness" \
-    # subcommands with options
-    "completion:Output a completion script for a given shell" \
-    "fmt:Format the exercise '.meta/config.json' files" \
-    "info:Print track information" \
-    "sync:Check or update Practice Exercise docs, metadata, and tests" \
-    "uuid:Output a version 4 UUID" \
-  )
-  _describe -t commands 'configlet commands' commands "$@"
 }
 
 _configlet "$@"

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -1,0 +1,115 @@
+#compdef configlet
+
+autoload -U is-at-least
+
+_configlet() {
+  typeset -a _arguments_options
+
+  if is-at-least 5.2; then
+    _arguments_options=(-s -S -C)
+  else
+    _arguments_options=(-s -C)
+  fi
+
+  local line
+  local curcontext="$curcontext"
+
+  _arguments "${_arguments_options[@]}" \
+      {-h,--help}'[Show help]' \
+      '--version[Show version information]' \
+      {-t,--track-dir}'+:[Select a track directory]' \
+      {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+      ":: :_configlet_commands" \
+      "*::: :->configlet"
+
+  words=($line[1] "${words[@]}")
+  (( CURRENT += 1 ))
+  curcontext="${curcontext%:*:*}:configlet-command-$line[1]:"
+
+  case $line[1] in
+    # subcommands with no options
+    (generate)
+      _arguments "${_arguments_options[@]}" \
+          {-h,--help}'[Show help]' \
+          '--version[Show version information]' \
+          {-t,--track-dir}'+:[Select a track directory]' \
+          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+      ;;
+    (lint)
+      _arguments "${_arguments_options[@]}" \
+          {-h,--help}'[Show help]' \
+          '--version[Show version information]' \
+          {-t,--track-dir}'+:[Select a track directory]' \
+          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+      ;;
+    # subcommands with options
+    (completion)
+      _arguments "${_arguments_options[@]}" \
+          {-h,--help}'[Show help]' \
+          '--version[Show version information]' \
+          {-t,--track-dir}'+:[Select a track directory]' \
+          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+          {-s,--shell}'[Select the shell type]: :(bash fish zsh)' \
+      ;;
+    (fmt)
+      _arguments "${_arguments_options[@]}" \
+          {-h,--help}'[Show help]' \
+          '--version[Show version information]' \
+          {-t,--track-dir}'+:[Select a track directory]' \
+          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+          {-e,--exercise}'+:[exercise slug]' \
+          {-u,--update}'[Write changes]' \
+          {-y,--yes}'[Auto-confirm update]' \
+      ;;
+    (info)
+      _arguments "${_arguments_options[@]}" \
+          {-h,--help}'[Show help]' \
+          '--version[Show version information]' \
+          {-t,--track-dir}'+:[Select a track directory]' \
+          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+          {-o,--offline}'[Do not update prob-specs cache]' \
+      ;;
+    (sync)
+      _arguments "${_arguments_options[@]}" \
+          {-h,--help}'[Show help]' \
+          '--version[Show version information]' \
+          {-t,--track-dir}'+:[Select a track directory]' \
+          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+          {-e,--exercise}'+:[exercise slug]' \
+          {-o,--offline}'[Do not update prob-specs cache]' \
+          {-u,--update}'[Write changes]' \
+          {-y,--yes}'[Auto-confirm update]' \
+          '--docs[Sync docs only]' \
+          '--filepaths[Populate .meta/config.json "files" entry]' \
+          '--metadata[Sync metadata only]' \
+          '--tests[For auto-confirming]: :(choose include exclude)' \
+      ;;
+    (uuid)
+      _arguments "${_arguments_options[@]}" \
+          {-h,--help}'[Show help]' \
+          '--version[Show version information]' \
+          {-t,--track-dir}'+:[Select a track directory]' \
+          {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)' \
+          {-n,--num}'+:[How many UUIDs]' \
+      ;;
+  esac
+}
+
+(( $+functions[_configlet_commands] )) ||
+_configlet_commands() {
+  local commands
+  commands=(
+    # subcommands with no options
+    "generate:Generate concept exercise introductions" \
+    "lint:Check the track configuration for correctness" \
+    # subcommands with options
+    "completion:Output a completion script for a given shell" \
+    "fmt:Format the exercise '.meta/config.json' files" \
+    "info:Print track information" \
+    "sync:Check or update Practice Exercise docs, metadata, and tests" \
+    "uuid:Output a version 4 UUID" \
+  )
+  _describe -t commands 'configlet commands' commands "$@"
+}
+
+_configlet "$@"

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -34,7 +34,7 @@ _configlet() {
   _configlet_global_opts=(
     {-h,--help}'[Show help]'
     '--version[Show version information]'
-    '(-t --track-dir)'{-t+,--track-dir=}'[Select a track directory]:'
+    '(-t --track-dir)'{-t+,--track-dir=}'[Select a track directory]:directory:_directories'
     {-v,--verbosity}'[Verbosity level]: :(quiet normal detailed)'
   )
 

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -48,18 +48,16 @@ _configlet() {
   curcontext="${curcontext%:*:*}:configlet-command-$line[1]:"
 
   _configlet_complete_any_exercise_slug() {
-    local -a cmd slugs slug_paths
-    slug_paths=(./exercises/concept/*(/))
-    slugs=( ${${slug_paths#./exercises/concept/}%-*-*} )
-    slug_paths=(./exercises/practice/*(/))
-    slugs+=( ${${slug_paths#./exercises/practice/}%-*-*} )
+    local -a slugs slug_paths
+    slug_paths=( ./exercises/{concept,practice}/*(/) )
+    slugs=( "${slug_paths[@]##*/}" )
     compadd "$@" -a slugs
   }
 
   _configlet_complete_practice_exercise_slug() {
-    local -a cmd slugs slug_paths
-    slug_paths=(./exercises/practice/*(/))
-    slugs=( ${${slug_paths#./exercises/practice/}%-*-*} )
+    local -a slugs slug_paths
+    slug_paths=( ./exercises/practice/*(/) )
+    slugs=( "${slug_paths[@]##*/}" )
     compadd "$@" -a slugs
   }
 

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -16,6 +16,7 @@ type
     sNil = "nil"
     sBash = "bash"
     sFish = "fish"
+    sZsh = "zsh"
 
   SyncKind* = enum
     skDocs = "docs"

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -932,7 +932,7 @@ proc testsForGenerate(binaryPath: string) =
 proc testsForCompletion(binaryPath: string) =
   suite "completion":
     const completionsDir = repoRootDir / "completions"
-    for shell in ["bash", "fish"]:
+    for shell in ["bash", "fish", "zsh"]:
       test shell:
         let c = shell[0]
         # Convert platform-specific line endings (e.g. CR+LF on Windows) to LF
@@ -943,7 +943,7 @@ proc testsForCompletion(binaryPath: string) =
         execAndCheck(0, &"{binaryPath} completion -s {shell}", expected)
         execAndCheck(0, &"{binaryPath} completion -s {c}", expected)
         execAndCheck(0, &"{binaryPath} completion -s{c}", expected)
-    for shell in ["powershell", "zsh"]:
+    for shell in ["powershell"]:
       test &"{shell} (produces an error)":
         let (outp, exitCode) = execCmdEx(&"{binaryPath} completion -s {shell}")
         check:


### PR DESCRIPTION
Add a zsh completion script and the ability to run

```shell
configlet completion --shell zsh
```

to write that script to stdout.

This commit also bumps the version of the shellcheck action, which is
necessary to prevent the action from running `shellcheck` on the new zsh
script. Shellcheck does not support zsh, so CI would indicate an error
otherwise.

The bump must be to the latest commit - we already used the latest
release (1.1.0). An [upstream commit](https://github.com/ludeeus/action-shellcheck/commit/ceeca77f6538) that claims to exclude zsh
scripts seems to be insufficient - we need to use the `ignore_names`
input that [does not exist in the latest release](https://github.com/ludeeus/action-shellcheck/commit/c2b45ddc5f85).

Closes: #633

---

It seems like every tutorial for this is pretty bad.

Some links for the reviewer:

- [zsh completions for `pacman`](https://gitlab.archlinux.org/pacman/pacman/-/blob/master/scripts/completion/zsh_completion.in).
- [zsh completions for `git`](https://github.com/zsh-users/zsh/blob/master/Completion/Unix/Command/_git).
- https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org
- If you have zsh completions installed, it may or may not be helpful to look in `/usr/share/zsh/functions/Completion/Unix/` and `/usr/share/zsh/site-functions` for the completions for a program you know well.
- [`man zshcompsys`](https://man.archlinux.org/man/zshcompsys.1.en). Good luck.
- For installing `zsh` and enabling completions: https://wiki.archlinux.org/title/zsh#Command_completion

---

To test this PR, copy `configlet.zsh` to some directory, naming it `_configlet`:

```shell
mkdir ~/configlet-comp
cp completions/configlet.zsh ~/configlet-comp/_configlet
```

(Don't put it under `/tmp`, or you might get an error message about an insecure completions folder).

Then add that directory to your `fpath`. In `.zshrc`:

```shell
fpath=(~/configlet-comp $fpath)
```

And make sure that [completions are also enabled](https://wiki.archlinux.org/title/zsh#Command_completion) in that file:

```shell
autoload -Uz compinit promptinit
compinit
```

Then start a new zsh shell, and `configlet [Tab]` should work.

The underlying issue is that the default `fpath` includes just `/usr/local/share/zsh/site-functions` and directories in `/usr/share/zsh`. We can't just write, as we can for bash:

```shell
configlet completion -s bash | source
```

or add the completions to some standard user completions directory, like for fish:

```shell
configlet completion -s fish > ~/.config/fish/completions/configlet.fish
```

So I think we have to provide instructions to make the user save the output of `configlet completion --shell zsh` to either:

1. `/usr/local/share/zsh/site-functions/_configlet`
1. `/usr/share/zsh/site-functions/_configlet`
1. `~/foo/_configlet`, explaining how to add `~/foo` to their `$fpath`

where we probably should do the last, because:
- e.g. generally only packages installed with the package manager should put stuff in `/usr/share/zsh/site-functions`.
- the first two require root permissions.