### PR TITLE
sync: ignore track-deprecated practice exercises

### DIFF
--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -47,7 +47,7 @@ type
 func init*(T: typedesc[TrackExerciseSlugs], exercises: Exercises): T =
   T(
     `concept`: getSlugs(exercises.`concept`),
-    practice: getSlugs(exercises.practice)
+    practice: getSlugs(exercises.practice, withDeprecated = false)
   )
 
 proc getSlugs*(exercises: Exercises, conf: Conf,

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -25,11 +25,13 @@ proc postHook*(e: ConceptExercise | PracticeExercise) =
     stderr.writeLine msg
     quit 1
 
-func getSlugs*(e: seq[ConceptExercise] | seq[PracticeExercise]): seq[Slug] =
+func getSlugs*(e: seq[ConceptExercise] | seq[PracticeExercise],
+               withDeprecated = true): seq[Slug] =
   ## Returns a seq of the slugs in `e`, in alphabetical order.
-  result = newSeq[Slug](e.len)
-  for i, item in e:
-    result[i] = item.slug
+  result = newSeqOfCap[Slug](e.len)
+  for item in e:
+    if withDeprecated or item.status != sDeprecated:
+      result.add item.slug
   sort result
 
 func truncateAndAdd*(s: var string, truncateLen: int, slug: Slug) =

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -73,7 +73,6 @@ proc testsForSync(binaryPath: static string) =
     bodyUnsyncedMetadata = """
       [warn] metadata: unsynced: acronym
       [warn] metadata: unsynced: armstrong-numbers
-      [warn] metadata: unsynced: binary
       [warn] metadata: unsynced: collatz-conjecture
       [warn] metadata: unsynced: darts
       [warn] metadata: unsynced: grade-school
@@ -452,7 +451,7 @@ proc testsForSync(binaryPath: static string) =
     const expectedOutput = fmt"""
       {header}
       {bodyUnsyncedMetadata}
-      Updated the metadata for 14 Practice Exercises
+      Updated the metadata for 13 Practice Exercises
       {footerSyncedMetadata}
     """.unindent()
     const expectedDiff = """
@@ -464,10 +463,6 @@ proc testsForSync(binaryPath: static string) =
       +++ exercises/practice/armstrong-numbers/.meta/config.json
       -  "blurb": "Determine if a number is an Armstrong number",
       +  "blurb": "Determine if a number is an Armstrong number.",
-      --- exercises/practice/binary/.meta/config.json
-      +++ exercises/practice/binary/.meta/config.json
-      -  "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
-      +  "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles.",
       --- exercises/practice/collatz-conjecture/.meta/config.json
       +++ exercises/practice/collatz-conjecture/.meta/config.json
       -  "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",

--- a/tests/test_tracks.nim
+++ b/tests/test_tracks.nim
@@ -19,7 +19,7 @@ proc main =
 
     test "returns the expected number of exercises":
       check:
-        practiceExercises.len == 68
+        practiceExercises.len == 67
 
     test "returns the expected object for `hello-world`":
       const expectedHelloWorld =
@@ -32,7 +32,7 @@ proc main =
         )
 
       check:
-        practiceExercises[20] == expectedHelloWorld
+        practiceExercises[19] == expectedHelloWorld
 
     test "returns the expected object for `two-fer`":
       const expectedTwoFer =
@@ -47,7 +47,7 @@ proc main =
         )
 
       check:
-        practiceExercises[65] == expectedTwoFer
+        practiceExercises[64] == expectedTwoFer
 
 main()
 {.used.}


### PR DESCRIPTION
Make `configlet sync` ignore an exercise that is both out of sync, and deprecated on the track. However, do not ignore an exercise that is only deprecated in problem-specifications.

Closes: #518

---

With this PR, `configlet sync` no longer reports an unsynced track-deprecated practice exercise, even with `--verbosity detailed` or `--exercise some-deprecated-exercise`, and does not support updating such an exercise. We could consider allowing that, but the best way probably involves an extra option, e.g. `configlet sync --deprecated`, so I think we should leave that till later. This PR does the main thing.

At the time of opening, this PR produces the below diff to the output of `configlet sync`

#### common-lisp

```diff
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: gigasecond
-[warn] docs: instructions unsynced: trinary
-[warn] gigasecond: missing 1 test case
-       - does not mutate the input (fcec307c-7529-49ab-b0fe-20309197618a)
-[warn] some exercises have unsynced docs
-[warn] some exercises are missing test cases
+[warn] some exercises have unsynced docs
```

#### csharp

```diff
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: octal
-[warn] docs: instructions unsynced: trinary
```

#### elixir

```diff
-[warn] docs: instructions unsynced: accumulate
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: hexadecimal
```

#### fsharp

```diff
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: octal
-[warn] docs: instructions unsynced: trinary
```

#### go

```diff
-[warn] docs: instructions unsynced: accumulate
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: octal
-[warn] docs: instructions unsynced: trinary
-[warn] metadata: unsynced: binary
-[warn] accumulate: missing 6 test cases
-       - accumulate empty (64d97c14-36dd-44a8-9621-2cecebd6ed23)
-       - accumulate squares (00008ed2-4651-4929-8c08-8b4dbd70872e)
-       - accumulate upcases (551016da-4396-4cae-b0ec-4c3a1a264125)
-       - accumulate reversed strings (cdf95597-b6ec-4eac-a838-3480d13d0d05)
-       - accumulate recursively (bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb)
-       - accumulate recursively (0b357334-4cad-49e1-a741-425202edfc7c)
```

#### haskell

```diff
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: gigasecond
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: octal
-[warn] docs: instructions unsynced: trinary
-[warn] metadata: unsynced: binary
-[warn] metadata: unsynced: gigasecond
-[warn] metadata: unsynced: hexadecimal
-[warn] metadata: unsynced: octal
-[warn] metadata: unsynced: trinary
-[warn] gigasecond: missing 1 test case
-       - does not mutate the input (fcec307c-7529-49ab-b0fe-20309197618a)
```

#### j

```diff
-[warn] docs: instructions unsynced: difference-of-squares
-[warn] docs: instructions unsynced: hamming
-[warn] difference-of-squares: missing 9 test cases
-       - Square the sum of the numbers up to the given number -> square of sum 1 (e46c542b-31fc-4506-bcae-6b62b3268537)
-       - Square the sum of the numbers up to the given number -> square of sum 5 (9b3f96cb-638d-41ee-99b7-b4f9c0622948)
-       - Square the sum of the numbers up to the given number -> square of sum 100 (54ba043f-3c35-4d43-86ff-3a41625d5e86)
-       - Sum the squares of the numbers up to the given number -> sum of squares 1 (01d84507-b03e-4238-9395-dd61d03074b5)
-       - Sum the squares of the numbers up to the given number -> sum of squares 5 (c93900cd-8cc2-4ca4-917b-dd3027023499)
-       - Sum the squares of the numbers up to the given number -> sum of squares 100 (94807386-73e4-4d9e-8dec-69eb135b19e4)
-       - Subtract sum of squares from square of sums -> difference of squares 1 (44f72ae6-31a7-437f-858d-2c0837adabb6)
-       - Subtract sum of squares from square of sums -> difference of squares 5 (005cb2bf-a0c8-46f3-ae25-924029f8b00b)
-       - Subtract sum of squares from square of sums -> difference of squares 100 (b1bf19de-9a16-41c0-a62b-1f02ecc0b036)
-[warn] hamming: missing 15 test cases
-       - empty strands (f6dcb64f-03b0-4b60-81b1-3c9dbf47e887)
-       - single letter identical strands (54681314-eee2-439a-9db0-b0636c656156)
-       - single letter different strands (294479a3-a4c8-478f-8d63-6209815a827b)
-       - long identical strands (9aed5f34-5693-4344-9b31-40c692fb5592)
-       - long different strands (cd2273a5-c576-46c8-a52b-dee251c3e6e5)
-       - disallow first strand longer (919f8ef0-b767-4d1b-8516-6379d07fcb28)
-       - disallow first strand longer (b9228bb1-465f-4141-b40f-1f99812de5a8)
-       - disallow second strand longer (8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e)
-       - disallow second strand longer (dab38838-26bb-4fff-acbe-3b0a9bfeba2d)
-       - disallow left empty strand (5dce058b-28d4-4ca7-aa64-adfe4e17784c)
-       - disallow left empty strand (db92e77e-7c72-499d-8fe6-9354d2bfd504)
-       - disallow empty first strand (b764d47c-83ff-4de2-ab10-6cfe4b15c0f3)
-       - disallow right empty strand (38826d4b-16fb-4639-ac3e-ba027dec8b5f)
-       - disallow right empty strand (920cd6e3-18f4-4143-b6b8-74270bb8f8a3)
-       - disallow empty second strand (9ab9262f-3521-4191-81f5-0ed184a5aa89)
```

#### java

```diff
-[warn] docs: instructions unsynced: accumulate
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: octal
-[warn] docs: instructions unsynced: strain
-[warn] docs: instructions unsynced: trinary
-[warn] metadata: unsynced: binary
-[warn] accumulate: missing 6 test cases
-       - accumulate empty (64d97c14-36dd-44a8-9621-2cecebd6ed23)
-       - accumulate squares (00008ed2-4651-4929-8c08-8b4dbd70872e)
-       - accumulate upcases (551016da-4396-4cae-b0ec-4c3a1a264125)
-       - accumulate reversed strings (cdf95597-b6ec-4eac-a838-3480d13d0d05)
-       - accumulate recursively (bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb)
-       - accumulate recursively (0b357334-4cad-49e1-a741-425202edfc7c)
```

#### javascript

```diff
-[warn] docs: instructions unsynced: accumulate
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: octal
-[warn] docs: instructions unsynced: point-mutations
-[warn] docs: instructions unsynced: trinary
-[warn] metadata: unsynced: binary
-[warn] accumulate: missing 6 test cases
-       - accumulate empty (64d97c14-36dd-44a8-9621-2cecebd6ed23)
-       - accumulate squares (00008ed2-4651-4929-8c08-8b4dbd70872e)
-       - accumulate upcases (551016da-4396-4cae-b0ec-4c3a1a264125)
-       - accumulate reversed strings (cdf95597-b6ec-4eac-a838-3480d13d0d05)
-       - accumulate recursively (bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb)
-       - accumulate recursively (0b357334-4cad-49e1-a741-425202edfc7c)
```

#### julia

```diff
-[warn] docs: instructions unsynced: accumulate
-[warn] docs: instructions unsynced: dnd-character
-[warn] docs: instructions unsynced: transpose
-[warn] metadata: unsynced: dnd-character
-[warn] accumulate: missing 6 test cases
-       - accumulate empty (64d97c14-36dd-44a8-9621-2cecebd6ed23)
-       - accumulate squares (00008ed2-4651-4929-8c08-8b4dbd70872e)
-       - accumulate upcases (551016da-4396-4cae-b0ec-4c3a1a264125)
-       - accumulate reversed strings (cdf95597-b6ec-4eac-a838-3480d13d0d05)
-       - accumulate recursively (bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb)
-       - accumulate recursively (0b357334-4cad-49e1-a741-425202edfc7c)
-[warn] transpose: missing 1 test case
-       - jagged triangle (76acfd50-5596-4d05-89f1-5116328a7dd9)
```

#### kotlin

```diff
-[warn] docs: instructions unsynced: accumulate
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: strain
-[warn] metadata: unsynced: binary
-[warn] accumulate: missing 6 test cases
-       - accumulate empty (64d97c14-36dd-44a8-9621-2cecebd6ed23)
-       - accumulate squares (00008ed2-4651-4929-8c08-8b4dbd70872e)
-       - accumulate upcases (551016da-4396-4cae-b0ec-4c3a1a264125)
-       - accumulate reversed strings (cdf95597-b6ec-4eac-a838-3480d13d0d05)
-       - accumulate recursively (bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb)
-       - accumulate recursively (0b357334-4cad-49e1-a741-425202edfc7c)
-[warn] binary: missing 15 test cases
-       - binary 0 is decimal 0 (567fc71e-1013-4915-9285-bca0648c0844)
-       - binary 1 is decimal 1 (c0824fb1-6a0a-4e9a-a262-c6c00af99fa8)
-       - binary 10 is decimal 2 (4d2834fb-3cc3-4159-a8fd-da1098def8ed)
-       - binary 11 is decimal 3 (b7b2b649-4a7c-4808-9eb9-caf00529bac6)
-       - binary 100 is decimal 4 (de761aff-73cd-43c1-9e1f-0417f07b1e4a)
-       - binary 1001 is decimal 9 (7849a8f7-f4a1-4966-963e-503282d6814c)
-       - binary 11010 is decimal 26 (836a101c-aecb-473b-ba78-962408dcda98)
-       - binary 10001101000 is decimal 1128 (1c6822a4-8584-438b-8dd4-40f0f0b66371)
-       - binary ignores leading zeros (91ffe632-8374-4016-b1d1-d8400d9f940d)
-       - 2 is not a valid binary digit (44f7d8b1-ddc3-4751-8be3-700a538b421c)
-       - a number containing a non-binary digit is invalid (c263a24d-6870-420f-b783-628feefd7b6e)
-       - a number with trailing non-binary characters is invalid (8d81305b-0502-4a07-bfba-051c5526d7f2)
-       - a number with leading non-binary characters is invalid (a7f79b6b-039a-4d42-99b4-fcee56679f03)
-       - a number with internal non-binary characters is invalid (9e0ece9d-b8aa-46a0-a22b-3bed2e3f741e)
-       - a number and a word whitespace separated is invalid (46c8dd65-0c32-4273-bb0d-f2b111bccfbd)
```

#### lfe

```diff
-[warn] docs: instructions unsynced: accumulate
-[warn] accumulate: missing 1 test case
-       - accumulate recursively (0b357334-4cad-49e1-a741-425202edfc7c)
```

#### lua

```diff
-[warn] docs: instructions unsynced: accumulate
-[warn] accumulate: missing 6 test cases
-       - accumulate empty (64d97c14-36dd-44a8-9621-2cecebd6ed23)
-       - accumulate squares (00008ed2-4651-4929-8c08-8b4dbd70872e)
-       - accumulate upcases (551016da-4396-4cae-b0ec-4c3a1a264125)
-       - accumulate reversed strings (cdf95597-b6ec-4eac-a838-3480d13d0d05)
-       - accumulate recursively (bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb)
-       - accumulate recursively (0b357334-4cad-49e1-a741-425202edfc7c)
```

#### nim

```diff
-[warn] docs: instructions unsynced: binary
```

#### ocaml

```diff
-[warn] docs: instructions unsynced: hexadecimal
```

#### perl5

```diff
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: trinary
-[warn] metadata: unsynced: binary
```

#### python

```diff
-[warn] docs: instructions unsynced: accumulate
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: error-handling
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: nucleotide-count
-[warn] docs: instructions unsynced: octal
-[warn] docs: instructions unsynced: parallel-letter-frequency
-[warn] docs: instructions unsynced: pascals-triangle
-[warn] docs: instructions unsynced: proverb
-[warn] docs: instructions unsynced: strain
-[warn] docs: instructions unsynced: trinary
-[warn] accumulate: missing 6 test cases
-       - accumulate empty (64d97c14-36dd-44a8-9621-2cecebd6ed23)
-       - accumulate squares (00008ed2-4651-4929-8c08-8b4dbd70872e)
-       - accumulate upcases (551016da-4396-4cae-b0ec-4c3a1a264125)
-       - accumulate reversed strings (cdf95597-b6ec-4eac-a838-3480d13d0d05)
-       - accumulate recursively (bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb)
-       - accumulate recursively (0b357334-4cad-49e1-a741-425202edfc7c)
```

#### racket

```diff
-[warn] docs: instructions unsynced: accumulate
-[warn] accumulate: missing 1 test case
-       - accumulate recursively (0b357334-4cad-49e1-a741-425202edfc7c)
```

#### raku

```diff
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: trinary
```

#### rust

```diff
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: nucleotide-codons
-[warn] docs: instructions unsynced: two-fer
-[warn] two-fer: missing 3 test cases
-       - no name given (1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce)
-       - a name given (b4c6dbb8-b4fb-42c2-bafd-10785abe7709)
-       - another name given (3549048d-1a6e-4653-9a79-b0bda163e8d5)
```

#### scala

```diff
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: octal
-[warn] docs: instructions unsynced: trinary
-[warn] metadata: unsynced: binary
```

#### scheme

```diff
-[warn] docs: instructions unsynced: list-ops
-[warn] docs: instructions unsynced: robot-name
-[warn] metadata: unsynced: list-ops
```

#### sml

```diff
-[warn] docs: instructions unsynced: binary
-[warn] metadata: unsynced: binary
```

#### swift

```diff
-[warn] docs: instructions unsynced: binary
-[warn] docs: instructions unsynced: hexadecimal
-[warn] docs: instructions unsynced: octal
-[warn] docs: instructions unsynced: trinary
-[warn] metadata: unsynced: binary
```