### PR TITLE
config: change `styleCheck` hints into errors again

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,4 +1,4 @@
-switch("styleCheck", "hint")
+switch("styleCheck", "error")
 hint("Name", on)
 # switch("experimental", "strictEffects") # TODO: re-enable when possible with `parsetoml`
 switch("experimental", "strictFuncs")


### PR DESCRIPTION
We needed commit 927ad806a45e because `nimble build` would previously error for a `styleCheck` problem in a Nimble package that we import. However, from Nim 1.6.8 (2022-09-27) onwards, `styleCheck` [only applies to the current package](https://github.com/nim-lang/Nim/commit/c484943cab39).

So let's turn `styleCheck` problems into errors again, which now just means that `nimble build` errors if code in the configlet repo either:

- declares an identifier using a style that violates the first point in the [NEP-1 naming conventions](https://github.com/nim-lang/Nim/blob/e03a178bff6b/doc/nep1.md#naming-conventions)
- or refers to an identifier using a style that is different to the declaration style.

Closes: #16

---

I've also checked this with Nim 1.6.10 RC2 (changes [here](https://github.com/nim-lang/Nim/compare/v1.6.8...version-1-6)), as there was a [styleCheck regression in 1.6.8](https://github.com/nim-lang/Nim/commit/31fe32afd11e2a638e954e42b6e21607efbbdc26).