### PR TITLE
tests(all_tests), helpers: find test files at compile time

### DIFF
--- a/patches/patch.nim
+++ b/patches/patch.nim
@@ -1,6 +1,6 @@
 import std/[hashes, os, parseutils, strutils]
 
-proc gorgeCheck(cmd, errorMsg: string): string =
+proc gorgeCheck*(cmd, errorMsg: string): string =
   ## Executes `cmd` at compile time and returns its text output (stdout + stderr).
   ##
   ## Raises an exception if the exit code is non-zero, using the given `errorMsg`.

--- a/patches/patch.nim
+++ b/patches/patch.nim
@@ -1,6 +1,6 @@
 import std/[hashes, os, parseutils, strutils]
 
-proc gorgeCheck*(cmd, errorMsg: string): string =
+proc gorgeCheck(cmd, errorMsg: string): string =
   ## Executes `cmd` at compile time and returns its text output (stdout + stderr).
   ##
   ## Raises an exception if the exit code is non-zero, using the given `errorMsg`.

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -17,7 +17,7 @@ type
 proc `==`(x, y: Path): bool {.borrow.}
 proc `<`(x, y: Path): bool {.borrow.}
 
-proc getSortedFiles*(dir: Path, relative = false,
+proc getSortedFiles*(dir: Path; relative = false;
                      pattern: static string = ""): seq[Path] =
   ## Returns the names of files in `dir`, in alphabetical order, limited to
   ## those that match the scanf `pattern` if it has non-zero length. The
@@ -38,7 +38,7 @@ proc getSortedSubdirs*(dir: Path): seq[Path] =
       result.add Path(path)
   sort result
 
-func w*(s: string, start: int): int =
+func w*(s: string; start: int): int =
   ## A matcher for `scanf`. Similar to `$w`, but only skips (does not bind).
   s.skipWhile(IdentChars, start)
 

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -26,7 +26,7 @@ proc getSortedFiles*(dir: Path; relative = false;
   ## Can be used at compile time, unlike `walkFiles` and `walkPattern`.
   result = @[]
   for kind, path in walkDir(dir.string, relative = relative):
-    if kind == pcFile and (when pattern.len > 0: path.scanf(pattern) else: true):
+    if kind == pcFile and (pattern.len == 0 or path.scanf(pattern)):
       result.add Path(path)
   sort result
 

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -4,12 +4,12 @@ from ../patches/patch import gorgeCheck
 proc getImports: NimNode =
   const files = block:
     const thisDir = currentSourcePath().parentDir()
-    const cmd = "git -C " & thisDir & " ls-files -- '*test_*.nim'"
+    const cmd = "git -C \"" & thisDir & "\" ls-files" # Don't match pattern here.
     gorgeCheck(cmd, "command failed:\n" & cmd)
   result = nnkBracket.newTree()
   for f in files.splitLines():
-    let f = f[0..^5] # Remove .nim file extension
-    result.add ident(f)
+    if f.startsWith("test_") and f.endsWith(".nim"):
+      result.add ident(f[0..^5]) # Remove .nim file extension
   expectMinLen(result, 9)
 
 macro importGitTrackedTestFiles =

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -1,24 +1,23 @@
-import std/[macros, os, sequtils, strutils]
-from ../patches/patch import gorgeCheck
+import std/[algorithm, macros, os, strutils]
 
-proc getImports: NimNode =
-  const files = block:
-    const thisDir = currentSourcePath().parentDir()
-    const cmd = "git -C \"" & thisDir & "\" ls-files" # Don't match pattern here.
-    gorgeCheck(cmd, "command failed:\n" & cmd)
-  result = nnkBracket.newTree()
-  for f in files.splitLines():
-    if f.startsWith("test_") and f.endsWith(".nim"):
-      result.add ident(f[0..^5]) # Remove .nim file extension
-  expectMinLen(result, 9)
+proc getSortedTestFiles(dir: string): seq[string] =
+  result = @[]
+  # Note that we cannot use `walkFiles` or `walkPattern` at compile time.
+  for kind, path in walkDir(dir, relative = true):
+    if kind == pcFile:
+      if path.startsWith("test_") and path.endsWith(".nim"):
+        result.add path[0..^5] # Remove .nim file extension.
+  sort result
 
-macro importGitTrackedTestFiles =
-  ## Imports every module in the current directory that is both:
-  ## - tracked by `git`
-  ## - and has a filename that matches `test_*.nim`
-  let imports = getImports()
-  result = quote do:
-    import "."/`imports`
-  echo "Combining these git-tracked test files:\n" & imports.toSeq().join("\n")
+macro importTestFiles =
+  ## Imports every Nim module that begins with `test_` in the parent directory.
+  const files = currentSourcePath().parentDir().getSortedTestFiles()
+  var bracket = nnkBracket.newTree()
+  for f in files:
+    bracket.add ident(f)
+  expectMinLen(bracket, 9)
+  result = newStmtList(quote do:
+    import "."/`bracket`)
+  echo "all_tests: 'importTestFiles' produced:\n" & result.repr
 
-importGitTrackedTestFiles()
+importTestFiles()


### PR DESCRIPTION
Remove the need to maintain a list of test files in `all_tests.nim`.

Recall that:

- We have `all_tests.nim` because compiling that one file is currently
  much faster than compiling each test file separately.
- We define `nimble test` to run `all_tests.nim`:

https://github.com/exercism/configlet/blob/1ab75f2ba85a84a4c8fdda913186ee93f2cc065e/configlet.nimble#L36-L37

Compiling `all_tests.nim` shows the output of the macro, which is currently:

```console
$ nim c tests/all_tests.nim
[...]

all_tests: 'importTestFiles' produced:

import
  "." /
      [test_binary, test_fmt, test_generate, test_json, test_lint,
       test_probspecs, test_sync, test_tracks, test_uuid]

[...]
```