### PR TITLE
lint: add initial checks for approaches and articles

### DIFF
--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -92,6 +92,7 @@ proc dirExists*(path: Path): bool {.borrow.}
 proc fileExists*(path: Path): bool {.borrow.}
 proc readFile*(path: Path): string {.borrow.}
 proc writeFile*(path: Path; content: string) {.borrow.}
+proc parentDir*(path: Path): string {.borrow.}
 
 func toLineAndCol(s: string; offset: Natural): tuple[line: int; col: int] =
   ## Returns the line and column number corresponding to the `offset` in `s`.

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -1,4 +1,4 @@
-import std/[json, strformat, strutils]
+import std/[json, os, strformat, strutils]
 import ".."/helpers
 import "."/validators
 
@@ -30,6 +30,13 @@ proc isValidApproachOrArticle(data: JsonNode, context: string,
                         isRequired = false),
     ]
     result = allTrue(checks)
+    if result:
+      let slug = data["slug"].getStr()
+      let slugDir = path.parentDir() / slug
+      if not dirExists(slugDir):
+        let msg = &"A 'slug' value is '{slug}', but there is no sibling " &
+                  "directory with that name"
+        result.setFalseAndPrint(msg, path)
 
 proc isValidConfig(data: JsonNode, path: Path, dk: DirKind): bool =
   if isObject(data, jsonRoot, path):

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -32,11 +32,11 @@ proc isValidApproachOrArticle(data: JsonNode, context: string,
     result = allTrue(checks)
     if result:
       let slug = data["slug"].getStr()
-      let slugDir = path.parentDir() / slug
+      let slugDir = Path(path.parentDir() / slug)
       if not dirExists(slugDir):
-        let msg = &"A 'slug' value is '{slug}', but there is no sibling " &
-                  "directory with that name"
-        result.setFalseAndPrint(msg, path)
+        let msg = &"A config.json '{context}.slug' value is '{slug}', but " &
+                  "there is no corresponding directory at the below location"
+        result.setFalseAndPrint(msg, slugDir)
 
 proc isValidConfig(data: JsonNode, path: Path, dk: DirKind): bool =
   if isObject(data, jsonRoot, path):

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -42,12 +42,22 @@ proc isValidConfig(data: JsonNode, path: Path, dk: DirKind): bool =
 
 proc isConfigMissingOrValid(dir: Path, dk: DirKind): bool =
   result = true
-  let configPath = dir / $dk / "config.json"
+  let dkPath = dir / $dk
+  let configPath = dkPath / "config.json"
   if fileExists(configPath):
     let j = parseJsonFile(configPath, result)
     if j != nil:
       if not isValidConfig(j, configPath, dk):
         result = false
+  else:
+    if dk == dkApproaches and fileExists(dkPath / "introduction.md"):
+      let msg =  &"The below directory has an 'introduction.md' file, but " &
+                 "does not contain a 'config.json' file"
+      result.setFalseAndPrint(msg, dkPath)
+    for dir in getSortedSubdirs(dkPath, relative = true):
+      let msg = &"The below directory has a '{dir}' subdirectory, but does " &
+                "not contain a 'config.json' file"
+      result.setFalseAndPrint(msg, dkPath)
 
 func countLinesWithoutCodeFence(s: string, dk: DirKind): int =
   ## Returns the number of lines in `s`, but:

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -4,8 +4,8 @@ import "."/validators
 
 type
   DirKind = enum
-    dkApproaches = "approaches"
-    dkArticles = "articles"
+    dkApproaches = ".approaches"
+    dkArticles = ".articles"
 
 proc hasValidIntroduction(data: JsonNode, path: Path): bool =
   const k = "introduction"
@@ -33,15 +33,16 @@ proc isValidApproachOrArticle(data: JsonNode, context: string,
 
 proc isValidConfig(data: JsonNode, path: Path, dk: DirKind): bool =
   if isObject(data, jsonRoot, path):
+    let k = dk.`$`[1..^1] # Remove dot.
     let checks = [
       if dk == dkApproaches: hasValidIntroduction(data, path) else: true,
-      hasArrayOf(data, $dk, path, isValidApproachOrArticle, isRequired = false),
+      hasArrayOf(data, k, path, isValidApproachOrArticle, isRequired = false),
     ]
     result = allTrue(checks)
 
 proc isConfigMissingOrValid(dir: Path, dk: DirKind): bool =
   result = true
-  let configPath = dir / &".{dk}" / "config.json"
+  let configPath = dir / $dk / "config.json"
   if fileExists(configPath):
     let j = parseJsonFile(configPath, result)
     if j != nil:
@@ -50,7 +51,7 @@ proc isConfigMissingOrValid(dir: Path, dk: DirKind): bool =
 
 proc isEverySnippetValid(exerciseDir: Path, dk: DirKind): bool =
   result = true
-  for dir in getSortedSubdirs(exerciseDir / &".{dk}"):
+  for dir in getSortedSubdirs(exerciseDir / $dk):
     let snippetPath = block:
       let ext = if dk == dkApproaches: "txt" else: "md"
       dir / &"snippet.{ext}"

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -99,8 +99,8 @@ proc isConfigMissingOrValid(dir: Path, dk: DirKind): bool =
         result = false
   else:
     if dk == dkApproaches and fileExists(dkPath / "introduction.md"):
-      let msg =  &"The below directory has an 'introduction.md' file, but " &
-                 "does not contain a 'config.json' file"
+      let msg = &"The below directory has an 'introduction.md' file, but " &
+                "does not contain a 'config.json' file"
       result.setFalseAndPrint(msg, dkPath)
     for dir in getSortedSubdirs(dkPath, relative = true):
       let msg = &"The below directory has a '{dir}' subdirectory, but does " &

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -1,0 +1,83 @@
+import std/[json, strformat, strutils]
+import ".."/helpers
+import "."/validators
+
+type
+  DirKind = enum
+    dkApproaches = "approaches"
+    dkArticles = "articles"
+
+proc hasValidIntroduction(data: JsonNode, path: Path): bool =
+  const k = "introduction"
+  if hasObject(data, k, path):
+    let d = data[k]
+    let checks = [
+      hasArrayOfStrings(d, "authors", path, k, uniqueValues = true),
+      hasArrayOfStrings(d, "contributors", path, k, isRequired = false),
+    ]
+    result = allTrue(checks)
+
+proc isValidApproachOrArticle(data: JsonNode, context: string,
+                              path: Path): bool =
+  if isObject(data, context, path):
+    let checks = [
+      hasString(data, "uuid", path, context, checkIsUuid = true),
+      hasString(data, "slug", path, context, checkIsKebab = true),
+      hasString(data, "title", path, context, maxLen = 255),
+      hasString(data, "blurb", path, context, maxLen = 280),
+      hasArrayOfStrings(data, "authors", path, context, uniqueValues = true),
+      hasArrayOfStrings(data, "contributors", path, context,
+                        isRequired = false),
+    ]
+    result = allTrue(checks)
+
+proc isValidConfig(data: JsonNode, path: Path, dk: DirKind): bool =
+  if isObject(data, jsonRoot, path):
+    let checks = [
+      if dk == dkApproaches: hasValidIntroduction(data, path) else: true,
+      hasArrayOf(data, $dk, path, isValidApproachOrArticle, isRequired = false),
+    ]
+    result = allTrue(checks)
+
+proc isConfigMissingOrValid(dir: Path, dk: DirKind): bool =
+  result = true
+  let configPath = dir / &".{dk}" / "config.json"
+  if fileExists(configPath):
+    let j = parseJsonFile(configPath, result)
+    if j != nil:
+      if not isValidConfig(j, configPath, dk):
+        result = false
+
+proc isEverySnippetValid(exerciseDir: Path, dk: DirKind): bool =
+  result = true
+  for dir in getSortedSubdirs(exerciseDir / &".{dk}"):
+    let snippetPath = block:
+      let ext = if dk == dkApproaches: "txt" else: "md"
+      dir / &"snippet.{ext}"
+    if fileExists(snippetPath):
+      let contents = readFile(snippetPath)
+      var numLines = 0
+      for line in contents.splitLines():
+        if not (line.startsWith("```") and dk == dkArticles):
+          inc numLines
+      dec numLines # Allow 8 lines with a final newline.
+      const maxNumLines = 8
+      if numLines > maxNumLines:
+        let msg = &"The file is {numLines} lines long, but it must be at " &
+                  &"most {maxNumLines} lines long"
+        result.setFalseAndPrint(msg, snippetPath)
+
+proc isDirValid(exerciseDir: Path): bool =
+  result = true
+  for dk in DirKind:
+    if not isConfigMissingOrValid(exerciseDir, dk):
+      result = false
+    if not isEverySnippetValid(exerciseDir, dk):
+      result = false
+
+proc isEveryApproachAndArticleValid*(trackDir: Path): bool =
+  result = true
+  for exerciseKind in ["concept", "practice"]:
+    for exerciseDir in getSortedSubdirs(trackDir / "exercises" / exerciseKind):
+      if not isDirValid(exerciseDir):
+        result = false

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -67,17 +67,12 @@ proc isEverySnippetValid(exerciseDir: Path, dk: DirKind): bool =
                   &"most {maxNumLines} lines long"
         result.setFalseAndPrint(msg, snippetPath)
 
-proc isDirValid(exerciseDir: Path): bool =
-  result = true
-  for dk in DirKind:
-    if not isConfigMissingOrValid(exerciseDir, dk):
-      result = false
-    if not isEverySnippetValid(exerciseDir, dk):
-      result = false
-
 proc isEveryApproachAndArticleValid*(trackDir: Path): bool =
   result = true
   for exerciseKind in ["concept", "practice"]:
     for exerciseDir in getSortedSubdirs(trackDir / "exercises" / exerciseKind):
-      if not isDirValid(exerciseDir):
-        result = false
+      for dk in DirKind:
+        if not isConfigMissingOrValid(exerciseDir, dk):
+          result = false
+        if not isEverySnippetValid(exerciseDir, dk):
+          result = false

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -24,7 +24,7 @@ proc hasValidIntroduction(data: JsonNode, path: Path): bool =
       hasArrayOfStrings(d, "contributors", path, k, isRequired = false),
     ]
     result = allTrue(checks)
-  if result and data.hasKey(k):
+  if data.kind == JObject and data.hasKey(k):
     let introductionPath = Path(path.parentDir() / "introduction.md")
     let msg = &"The config.json '{k}' object is present, but there is no " &
               "corresponding introduction file at the below location"

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -9,7 +9,7 @@ type
 
 proc hasValidIntroduction(data: JsonNode, path: Path): bool =
   const k = "introduction"
-  if hasObject(data, k, path):
+  if hasObject(data, k, path, isRequired = false):
     let d = data[k]
     let checks = [
       hasArrayOfStrings(d, "authors", path, k, uniqueValues = true),

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -1,7 +1,7 @@
 import std/[strformat, strutils]
 import ".."/[cli, helpers]
-import "."/[concept_exercises, concepts, docs, practice_exercises,
-            track_config, validators]
+import "."/[approaches_and_articles, concept_exercises, concepts, docs,
+            practice_exercises, track_config, validators]
 
 proc allChecksPass(trackDir: Path): bool =
   ## Returns true if all the linting checks pass for the track at `trackDir`.
@@ -16,6 +16,7 @@ proc allChecksPass(trackDir: Path): bool =
     isEveryConceptConfigValid(trackDir),
     isEveryConceptExerciseConfigValid(trackDir),
     isEveryPracticeExerciseConfigValid(trackDir),
+    isEveryApproachAndArticleValid(trackDir),
     sharedExerciseDocsExist(trackDir),
     trackDocsExist(trackDir),
   ]

--- a/src/lint/lint.nim
+++ b/src/lint/lint.nim
@@ -46,6 +46,7 @@ proc lint*(conf: Conf) =
       - Every concept exercise has a valid .meta/config.json file
       - Every practice exercise has the required .md files
       - Every practice exercise has a valid .meta/config.json file
+      - Every approach and article is valid
       - Required track docs are present
       - Required shared exercise docs are present""".dedent()
     if printedWarning:


### PR DESCRIPTION
There is not yet a formal spec for an approach `config.json` file or an article `config.json` file, but I've tried to implement linting them from the docs for [concept exercises](https://github.com/exercism/docs/blob/5509b2f12fac/building/tracks/concept-exercises.md#file-approachesconfigjson) and [practice exercises](https://github.com/exercism/docs/blob/5509b2f12fac/building/tracks/practice-exercises.md#file-approachesconfigjson) (which talk about approaches) and a [commit](https://github.com/exercism/csharp/commit/4069cca97782) on the csharp track.