### PR TITLE
patched_stdlib(json): bump from `c17baaefbcff` to `b6bfe38ff528`

### DIFF
--- a/src/patched_stdlib/json.nim
+++ b/src/patched_stdlib/json.nim
@@ -1,5 +1,5 @@
 # This file is minimally adapted from this version in the Nim standard library:
-# https://github.com/nim-lang/Nim/blob/c17baaefbcff/lib/pure/json.nim
+# https://github.com/nim-lang/Nim/blob/b6bfe38ff528/lib/pure/json.nim
 # The standard library version is lenient: it silently allows a trailing comma.
 # The below version is stricter: it raises a `JsonParsingError` for a trailing
 # comma.
@@ -181,6 +181,9 @@ import hashes, tables, strutils, lexbase, streams, macros, parsejson
 import options # xxx remove this dependency using same approach as https://github.com/nim-lang/Nim/pull/14563
 import std/private/since
 
+when defined(nimPreviewSlimSystem):
+  import std/[syncio, assertions, formatfloat]
+
 export
   tables.`$`
 
@@ -231,10 +234,6 @@ proc newJRawNumber(s: string): JsonNode =
   ## with the additional information that it should be converted back
   ## to the string representation without the quotes.
   result = JsonNode(kind: JString, str: s, isUnquoted: true)
-
-proc newJStringMove(s: string): JsonNode =
-  result = JsonNode(kind: JString)
-  shallowCopy(result.str, s)
 
 proc newJInt*(n: BiggestInt): JsonNode =
   ## Creates a new `JInt JsonNode`.
@@ -873,8 +872,12 @@ proc parseJson(p: var JsonParser; rawIntegers, rawFloats: bool, depth = 0): Json
   case p.tok
   of tkString:
     # we capture 'p.a' here, so we need to give it a fresh buffer afterwards:
-    result = newJStringMove(p.a)
-    p.a = ""
+    when defined(gcArc) or defined(gcOrc):
+      result = JsonNode(kind: JString, str: move p.a)
+    else:
+      result = JsonNode(kind: JString)
+      shallowCopy(result.str, p.a)
+      p.a = ""
     discard getTok(p)
   of tkInt:
     if rawIntegers:
@@ -978,12 +981,12 @@ proc parseJson*(s: Stream, filename: string = ""; rawIntegers = false, rawFloats
 
 when defined(js):
   from math import `mod`
-  from std/jsffi import JSObject, `[]`, to
+  from std/jsffi import JsObject, `[]`, to
   from std/private/jsutils import getProtoName, isInteger, isSafeInteger
 
-  proc parseNativeJson(x: cstring): JSObject {.importjs: "JSON.parse(#)".}
+  proc parseNativeJson(x: cstring): JsObject {.importjs: "JSON.parse(#)".}
 
-  proc getVarType(x: JSObject, isRawNumber: var bool): JsonNodeKind =
+  proc getVarType(x: JsObject, isRawNumber: var bool): JsonNodeKind =
     result = JNull
     case $getProtoName(x) # TODO: Implicit returns fail here.
     of "[object Array]": return JArray
@@ -1002,12 +1005,12 @@ when defined(js):
     of "[object String]": return JString
     else: assert false
 
-  proc len(x: JSObject): int =
+  proc len(x: JsObject): int =
     asm """
       `result` = `x`.length;
     """
 
-  proc convertObject(x: JSObject): JsonNode =
+  proc convertObject(x: JsObject): JsonNode =
     var isRawNumber = false
     case getVarType(x, isRawNumber)
     of JArray:
@@ -1020,7 +1023,7 @@ when defined(js):
         if (`x`.hasOwnProperty(property)) {
       """
       var nimProperty: cstring
-      var nimValue: JSObject
+      var nimValue: JsObject
       asm "`nimProperty` = property; `nimValue` = `x`[property];"
       result[$nimProperty] = nimValue.convertObject()
       asm "}}"


### PR DESCRIPTION
The development version of Nim was no longer able to build configlet, producing this error:

```console
$ nimble build
/foo/configlet/src/patched_stdlib/json.nim(237, 3) Error: undeclared identifier: 'shallowCopy'
```

To resolve the problem, this commit pulls the latest changes to `json.nim`.

This commit corresponds to the following diff in the Nim compiler repo:

```shell
git diff c17baaefbcff..b6bfe38ff528 -U0 -- lib/pure/json.nim
```

```diff
diff --git a/lib/pure/json.nim b/lib/pure/json.nim
index 922cd4e2f..d0b1a4051 100644
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -166,0 +167,3 @@ import std/private/since
+when defined(nimPreviewSlimSystem):
+  import std/[syncio, assertions, formatfloat]
+
@@ -218,4 +220,0 @@ proc newJRawNumber(s: string): JsonNode =
-proc newJStringMove(s: string): JsonNode =
-  result = JsonNode(kind: JString)
-  shallowCopy(result.str, s)
-
@@ -859,2 +858,6 @@ proc parseJson(p: var JsonParser; rawIntegers, rawFloats: bool, depth = 0): Json
-    result = newJStringMove(p.a)
-    p.a = ""
+    when defined(gcArc) or defined(gcOrc):
+      result = JsonNode(kind: JString, str: move p.a)
+    else:
+      result = JsonNode(kind: JString)
+      shallowCopy(result.str, p.a)
+      p.a = ""
@@ -958 +961 @@ when defined(js):
-  from std/jsffi import JSObject, `[]`, to
+  from std/jsffi import JsObject, `[]`, to
@@ -961 +964 @@ when defined(js):
-  proc parseNativeJson(x: cstring): JSObject {.importjs: "JSON.parse(#)".}
+  proc parseNativeJson(x: cstring): JsObject {.importjs: "JSON.parse(#)".}
@@ -963 +966 @@ when defined(js):
-  proc getVarType(x: JSObject, isRawNumber: var bool): JsonNodeKind =
+  proc getVarType(x: JsObject, isRawNumber: var bool): JsonNodeKind =
@@ -982 +985 @@ when defined(js):
-  proc len(x: JSObject): int =
+  proc len(x: JsObject): int =
@@ -987 +990 @@ when defined(js):
-  proc convertObject(x: JSObject): JsonNode =
+  proc convertObject(x: JsObject): JsonNode =
@@ -1000 +1003 @@ when defined(js):
-      var nimValue: JSObject
+      var nimValue: JsObject
```

The upstream diff [can also be viewed on GitHub](https://github.com/nim-lang/Nim/compare/c17baaefbcff..b6bfe38ff528#diff-14742d433bdc451cdda2c61e7775619bc569fbe6ab1f148ddd821cc771ed8b62) (though you may have to wait a long time for the page to load).

Note that `parsejson.nim` was already up to date.