### PR TITLE
.github(workflows): bump `actions/checkout` from 3.0.2 to 3.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
         with:
           fetch-depth: 0 # Allows using `git log` to set initial release notes.
 
@@ -71,7 +71,7 @@ jobs:
     name: Upload checksums file
     steps:
       - name: Checkout code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
       - name: Upload checksums file
         run: ./.github/bin/upload-checksums-file

--- a/.github/workflows/lint-whitespace.yml
+++ b/.github/workflows/lint-whitespace.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
       - name: Check that every file has no trailing whitespace, and exactly one final newline
         run: ./.github/bin/lint-whitespace

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@e3969ef4ed874458f4b66d4631f78fff7717012c

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
       - name: Run shellcheck
         uses: ludeeus/action-shellcheck@203a3fd018dfe73f8ae7e3aa8da2c149a5f41c33

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
       - name: On Linux, install musl
         if: matrix.target.os == 'linux'


### PR DESCRIPTION
See the [release notes](https://github.com/actions/checkout/releases/tag/v3.1.0) and [commits since our previously used version](https://github.com/actions/checkout/compare/2541b1294d27...93ea575cb5d8).

---

```shell
git ls-files -z -- '.github/workflows/*.yml' \
  | xargs -0 sed -i 's/2541b1294d2704b0964813337f33b291d3f8596b/93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8/g' 
```

```console
$ git rev-parse --short HEAD
dba8f264
$ git grep --break --heading 'actions/checkout'
.github/workflows/build.yml
36:        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
74:        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

.github/workflows/lint-whitespace.yml
11:        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

.github/workflows/markdownlint.yml
11:        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

.github/workflows/shellcheck.yml
11:        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

.github/workflows/tests.yml
41:        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
```