### PR TITLE
sync(exercises): explicitly initialize `reimplements`

### DIFF
--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -51,6 +51,7 @@ proc new(T: typedesc[ExerciseTestCase], testCase: ProbSpecsTestCase): T =
     uuid: uuid(testCase),
     description: description(testCase),
     json: testCase,
+    reimplements: none(ExerciseTestCase),
   )
 
 proc getReimplementations(testCases: ProbSpecsTestCases): Table[string, string] =


### PR DESCRIPTION
Fix an error when building configlet with the development version of Nim:

> /foo/configlet/src/sync/exercises.nim(50, 4) Error: The ExerciseTestCase:ObjectType type requires the following fields to be initialized: reimplements.

---

Unfortunately, this change currently produces a `ProveInit` warning. We could avoid it with

```nim
reimplements: Option[ExerciseTestCase](),
```

but I'll try to fix the warning upstream in Nim, because `none` is the better thing to write here.