### PR TITLE
sync(tests): make `--tests include` exclude reimplemented test

### DIFF
--- a/src/sync/sync_tests.nim
+++ b/src/sync/sync_tests.nim
@@ -76,7 +76,10 @@ Do you want to replace the existing test case ([y]es/[n]o/[s]kip)? """
 proc syncDecision(testCase: ExerciseTestCase, testsMode: TestsMode): SyncDecision =
   case testsMode
   of tmInclude:
-    sdIncludeTest
+    if testCase.reimplements.isNone():
+      sdIncludeTest
+    else:
+      sdReplaceTest
   of tmExclude:
     sdExcludeTest
   of tmChoose:

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -606,14 +606,6 @@ proc testsForSync(binaryPath: static string) =
 
       expectedAnagramDiffInclude = fmt"""
         {expectedAnagramDiffStart}
-        +[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
-        +description = "detects two anagrams"
-        +reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
-        +
-      """.unindent()
-
-      expectedAnagramDiffChooseInclude = fmt"""
-        {expectedAnagramDiffStart}
         +include = false
         +
         +[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
@@ -652,7 +644,7 @@ proc testsForSync(binaryPath: static string) =
     test "--tests choose: includes a missing test case for a given exercise when the input is 'y', and exits with 0":
       execAndCheckExitCode(0, &"{syncOfflineUpdateTests} choose -e anagram",
                            inputStr = "y")
-    testDiffThenRestore(trackDir, expectedAnagramDiffChooseInclude, anagramTestsTomlPath)
+    testDiffThenRestore(trackDir, expectedAnagramDiffInclude, anagramTestsTomlPath)
 
     test "--tests choose: excludes a missing test case for a given exercise when the input is 'n', and exits with 0":
       execAndCheckExitCode(0, &"{syncOfflineUpdateTests} choose -e anagram",
@@ -685,10 +677,11 @@ proc testsForSync(binaryPath: static string) =
       --- exercises/practice/anagram/.meta/tests.toml
       +++ exercises/practice/anagram/.meta/tests.toml
       {testsTomlHeaderDiff}
+      +include = false
+      +
       +[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
       +description = "detects two anagrams"
       +reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
-      +
       --- exercises/practice/diffie-hellman/.meta/tests.toml
       +++ exercises/practice/diffie-hellman/.meta/tests.toml
       {testsTomlHeaderDiff}
@@ -704,25 +697,31 @@ proc testsForSync(binaryPath: static string) =
       --- exercises/practice/hamming/.meta/tests.toml
       +++ exercises/practice/hamming/.meta/tests.toml
       {testsTomlHeaderDiff}
+      +include = false
+      +
       +[b9228bb1-465f-4141-b40f-1f99812de5a8]
       +description = "disallow first strand longer"
       +reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
+      +include = false
       +
       +[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
       +description = "disallow second strand longer"
       +reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
+      +include = false
       +
       +[db92e77e-7c72-499d-8fe6-9354d2bfd504]
       +description = "disallow left empty strand"
+      +include = false
       +reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
       +
       +[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
       +description = "disallow empty first strand"
       +reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
-      +
+      +include = false
       +
       +[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
       +description = "disallow right empty strand"
+      +include = false
       +reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
       +
       +[9ab9262f-3521-4191-81f5-0ed184a5aa89]


### PR DESCRIPTION
When updating tests interactively, and answering yes:

```shell
yes | configlet sync -u --tests
```

configlet would add `include = false` to any test that was reimplemented by a just-added test.

However, when running

```shell
configlet sync -u --tests include
```

configlet would not add `include = false` anywhere.

Change the behavior of the second command above to that of the first.

Fixes: #297

---

The diff to the tests is due to the below diff from `configlet sync -u --tests include`.

I plan to make the diffs that we check in `test_binary.nim` include some context lines again, so that it's more readable and strict. 

```diff
--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,12 +1,24 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.

 [dd40c4d2-3c8b-44e5-992a-f42b393ec373]
 description = "no matches"

 [b3cca662-f50a-489e-ae10-ab8290a09bdc]
 description = "detects two anagrams"
+include = false
+
+[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+description = "detects two anagrams"
+reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"

 [a27558ee-9ba0-4552-96b1-ecf665b06556]
 description = "does not detect anagram subsets"
--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.

 [f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
 description = "empty strands"
@@ -19,12 +26,42 @@ description = "long different strands"

 [919f8ef0-b767-4d1b-8516-6379d07fcb28]
 description = "disallow first strand longer"
+include = false
+
+[b9228bb1-465f-4141-b40f-1f99812de5a8]
+description = "disallow first strand longer"
+reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"

 [8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
 description = "disallow second strand longer"
+include = false
+
+[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
+description = "disallow second strand longer"
+reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"

 [5dce058b-28d4-4ca7-aa64-adfe4e17784c]
 description = "disallow left empty strand"
+include = false
+
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+include = false
+reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+
+[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
+description = "disallow empty first strand"
+reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"

 [38826d4b-16fb-4639-ac3e-ba027dec8b5f]
 description = "disallow right empty strand"
+include = false
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow right empty strand"
+include = false
+reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+
+[9ab9262f-3521-4191-81f5-0ed184a5aa89]
+description = "disallow empty second strand"
+reimplements = "920cd6e3-18f4-4143-b6b8-74270bb8f8a3"
```