### PR TITLE
completions(bash, fish): add zsh completion for -s/--shell

### DIFF
--- a/completions/configlet.bash
+++ b/completions/configlet.bash
@@ -48,7 +48,7 @@ _configlet_complete_global_option_() {
 _configlet_complete_completion_() {
   case $prev in
     '-s' | '--shell')
-      _configlet_complete_options_ "bash fish"
+      _configlet_complete_options_ "bash fish zsh"
       ;;
     *)
       _configlet_complete_options_ "-s --shell $global_opts"

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -15,7 +15,7 @@ complete -c configlet -n "__fish_use_subcommand" -a generate -d "Generate concep
 # completion subcommand
 complete -c configlet -n "__fish_use_subcommand" -a completion -d "Output a completion script for a given shell"
 complete -c configlet -n "__fish_seen_subcommand_from completion" -s s -l shell -d "Shell type" \
-  -x -a "bash fish"
+  -x -a "bash fish zsh"
 
 # info subcommand
 complete -c configlet -n "__fish_use_subcommand" -a info -d "Track info"


### PR DESCRIPTION
Commit https://github.com/exercism/configlet/commit/e4c86435d284c4ba7da76ae00cc80387ceb865dc added a completion script for zsh, but forgot to add
zsh as a completion for the value of -s/--shell in the bash and fish
completion scripts.

---

"Some completion scripts had incomplete completions for `completion`. Complete them."