### PR TITLE
.github(workflows): bump `iffy/install-nim` from 4.2.0 to 4.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: ./.github/bin/linux-install-build-tools
 
       - name: Install Nim
-        uses: iffy/install-nim@7efc1c47b112336664753ebbe81036490e52e4b7
+        uses: iffy/install-nim@1ab2fcc1d8294b3956d5696f45cd470c9fe69466
         with:
           version: "binary:1.6.8"
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: ./.github/bin/linux-install-build-tools
 
       - name: Install Nim
-        uses: iffy/install-nim@7efc1c47b112336664753ebbe81036490e52e4b7
+        uses: iffy/install-nim@1ab2fcc1d8294b3956d5696f45cd470c9fe69466
         with:
           version: "binary:1.6.8"
         env:


### PR DESCRIPTION
See the [changelog](https://github.com/iffy/install-nim/blob/1ab2fcc1d829/CHANGELOG.md) and [commits since our previously used version](https://github.com/iffy/install-nim/compare/v4.2.0...v4.4.0).