### PR TITLE
.github, fetch-configlet: rename release assets

### DIFF
--- a/.github/bin/create-artifact
+++ b/.github/bin/create-artifact
@@ -10,7 +10,7 @@ case "${OS}" in
     artifact_file="${artifacts_dir}/${binary_name}-${OS}-${ARCH}.zip"
     7z a "${artifact_file}" "${binary_name}.exe"
     ;;
-  linux | mac)
+  linux | macos)
     artifact_file="${artifacts_dir}/${binary_name}-${OS}-${ARCH}.tgz"
     tar -cvzf "${artifact_file}" "${binary_name}"
     ;;

--- a/.github/bin/create-artifact
+++ b/.github/bin/create-artifact
@@ -11,7 +11,7 @@ case "${OS}" in
     7z a "${artifact_file}" "${binary_name}.exe"
     ;;
   linux | macos)
-    artifact_file="${artifacts_dir}/${binary_name}-${OS}-${ARCH}.tgz"
+    artifact_file="${artifacts_dir}/${binary_name}-${OS}-${ARCH}.tar.gz"
     tar -cvzf "${artifact_file}" "${binary_name}"
     ;;
 esac

--- a/.github/bin/create-artifact
+++ b/.github/bin/create-artifact
@@ -7,11 +7,11 @@ binary_name='configlet'
 
 case "${OS}" in
   windows)
-    artifact_file="${artifacts_dir}/${binary_name}-${OS}-${ARCH}.zip"
+    artifact_file="${artifacts_dir}/${binary_name}_${OS}_${ARCH}.zip"
     7z a "${artifact_file}" "${binary_name}.exe"
     ;;
   linux | macos)
-    artifact_file="${artifacts_dir}/${binary_name}-${OS}-${ARCH}.tar.gz"
+    artifact_file="${artifacts_dir}/${binary_name}_${OS}_${ARCH}.tar.gz"
     tar -cvzf "${artifact_file}" "${binary_name}"
     ;;
 esac

--- a/.github/bin/create-artifact
+++ b/.github/bin/create-artifact
@@ -4,14 +4,15 @@ artifacts_dir='artifacts'
 mkdir -p "${artifacts_dir}"
 
 binary_name='configlet'
+build_tag="${GITHUB_REF_NAME}"
 
 case "${OS}" in
   windows)
-    artifact_file="${artifacts_dir}/${binary_name}_${OS}_${ARCH}.zip"
+    artifact_file="${artifacts_dir}/${binary_name}_${build_tag}_${OS}_${ARCH}.zip"
     7z a "${artifact_file}" "${binary_name}.exe"
     ;;
   linux | macos)
-    artifact_file="${artifacts_dir}/${binary_name}_${OS}_${ARCH}.tar.gz"
+    artifact_file="${artifacts_dir}/${binary_name}_${build_tag}_${OS}_${ARCH}.tar.gz"
     tar -cvzf "${artifact_file}" "${binary_name}"
     ;;
 esac

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,15 @@ jobs:
         include:
           - os: linux
             runs-on: ubuntu-22.04
-            arch: 64bit
+            arch: x86-64
 
           - os: macos
             runs-on: macos-12
-            arch: 64bit
+            arch: x86-64
 
           - os: windows
             runs-on: windows-2022
-            arch: 64bit
+            arch: x86-64
 
     name: "${{ matrix.os }}-${{ matrix.arch }}"
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
             runs-on: ubuntu-22.04
             arch: 64bit
 
-          - os: mac
+          - os: macos
             runs-on: macos-12
             arch: 64bit
 

--- a/.github/workflows/fetch-configlet.yml
+++ b/.github/workflows/fetch-configlet.yml
@@ -18,7 +18,7 @@ jobs:
           - os: linux
             runs-on: ubuntu-22.04
 
-          - os: mac
+          - os: macos
             runs-on: macos-12
 
           - os: windows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
             runs-on: ubuntu-22.04
             arch: 64bit
 
-          - os: mac
+          - os: macos
             runs-on: macos-12
             arch: 64bit
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,15 +19,15 @@ jobs:
         include:
           - os: linux
             runs-on: ubuntu-22.04
-            arch: 64bit
+            arch: x86-64
 
           - os: macos
             runs-on: macos-12
-            arch: 64bit
+            arch: x86-64
 
           - os: windows
             runs-on: windows-2022
-            arch: 64bit
+            arch: x86-64
 
     name: "${{ matrix.os }}-${{ matrix.arch }}"
     runs-on: ${{ matrix.runs-on }}

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -24,10 +24,10 @@ get_download_url() {
   local latest='https://api.github.com/repos/exercism/configlet/releases/latest'
   local arch
   case "$(uname -m)" in
-    *64*)  arch='64bit' ;;
-    *686*) arch='32bit' ;;
-    *386*) arch='32bit' ;;
-    *)     arch='64bit' ;;
+    x86_64) arch='x86-64' ;;
+    *686*)  arch='i386'   ;;
+    *386*)  arch='i386'   ;;
+    *)      arch='x86-64' ;;
   esac
   local suffix="${os}-${arch}.${ext}"
   curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${latest}" |

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -58,8 +58,8 @@ main() {
 
   local ext
   case "${os}" in
-    windows*) ext='zip' ;;
-    *)        ext='tgz' ;;
+    windows*) ext='zip'    ;;
+    *)        ext='tar.gz' ;;
   esac
 
   echo "Fetching configlet..." >&2

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -48,7 +48,7 @@ main() {
 
   local os
   case "$(uname)" in
-    Darwin*)   os='mac'     ;;
+    Darwin*)   os='macos'   ;;
     Linux*)    os='linux'   ;;
     Windows*)  os='windows' ;;
     MINGW*)    os='windows' ;;

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -29,7 +29,7 @@ get_download_url() {
     *386*)  arch='i386'   ;;
     *)      arch='x86-64' ;;
   esac
-  local suffix="${os}-${arch}.${ext}"
+  local suffix="${os}_${arch}.${ext}"
   curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${latest}" |
     grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |
     cut -d'"' -f4

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -12,7 +12,7 @@ $requestOpts = @{
     RetryIntervalSec  = 1
 }
 
-$arch = If ([Environment]::Is64BitOperatingSystem) { "64bit" } Else { "32bit" }
+$arch = If ([Environment]::Is64BitOperatingSystem) { "x86-64" } Else { "i386" }
 $fileName = "configlet-windows-$arch.zip"
 
 Function Get-DownloadUrl {

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -13,7 +13,7 @@ $requestOpts = @{
 }
 
 $arch = If ([Environment]::Is64BitOperatingSystem) { "x86-64" } Else { "i386" }
-$fileName = "configlet_windows_$arch.zip"
+$fileName = "configlet_.+_windows_$arch.zip"
 
 Function Get-DownloadUrl {
     $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -13,7 +13,7 @@ $requestOpts = @{
 }
 
 $arch = If ([Environment]::Is64BitOperatingSystem) { "x86-64" } Else { "i386" }
-$fileName = "configlet-windows-$arch.zip"
+$fileName = "configlet_windows_$arch.zip"
 
 Function Get-DownloadUrl {
     $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"


### PR DESCRIPTION
Summary:

- Add version string
- Delimit with underscore, not hyphen
- Rename `64bit` to `x86-64`
- Rename `32bit` to `i386` (note that we do not have 32-bit releases yet anyway)
- Rename `tgz` to `tar.gz`
- Rename `mac` to `macos`

The configlet release assets have always had architecture-ambiguous names:

```text
configlet-linux-64bit.tgz
configlet-mac-64bit.tgz
configlet-windows-64bit.zip
```

This naming format is old (added by https://github.com/exercism/configlet/commit/d4c6e26836a5d74e6fa9698498c96fee7fdee0a5 in the `canonical-data-syncer` days), and was ultimately inheirited from:

- the `exercism/configlet-v2` releases (https://github.com/exercism/v2-configlet/releases)
- the `exercism/cli` releases (see https://github.com/exercism/cli/issues/700#issuecomment-529013140 and [cli-v3.0.12](https://github.com/exercism/cli/releases/tag/v3.0.12)).

The ambiguous names haven't mattered much so far, because configlet has only released for `x86-64`. However, I'm getting closer to adding releases for other 64bit architectures, so we finally need to change the names.

For the rationale being the new naming format, see my (hopefully sufficiently exhaustive) bikeshedding in https://github.com/exercism/configlet/issues/363#issuecomment-1292500893.

Before this commit, the release assets were named like:

```text
configlet-linux-64bit.tgz
configlet-mac-64bit.tgz
configlet-windows-64bit.zip
configlet_4.0.0-beta.7_checksums_sha256.txt
```

With this commit, the next release will have assets named:

```text
configlet_4.0.0-beta.8_checksums_sha256.txt
configlet_4.0.0-beta.8_linux_x86-64.tar.gz
configlet_4.0.0-beta.8_macos_x86-64.tar.gz
configlet_4.0.0-beta.8_windows_x86-64.zip
```

where the archive names now match the naming format for the existing checksums file.

Closes: #363
Refs: #24

---

I've tried to convince myself that the naming format with underscores everywhere but architecture and version string (where semver mandates a hyphen):

```
configlet_4.0.0-beta.7_linux_x86-64.tar.gz
```

is a better format than hyphens everywhere but architecture:

```
configlet-4.0.0-beta.7-linux-x86_64.tar.gz
```

or hyphens everywhere:

```
configlet-4.0.0-beta.7-linux-x86-64.tar.gz
```

or underscores everywhere possible:

```
configlet_4.0.0-beta.7_linux_x86_64.tar.gz
```

Even though I don't love that:

-  It ignores an existing convention that "hyphens separate words, and underscores delimit within a word" (try double clicking on the x86 in `x86_64` and `x86-64` if you aren't aware of this - the first selects the whole thing, the second doesn't). Note that double-clicking `beta` in `4.0.0-beta.7` won't select the whole version, and the same is true of `4.0.0_beta.7` even if semver permitted that, so us using underscores everywhere possible doesn't achieve a naming format where double-clicking on part of the name always performs tokenization. 
- `uname -m` returns `x86_64`, not `x86-64`. It is still referred to as `x86-64` in plenty of other places (e.g. https://en.wikipedia.org/wiki/X86-64)
- If we pretend that prerelease versions don't exist, and applications with more than one word don't exist, I probably prefer:

```
configlet-4.0.0-linux-x86_64.tar.gz
```
 
to this PR's:

```
configlet_4.0.0_linux_x86-64.tar.gz
```

---

To allow the `fetch-configlet` workflow to pass, I have added assets with the new naming format to the [configlet 4.0.0-beta.7 release](https://github.com/exercism/configlet/releases/tag/4.0.0-beta.7) - they're copies of the existing assets, with the same checksums.

Before we create a release that includes this PR, we need to:

- update the `fetch-configlet` script used by the org-wide configlet workflow.
- and create and merge a PR on every track to update the track-level `fetch-configlet{.ps1}` scripts. We can do this mass PR either:
   - manually
   - or by adding `fetch-configlet` to `org-wide-files` (tracked in https://github.com/exercism/org-wide-files/issues/262)

But for some period of time, we should keep assets with the old naming format in releases. Then an out-of-date `fetch-configlet` script will continue to work.