### PR TITLE
config: enable `strictDefs`

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -3,6 +3,8 @@ hint("Name", on)
 # switch("experimental", "strictEffects") # TODO: re-enable when possible with `parsetoml`
 switch("experimental", "strictFuncs")
 switch("define", "nimStrictDelete")
+when defined(nimHasOutParams):
+  switch("experimental", "strictDefs")
 
 # Replace the stdlib JSON modules with our own stricter versions.
 patchFile("stdlib", "json", "src/patched_stdlib/json")


### PR DESCRIPTION
With this commit, the development version of Nim produces a warning for each local variable that is used without being initialized.

For example, the [Nim experimental manual](https://github.com/nim-lang/Nim/blob/0d23419e681c/doc/manual_experimental.md#strict-definitions-and-out-parameters) explains that this will be considered invalid:

```nim
proc foo =
  var s: seq[string]
  s.add "abc"
```

and therefore the devel Nim compiler currently warns:

```text
/tmp/foo.nim(3, 3) Warning: use explicit initialization of 's' for clarity [Uninit]
```

But this is valid:

```Nim
proc foo =
  var s: seq[string] = @[]
  s.add "abc"
```

and this is also valid (the compiler proves it via control-flow analysis):

```Nim
proc foo(cond: bool) =
  var s: seq[string]
  if cond:
    s = @["y"]
  else:
    s = @[]
  s.add "abc"
```

The experimental manual also says:

> Note: The implementation of "strict definitions" and "out parameters" is experimental but the concept is solid and it is expected that eventually this mode becomes the default in later versions.

---

Further reading:

- The [upstream commit that implements this feature](https://github.com/nim-lang/Nim/commit/0d23419e681c).
- https://en.wikipedia.org/wiki/Definite_assignment_analysis
- [nim-lang/RFCs#378 **Definite assignment analysis and out parameters**](https://github-redirect.dependabot.com/nim-lang/RFCs/issues/378) 
- [nim-lang/RFCs#252 **User-defined implicit initialization hooks**](https://github-redirect.dependabot.com/nim-lang/RFCs/issues/252) 
- [nim-lang/RFCs#437 **Roadmap for Nim**](https://github-redirect.dependabot.com/nim-lang/RFCs/issues/437)