### PR TITLE
completions(fish): remove invalid file completions

### DIFF
--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -1,28 +1,32 @@
+# disable file completions everywhere
+complete -c configlet -f
+
 # global options
-complete -c configlet -s h -l help -f -d "Show help"
-complete -c configlet      -l version -f -d "Show version info"
-complete -c configlet -s t -l track-dir -d "Select a track directory"
+complete -c configlet -s h -l help -d "Show help"
+complete -c configlet      -l version -d "Show version info"
+complete -c configlet -s t -l track-dir -d "Select a track directory" \
+  -x -a "(__fish_complete_directories)"
 complete -c configlet -s v -l verbosity -x -a "quiet normal detailed" -d "Verbose level"
 
 # subcommands with no options
-complete -c configlet -n "__fish_use_subcommand" -a lint -f -d "Check the track configuration for correctness"
-complete -c configlet -n "__fish_use_subcommand" -a generate -f -d "Generate concept exercise introductions"
+complete -c configlet -n "__fish_use_subcommand" -a lint -d "Check the track configuration for correctness"
+complete -c configlet -n "__fish_use_subcommand" -a generate -d "Generate concept exercise introductions"
 
 # completion subcommand
-complete -c configlet -n "__fish_use_subcommand" -a completion -f -d "Output a completion script for a given shell"
+complete -c configlet -n "__fish_use_subcommand" -a completion -d "Output a completion script for a given shell"
 complete -c configlet -n "__fish_seen_subcommand_from completion" -s s -l shell -d "Shell type" \
   -x -a "bash fish"
 
 # info subcommand
-complete -c configlet -n "__fish_use_subcommand" -a info -f -d "Track info"
-complete -c configlet -n "__fish_seen_subcommand_from info" -s o -l offline -f -d "Do not update prob-specs cache"
+complete -c configlet -n "__fish_use_subcommand" -a info -d "Track info"
+complete -c configlet -n "__fish_seen_subcommand_from info" -s o -l offline -d "Do not update prob-specs cache"
 
 # uuid subcommand
-complete -c configlet -n "__fish_use_subcommand" -a uuid -f -d "Output a UUID"
+complete -c configlet -n "__fish_use_subcommand" -a uuid -d "Output a UUID"
 complete -c configlet -n "__fish_seen_subcommand_from uuid" -s n -l num -x -d "How many UUIDs"
 
 # fmt subcommand
-complete -c configlet -n "__fish_use_subcommand" -a fmt -f -d "Format the exercise '.meta/config.json' files"
+complete -c configlet -n "__fish_use_subcommand" -a fmt -d "Format the exercise '.meta/config.json' files"
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s u -l update -d "Write changes"
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s y -l yes -d "Auto-confirm update"
 complete -c configlet -n "__fish_seen_subcommand_from fmt" -s e -l exercise -d "exercise slug" \
@@ -30,11 +34,11 @@ complete -c configlet -n "__fish_seen_subcommand_from fmt" -s e -l exercise -d "
 
 # sync subcommand
 complete -c configlet -n "__fish_use_subcommand" -a sync -d "Check or update Practice Exercise docs, metadata, and tests"
-complete -c configlet -n "__fish_seen_subcommand_from sync" -s o -l offline -f -d "Do not update prob-specs cache"
+complete -c configlet -n "__fish_seen_subcommand_from sync" -s o -l offline -d "Do not update prob-specs cache"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s u -l update -d "Write changes"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s y -l yes -d "Auto-confirm update"
 complete -c configlet -n "__fish_seen_subcommand_from sync"      -l docs -d "Sync docs only"
-complete -c configlet -n "__fish_seen_subcommand_from sync"      -l filepaths -f -d 'Populate .meta/config.json "files" entry'
+complete -c configlet -n "__fish_seen_subcommand_from sync"      -l filepaths -d 'Populate .meta/config.json "files" entry'
 complete -c configlet -n "__fish_seen_subcommand_from sync"      -l metadata -d "Sync metadata only"
 complete -c configlet -n "__fish_seen_subcommand_from sync"      -l tests -d "For auto-confirming" -x -a "choose include exclude"
 complete -c configlet -n "__fish_seen_subcommand_from sync" -s e -l exercise -d "exercise slug" \


### PR DESCRIPTION
With the fish completions, writing a command or option that does not
take an argument and then pressing tab would suggest files and
directories:

```console
$ bin/configlet sync [Tab]
bin/                config.json      docs/       LICENSE   README.md
CODE_OF_CONDUCT.md  config/          exercises/  mix.exs   reference/
concepts/           CONTRIBUTING.md  HELLO.md    mix.lock
```

even though adding such an argument would produce an error.

Remove those completions across the whole command, and then add them
only where we want them (directory completions for `-t`/`--track-dir`). This
also improves the completions for `-t`/`--track-dir`, since it would
previously suggest both files and directories.

---

Docs:
- https://fishshell.com/docs/current/cmds/complete.html
- https://fishshell.com/docs/current/completions.html