### PR TITLE
fetch-configlet: make some variables local

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -6,20 +6,6 @@
 
 set -eo pipefail
 
-case "$(uname)" in
-  Darwin*)   os='mac'     ;;
-  Linux*)    os='linux'   ;;
-  Windows*)  os='windows' ;;
-  MINGW*)    os='windows' ;;
-  MSYS_NT-*) os='windows' ;;
-  *)         os='linux'   ;;
-esac
-
-case "${os}" in
-  windows*) ext='zip' ;;
-  *)        ext='tgz' ;;
-esac
-
 curlopts=(
   --silent
   --show-error
@@ -33,6 +19,8 @@ if [[ -n "${GITHUB_TOKEN}" ]]; then
 fi
 
 get_download_url() {
+  local os="$1"
+  local ext="$2"
   local latest='https://api.github.com/repos/exercism/configlet/releases/latest'
   local arch
   case "$(uname -m)" in
@@ -58,9 +46,25 @@ main() {
     return 1
   fi
 
+  local os
+  case "$(uname)" in
+    Darwin*)   os='mac'     ;;
+    Linux*)    os='linux'   ;;
+    Windows*)  os='windows' ;;
+    MINGW*)    os='windows' ;;
+    MSYS_NT-*) os='windows' ;;
+    *)         os='linux'   ;;
+  esac
+
+  local ext
+  case "${os}" in
+    windows*) ext='zip' ;;
+    *)        ext='tgz' ;;
+  esac
+
   echo "Fetching configlet..." >&2
   local download_url
-  download_url="$(get_download_url)"
+  download_url="$(get_download_url "${os}" "${ext}")"
   local output_path="${output_dir}/latest-configlet.${ext}"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
 

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -39,10 +39,9 @@ if [[ -n "${GITHUB_TOKEN}" ]]; then
   curlopts+=(--header "authorization: Bearer ${GITHUB_TOKEN}")
 fi
 
-suffix="${os}-${arch}.${ext}"
-
 get_download_url() {
   local latest='https://api.github.com/repos/exercism/configlet/releases/latest'
+  local suffix="${os}-${arch}.${ext}"
   curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${latest}" |
     grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |
     cut -d'"' -f4

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -6,8 +6,6 @@
 
 set -eo pipefail
 
-readonly LATEST='https://api.github.com/repos/exercism/configlet/releases/latest'
-
 case "$(uname)" in
   Darwin*)   os='mac'     ;;
   Linux*)    os='linux'   ;;
@@ -44,7 +42,8 @@ fi
 suffix="${os}-${arch}.${ext}"
 
 get_download_url() {
-  curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${LATEST}" |
+  local latest='https://api.github.com/repos/exercism/configlet/releases/latest'
+  curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${latest}" |
     grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |
     cut -d'"' -f4
 }

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -20,13 +20,6 @@ case "${os}" in
   *)        ext='tgz' ;;
 esac
 
-case "$(uname -m)" in
-  *64*)  arch='64bit' ;;
-  *686*) arch='32bit' ;;
-  *386*) arch='32bit' ;;
-  *)     arch='64bit' ;;
-esac
-
 curlopts=(
   --silent
   --show-error
@@ -41,6 +34,13 @@ fi
 
 get_download_url() {
   local latest='https://api.github.com/repos/exercism/configlet/releases/latest'
+  local arch
+  case "$(uname -m)" in
+    *64*)  arch='64bit' ;;
+    *686*) arch='32bit' ;;
+    *386*) arch='32bit' ;;
+    *)     arch='64bit' ;;
+  esac
   local suffix="${os}-${arch}.${ext}"
   curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${latest}" |
     grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -48,6 +48,7 @@ get_download_url() {
 }
 
 main() {
+  local output_dir
   if [[ -d ./bin ]]; then
     output_dir="./bin"
   elif [[ $PWD == */bin ]]; then
@@ -58,8 +59,9 @@ main() {
   fi
 
   echo "Fetching configlet..." >&2
+  local download_url
   download_url="$(get_download_url)"
-  output_path="${output_dir}/latest-configlet.${ext}"
+  local output_path="${output_dir}/latest-configlet.${ext}"
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
 
   case "${ext}" in
@@ -69,12 +71,14 @@ main() {
 
   rm -f "${output_path}"
 
+  local executable_ext
   case "${os}" in
     windows*) executable_ext='.exe' ;;
     *)        executable_ext=''     ;;
   esac
 
-  configlet_path="${output_dir}/configlet${executable_ext}"
+  local configlet_path="${output_dir}/configlet${executable_ext}"
+  local configlet_version
   configlet_version="$(${configlet_path} --version)"
   echo "Downloaded configlet ${configlet_version} to ${configlet_path}"
 }


### PR DESCRIPTION
Reduce the number of globals.

From e.g. the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html#use-local-variables):

> Ensure that local variables are only seen inside a function and its children by using `local` when declaring them. This avoids polluting the global name space and inadvertently setting variables that may have significance outside the function.
>
> Declaration and assignment must be separate statements when the assignment value is provided by a command substitution; as the `local` builtin does not propagate the exit code from the command substitution.
>
>```bash
>my_func2() {
>  local name="$1"
>
>  # Separate lines for declaration and assignment:
>  local my_var
>  my_var="$(my_func)"
>  (( $? == 0 )) || return
>
>  …
>}
>```
>
>```bash
>my_func2() {
>  # DO NOT do this:
>  # $? will always be zero, as it contains the exit code of 'local', not my_func
>  local my_var="$(my_func)"
>  (( $? == 0 )) || return
>
>  …
>}
>```