### PR TITLE
sync: improve error handling

### DIFF
--- a/src/cli.nim
+++ b/src/cli.nim
@@ -2,6 +2,16 @@ import std/[os, parseutils, strformat, strutils, terminal]
 import pkg/[cligen/parseopt3, supersnappy]
 
 type
+  ConfigletError* = object of CatchableError ## Quit with exit code 1
+  ConfigletErrorAndHelp* = object of CatchableError ## Quit with exit code 1, and print help
+
+func error*(s: string) =
+  raise newException(ConfigletError, s)
+
+func errorAndHelp*(s: string) =
+  raise newException(ConfigletErrorAndHelp, s)
+
+type
   ActionKind* = enum
     actNil = "nil"
     actCompletion = "completion"

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -2,8 +2,10 @@ import std/[os, parseutils, strformat, strutils, terminal]
 import pkg/[cligen/parseopt3, supersnappy]
 
 type
-  ConfigletError* = object of CatchableError ## Quit with exit code 1
-  ConfigletErrorAndHelp* = object of CatchableError ## Quit with exit code 1, and print help
+  ConfigletError* = object of CatchableError ## \
+    ## Raised to quit with exit code 1, but not print configlet usage
+  ConfigletErrorAndHelp* = object of CatchableError ## \
+    ## Raised to quit with exit code 1, and print configlet usage
 
 func error*(s: string) =
   raise newException(ConfigletError, s)

--- a/src/configlet.nim
+++ b/src/configlet.nim
@@ -31,6 +31,9 @@ proc configlet =
 proc main =
   try:
     configlet()
+  except ConfigletError:
+    let s = getCurrentExceptionMsg()
+    showError(s, writeHelp = false)
   except CatchableError:
     let msg = getCurrentExceptionMsg()
     showError(msg)

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -21,7 +21,7 @@ proc validate(conf: Conf) =
 
         If no syncing scope option is provided, configlet uses the full syncing scope.
         If '--tests' is provided without an argument, configlet uses the 'choose' mode.""".dedent(8)
-      showError(msg)
+      errorAndHelp msg
     if not conf.action.yes and not isatty(stdin):
       let intersection = conf.action.scope * {skDocs, skFilepaths, skMetadata}
       if intersection.len > 0:
@@ -37,7 +37,7 @@ proc validate(conf: Conf) =
             that configlet performs no changes
           - or run the same command in an interactive terminal, to update by answering
             prompts""".dedent(10)
-        showError(msg)
+        errorAndHelp msg
 
 type
   TrackExerciseSlugs* = object
@@ -74,11 +74,9 @@ proc getSlugs*(exercises: Exercises, conf: Conf,
       result.`concept`.setLen 0
       result.practice = @[userExercise]
     else:
-      let msg = &"The `-e, --exercise` option was used to specify an " &
-                &"exercise slug, but `{userExercise}` is not an slug in the " &
-                &"track config:\n{trackConfigPath}"
-      stderr.writeLine msg
-      quit 1
+      error "The `-e, --exercise` option was used to specify an exercise " &
+            &"slug, but `{userExercise}` is not an slug in the track config:" &
+            &"\n{trackConfigPath}"
 
 proc syncImpl(conf: Conf): set[SyncKind] =
   ## Checks the data specified in `conf.action.scope`, and updates them if

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -20,10 +20,9 @@ proc postHook*(e: ConceptExercise | PracticeExercise) =
   ## string.
   let s = e.slug.string
   if not isKebabCase(s):
-    let msg = "Error: the track `config.json` file contains " &
-              &"an exercise slug of \"{s}\", which is not a kebab-case string"
-    stderr.writeLine msg
-    quit 1
+    let msg = "the track `config.json` file contains an exercise slug of " &
+              &"\"{s}\", which is not a kebab-case string"
+    error msg
 
 func getSlugs*(e: seq[ConceptExercise] | seq[PracticeExercise],
                withDeprecated = true): seq[Slug] =
@@ -107,24 +106,22 @@ func renameHook*(f: var (ConceptExerciseFiles | PracticeExerciseFiles); key: str
 
 proc parseFile*(path: string, T: typedesc): T =
   ## Parses the JSON file at `path` into `T`.
-  let contents =
+  let contents = block:
+    var res = ""
     try:
-      readFile(path)
+      res = readFile(path)
     except IOError:
-      let msg = getCurrentExceptionMsg()
-      stderr.writeLine &"Error: {msg}"
-      quit 1
+      error getCurrentExceptionMsg()
+    res
   if contents.len > 0:
     try:
-      contents.fromJson(T)
+      result = contents.fromJson(T)
     except jsony.JsonError:
       let jsonyMsg = getCurrentExceptionMsg()
       let details = tidyJsonyMessage(jsonyMsg, contents)
-      let msg = &"JSON parsing error:\n{path}{details}"
-      stderr.writeLine msg
-      quit 1
+      error &"JSON parsing error:\n{path}{details}"
   else:
-    T()
+    result = T()
 
 func addNewlineAndIndent(s: var string, indentLevel: int) =
   ## Appends a newline and spaces (given by `indentLevel` multiplied by 2) to
@@ -269,9 +266,7 @@ proc addObject(s: var string; key: string; val: JsonNode; indentLevel = 1) =
       else:
         s.add c
   else:
-    stderr.writeLine &"The value of a `{key}` key is not a JSON object:"
-    stderr.writeLine val.pretty()
-    quit 1
+    error &"The value of a `{key}` key is not a JSON object:\n{val.pretty()}"
 
 func keyOrderForSync(originalKeyOrder: seq[ExerciseConfigKey]): seq[ExerciseConfigKey] =
   if originalKeyOrder.len == 0:

--- a/src/sync/sync_docs.nim
+++ b/src/sync/sync_docs.nim
@@ -122,8 +122,7 @@ proc write(pairsToWrite: seq[PathAndContents]) =
       createDir path.parentDir()
       writeFile(path, pathAndContents.contents)
     else:
-      stderr.writeLine &"Unexpected path before writing: {path}"
-      quit 1
+      error &"Unexpected path before writing: {path}"
   let s = if pairsToWrite.len > 1: "s" else: ""
   logNormal(&"Updated the docs for {pairsToWrite.len} Practice Exercise{s}")
 

--- a/src/sync/sync_filepaths.nim
+++ b/src/sync/sync_filepaths.nim
@@ -147,8 +147,7 @@ proc write(configPairs: seq[PathAndUpdatedExerciseConfig]) =
           configPair.exerciseConfig.p.pretty(prettyMode = pmSync)
       writeFile(path, contents)
     else:
-      stderr.writeLine &"Unexpected path before writing: {path}"
-      quit 1
+      error &"Unexpected path before writing: {path}"
   let s = if configPairs.len > 1: "s" else: ""
   logNormal(&"Updated the filepaths for {configPairs.len} exercise{s}")
 

--- a/src/sync/sync_metadata.nim
+++ b/src/sync/sync_metadata.nim
@@ -100,8 +100,7 @@ proc write(configPairs: seq[PathAndUpdatedConfig]) =
       createDir path.parentDir()
       writeFile(path, updatedJson)
     else:
-      stderr.writeLine &"Unexpected path before writing: {path}"
-      quit 1
+      error &"Unexpected path before writing: {path}"
   let s = if configPairs.len > 1: "s" else: ""
   logNormal(&"Updated the metadata for {configPairs.len} Practice Exercise{s}")
 

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -148,7 +148,7 @@ proc testsForSync(binaryPath: static string) =
   suite "sync, for an exercise that does not exist (prints the expected output, and exits with 1)":
     test "-e foo":
       const expectedOutput = fmt"""
-        The `-e, --exercise` option was used to specify an exercise slug, but `foo` is not an slug in the track config:
+        Error: The `-e, --exercise` option was used to specify an exercise slug, but `foo` is not an slug in the track config:
         {trackDir / "config.json"}
       """.unindent()
       execAndCheck(1, &"{syncOffline} -e foo --docs", expectedOutput)

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -140,18 +140,24 @@ proc testsForSync(binaryPath: static string) =
   suite "sync, when the track `config.json` file is not found (prints the expected output, and exits with 1)":
     test "-t foo":
       const expectedOutput = fmt"""
-        Error: cannot open: my_missing_directory{DirSep}config.json
+        cannot open: my_missing_directory{DirSep}config.json
       """.unindent()
       let cmd = &"{binaryPath} -t my_missing_directory sync -o"
-      execAndCheck(1, cmd, expectedOutput)
+      let (outp, exitCode) = execCmdEx(cmd)
+      check:
+        outp.contains(expectedOutput)
+        exitCode == 1
 
   suite "sync, for an exercise that does not exist (prints the expected output, and exits with 1)":
     test "-e foo":
       const expectedOutput = fmt"""
-        Error: The `-e, --exercise` option was used to specify an exercise slug, but `foo` is not an slug in the track config:
+        The `-e, --exercise` option was used to specify an exercise slug, but `foo` is not an slug in the track config:
         {trackDir / "config.json"}
       """.unindent()
-      execAndCheck(1, &"{syncOffline} -e foo --docs", expectedOutput)
+      let (outp, exitCode) = execCmdEx(&"{syncOffline} -e foo --docs")
+      check:
+        outp.contains(expectedOutput)
+        exitCode == 1
 
   suite "sync, without --update, checking parseopt3 patch (--tests -e bob is parsed correctly)":
     # With an unpatched cligen/parseopt3, we can only write `--tests` without a


### PR DESCRIPTION
Replace:

- `showError` with `errorAndHelp`
- (`stderr.writeLine msg` then `quit 1`) with `error`

Refs: #123
Refs: #325

---

Working towards the approach that I use elsewhere, including:

https://github.com/exercism/configlet/blob/b6fff14959b095b77c982d32fbc3941d909a1845/bin/bump_version.nim#L17-L19