### PR TITLE
configlet: catch every `CatchableError`

### DIFF
--- a/src/configlet.nim
+++ b/src/configlet.nim
@@ -2,7 +2,7 @@ import std/posix
 import "."/[cli, completion/completion, fmt/fmt, info/info, generate/generate,
             lint/lint, logger, sync/sync, uuid/uuid]
 
-proc main =
+proc configlet =
   onSignal(SIGTERM):
     quit(0)
 
@@ -28,4 +28,12 @@ proc main =
   of actInfo:
     info(conf)
 
-main()
+proc main =
+  try:
+    configlet()
+  except CatchableError:
+    let msg = getCurrentExceptionMsg()
+    showError(msg)
+
+when isMainModule:
+  main()


### PR DESCRIPTION
This helps with things like https://github.com/exercism/configlet/commit/3457c09d786c86b5700c62bc5ff72e2a9a5cdcd5.

It also prepares for refactoring the error handling everywhere, preferring to raise an exception rather than calling a deep `quit`.

Refs: #123
Refs: #325
Closes: #696