### PR TITLE
sync: improve error messages for invalid update options

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -295,10 +295,17 @@ func genHelpText: string =
       result.add alignLeft(syntax[opt], maxLen) & optionDescriptions[opt] & "\n"
   setLen(result, result.len - 1)
 
-proc showHelp(exitCode: range[0..255] = 0) =
-  const helpText = genHelpText().compress()
+func firstLine(s: string): string =
+  s[0 ..< s.find('\n')]
+
+proc showHelp(exitCode: range[0..255] = 0, prependDashedLine = false) =
+  const helpCompressed = genHelpText().compress()
+  let helpUncompressed = helpCompressed.uncompress()
   let f = if exitCode == 0: stdout else: stderr
-  f.writeLine helpText.uncompress()
+  if prependDashedLine:
+    let dashLen = helpUncompressed.firstLine().len
+    f.write(&"\n\n{'-'.repeat(dashLen)}\n\n")
+  f.writeLine helpUncompressed
   if f == stdout:
     f.flushFile()
   quit(exitCode)
@@ -323,8 +330,7 @@ proc showError*(s: string) =
   else:
     stderr.write(errorPrefix)
   stderr.write(s)
-  stderr.write("\n\n")
-  showHelp(exitCode = 1)
+  showHelp(exitCode = 1, prependDashedLine = true)
 
 func formatOpt(kind: CmdLineKind, key: string, val = ""): string =
   ## Returns a string that describes an option, given its `kind`, `key` and


### PR DESCRIPTION
Changes:

- Add tests for the fix in d5f5485f8ced.

- Try to improve error wordings, and try to reorder list items by likelihood of what the user wanted.

Follow-up from https://github.com/exercism/configlet/pull/674#issuecomment-1274713672

---

### Before this commit

```console
$ configlet sync -o -uy --tests
Error: '-y, --yes' was provided to non-interactively update, but the tests updating mode is still 'choose'.
You can either:
- remove '-y, --yes', and update by confirming prompts
- or narrow the syncing scope via some combination of --docs, --filepaths, and --metadata
- or add '--tests include' or '--tests exclude' to non-interactively include/exclude missing tests
If no syncing scope option is provided, configlet uses the full syncing scope.
If no --tests value is provided, configlet uses the 'choose' mode.

configlet 4.0.0-beta.6
The official tool for managing Exercism language track repositories.

Usage:
  configlet [global-options] <command> [command-options]
[...]
```

```console
$ configlet sync -o -u --docs < /dev/null
Error: Configlet was used in a non-interactive context, and the --update option was passed without the --yes option
You can either:
- keep using configlet non-interactively, and remove the --update option so that no destructive changes are performed
- keep using configlet non-interactively, and add the --yes option to perform destructive changes
- use configlet in an interactive terminal

configlet 4.0.0-beta.6
The official tool for managing Exercism language track repositories.

Usage:
  configlet [global-options] <command> [command-options]
[...]
```

### With this commit

```console
$ configlet sync -o -uy --tests
Error: '-y, --yes' was provided to non-interactively update, but tests are in
the syncing scope and the tests updating mode is 'choose'.

You can either:
- use '--tests include' or '--tests exclude' to non-interactively include/exclude
  missing tests
- or narrow the syncing scope via some combination of '--docs', '--filepaths', and
  '--metadata' (removing '--tests' if it was passed)
- or remove '-y, --yes', and update by answering prompts

If no syncing scope option is provided, configlet uses the full syncing scope.
If '--tests' is provided without an argument, configlet uses the 'choose' mode.

----------------------

configlet 4.0.0-beta.6
The official tool for managing Exercism language track repositories.

Usage:
  configlet [global-options] <command> [command-options]
[...]
```

```console
$ configlet sync -o -u --docs < /dev/null
Error: configlet ran in a non-interactive context, but interaction was required because
'--update' was passed without '--yes', and at least one of docs, filepaths, and
metadata were in the syncing scope.

You can either:
- keep using configlet non-interactively, and add the '--yes' option to perform
  changes without confirmation
- or keep using configlet non-interactively, and remove the '--update' option so
  that configlet performs no changes
- or run the same command in an interactive terminal, to update by answering
  prompts

----------------------

configlet 4.0.0-beta.6
The official tool for managing Exercism language track repositories.

Usage:
  configlet [global-options] <command> [command-options]
[...]
```