### PR TITLE
github: set draft release title and notes

### DIFF
--- a/.github/bin/publish-release
+++ b/.github/bin/publish-release
@@ -7,6 +7,8 @@ if ! gh release view "${build_tag}"; then
   # tag for the previous official configlet release:
   # - is the most recent (or second most recent) local tag.
   # - exists locally (so we support creating test releases on a forked repo).
+  # The `gh release create` command does have a `--generate-notes` option,
+  # but the below gives full control over the format, and includes commit refs.
   previous_release_sha="$(gh api graphql --jq 'recurse | strings' -f query='
     {
       repository(owner: "exercism", name: "configlet") {

--- a/.github/bin/publish-release
+++ b/.github/bin/publish-release
@@ -3,7 +3,24 @@
 build_tag="${GITHUB_REF_NAME}"
 
 if ! gh release view "${build_tag}"; then
-  gh release create --draft "${build_tag}" "${ARTIFACT_FILE}"
+  # Generate a list of commits for the release notes, without assuming that the
+  # tag for the previous official configlet release:
+  # - is the most recent (or second most recent) local tag.
+  # - exists locally (so we support creating test releases on a forked repo).
+  previous_release_sha="$(gh api graphql --jq 'recurse | strings' -f query='
+    {
+      repository(owner: "exercism", name: "configlet") {
+        latestRelease {
+          tagCommit {
+            oid
+          }
+        }
+      }
+    }')"
+  commits="$(git log --format='- %h %s' "${previous_release_sha}..${build_tag}")"
+  body="$(printf '### Changes\n\n%s' "${commits}")"
+  gh release create --draft --title "${build_tag}" --notes "${body}" \
+    "${build_tag}" "${ARTIFACT_FILE}"
 else
   gh release upload "${build_tag}" "${ARTIFACT_FILE}"
 fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0
 
       - name: On Linux, install musl
         if: matrix.target.os == 'linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # Allows using `git log` to set initial release notes.
 
       - name: On Linux, install musl
         if: matrix.target.os == 'linux'


### PR DESCRIPTION
Before this commit, the draft release was created without a title or release notes. To give a better starting point for a maintainer preparing a release, set the title to the current tag, and set the initial notes to a list of commits since the previous official release.

The checkout Action only fetches one commit by default, so also change the build workflow to fetch all git history.

The `gh release create` command does have a `--generate-notes` option, but the implementation in this commit gives full control over the format, and includes commit refs.

---

Tested here: https://github.com/ee7/exercism-configlet/releases/tag/github-set-draft-release-title-and-notes