### PR TITLE
sync: allow passing both `-uy` and `--tests include|exclude`

### DIFF
--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -7,7 +7,7 @@ proc validate(conf: Conf) =
   ## Exits with an error message if the given `conf` contains an invalid
   ## combination of options.
   if conf.action.update:
-    if conf.action.yes and skTests in conf.action.scope:
+    if conf.action.yes and skTests in conf.action.scope and conf.action.tests == tmChoose:
       let msg = fmt"""
         '{list(optFmtSyncYes)}' was provided to non-interactively update, but the tests updating mode is still 'choose'.
         You can either:


### PR DESCRIPTION
Before this commit:

```console
$ configlet sync -uy --docs --tests include
Error: '-y, --yes' was provided to non-interactively update, but the tests updating mode is still 'choose'.
```

With this commit:

```console
$ configlet sync -uy --docs --tests include
Updating cached 'problem-specifications' data...
Checking exercises...
Every exercise has up-to-date docs!
Every exercise has up-to-date tests!
```

Fixes: #673