### PR TITLE
.github: workflows: add workflow to test `fetch-configlet` scripts

### DIFF
--- a/.github/workflows/fetch-configlet.yml
+++ b/.github/workflows/fetch-configlet.yml
@@ -14,11 +14,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [linux, macOS, windows]
+        include:
+          - os: linux
+            runs-on: ubuntu-22.04
+
+          - os: mac
+            runs-on: macos-12
+
+          - os: windows
+            runs-on: windows-2022
 
     name: fetch-configlet-${{ matrix.os }}
-    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-22.04' ||
-                (matrix.os == 'macOS' && 'macos-12' || 'windows-2022') }}
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791

--- a/.github/workflows/fetch-configlet.yml
+++ b/.github/workflows/fetch-configlet.yml
@@ -1,0 +1,44 @@
+name: Fetch configlet
+
+on:
+  push:
+    paths:
+      - scripts/fetch-configlet*
+  pull_request:
+    paths:
+      - scripts/fetch-configlet*
+  workflow_dispatch:
+
+jobs:
+  fetch_configlet:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [linux, macOS, windows]
+
+    name: fetch-configlet-${{ matrix.os }}
+    runs-on: ${{ matrix.os == 'linux' && 'ubuntu-22.04' ||
+                (matrix.os == 'macOS' && 'macos-12' || 'windows-2022') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791
+
+      - name: Run fetch-configlet
+        shell: bash
+        run: ./scripts/fetch-configlet
+
+      - name: Run the downloaded configlet
+        env:
+          EXT: ${{ matrix.os == 'windows' && '.exe' || '' }}
+        shell: bash
+        run: |
+          configlet_path="./bin/configlet${EXT}"
+          "${configlet_path}" --version
+
+      - name: On Windows, also test fetch-configlet.ps1
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          Remove-Item bin/configlet.exe
+          scripts/fetch-configlet.ps1
+          bin/configlet.exe --version

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -72,5 +72,3 @@ main() {
 }
 
 main
-
-# Temporary comment to trigger `fetch-configlet.yml` workflow

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -72,3 +72,5 @@ main() {
 }
 
 main
+
+# Temporary comment to trigger `fetch-configlet.yml` workflow


### PR DESCRIPTION
The fetch-configlet scripts were previously not tested during CI. Test them.

The `fetch-configlet.ps1` script currently always fetches the Windows release asset:

https://github.com/exercism/configlet/blob/7dd6784061745316df5fe71588db5c8a61477103/scripts/fetch-configlet.ps1#L16

so this workflow only tests that script on Windows. (Issue #361 tracks this low-priority problem).

Closes: #121