### PR TITLE
github(workflows): bump `iffy/install-nim` from 4.1.3 to 4.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./.github/bin/linux-install-build-tools
 
       - name: Install Nim
-        uses: iffy/install-nim@7dd1812db4916d00b984d1c43339346a76e05487
+        uses: iffy/install-nim@7efc1c47b112336664753ebbe81036490e52e4b7
         with:
           version: "binary:1.6.6"
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: ./.github/bin/linux-install-build-tools
 
       - name: Install Nim
-        uses: iffy/install-nim@7dd1812db4916d00b984d1c43339346a76e05487
+        uses: iffy/install-nim@7efc1c47b112336664753ebbe81036490e52e4b7
         with:
           version: "binary:1.6.6"
         env:


### PR DESCRIPTION
This will allow us to use the binary release of today's Nim 1.6.8.

Links:

- https://github.com/iffy/install-nim/releases/tag/v4.2.0
- https://github.com/iffy/install-nim/compare/7dd1812db491...7efc1c47b112