### PR TITLE
sync, info: improve error message for cache update failure

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -304,7 +304,7 @@ proc showHelp(exitCode: range[0..255] = 0, prependDashedLine = false) =
   let f = if exitCode == 0: stdout else: stderr
   if prependDashedLine:
     let dashLen = helpUncompressed.firstLine().len
-    f.write(&"\n\n{'-'.repeat(dashLen)}\n\n")
+    f.write(&"\n{'-'.repeat(dashLen)}\n\n")
   f.writeLine helpUncompressed
   if f == stdout:
     f.flushFile()
@@ -323,14 +323,17 @@ let
   colorStdout* = shouldUseColor(stdout)
   colorStderr* = shouldUseColor(stderr)
 
-proc showError*(s: string) =
+proc showError*(s: string, writeHelp = true) =
   const errorPrefix = "Error: "
   if colorStderr:
     stderr.styledWrite(fgRed, errorPrefix)
   else:
     stderr.write(errorPrefix)
-  stderr.write(s)
-  showHelp(exitCode = 1, prependDashedLine = true)
+  stderr.writeLine(s)
+  if writeHelp:
+    showHelp(exitCode = 1, prependDashedLine = true)
+  else:
+    quit 1
 
 func formatOpt(kind: CmdLineKind, key: string, val = ""): string =
   ## Returns a string that describes an option, given its `kind`, `key` and


### PR DESCRIPTION
Before this commit, running a `configlet sync` or `configlet info` command when all these conditions were satisfied:

- the `problem-specifications` cache was present and valid
- and the `--offline` option was not passed
- but we failed to update the cache due to a network error

produced an unhelpful error:

```console
$ configlet sync
Updating cached 'problem-specifications' data...
fatal: unable to access 'https://github.com/exercism/problem-specifications/': Could not resolve host: github.com

failed to fetch 'main' in problem-specifications directory: '/home/foo/.cache/exercism/configlet/problem-specifications'
exec.nim(68)             execAndCheck
Error: unhandled exception:  [OSError]
```

With this commit, configlet explains what the user can do next:

```console
$ configlet sync
Updating cached 'problem-specifications' data...
fatal: unable to access 'https://github.com/exercism/problem-specifications/': Could not resolve host: github.com

failed to fetch 'main' in problem-specifications directory: '/home/foo/.cache/exercism/configlet/problem-specifications'
Error: Unable to update the problem-specifications cache.

You can either:

- ensure that you have network connectivity, and run the same configlet command again
- or add the '--offline' option to skip updating the cache

The most recent commit in the problem-specifications cache is:

    commit 7012a73188698b2b7a2c340c1753d0198a38d8fa
    Author:     Katrina Owen <katrina.owen@gmail.com>
    CommitDate: Mon, 17 Oct 2022 16:36:08 +0200

        Change wording in tournament instructions (#2135)
```

Fixes: #683