### PR TITLE
.github(workflows), nimble: bump Nim from 1.6.8 to 1.6.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@560f0647083257e632182be888862d69eeb6f2c4
         with:
-          version: "binary:1.6.8"
+          version: "binary:1.6.10"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@560f0647083257e632182be888862d69eeb6f2c4
         with:
-          version: "binary:1.6.8"
+          version: "binary:1.6.10"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -18,7 +18,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 1.6.8"
+requires "nim >= 1.6.10"
 requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"      # 1.5.19 (2021-09-13)
 requires "jsony#2a2cc4331720b7695c8b66529dbfea6952727e7b"       # 1.1.3  (2022-01-03)
 requires "parsetoml#9cdeb3f65fd10302da157db8a8bac5c42f055249"   # 0.6.0  (2021-06-07)


### PR DESCRIPTION
See the [release blog post](https://nim-lang.org/blog/2022/11/23/version-1610-released.html) and [changes since 1.6.8](https://github.com/nim-lang/Nim/compare/v1.6.8...version-1-6).

---

To-do:

- [x] Wait for Nim 1.6.10 release
- [x] Update `iffy/install-nim`
- [x] Merge #709
- [x] Rebase on `main`
 
Previous Nim bump: https://github.com/exercism/configlet/pull/666

Command run:

```shell
git ls-files -z | xargs -0 sed -i 's/1.6.8/1.6.10/g'  
```

Double checking:

```console
$ git rev-parse --short HEAD
1a5b35d7
$ git grep --break --heading '1\.6'
.github/workflows/build.yml
42:          version: "binary:1.6.10"

.github/workflows/tests.yml
45:          version: "binary:1.6.10"

configlet.nimble
21:requires "nim >= 1.6.10"
```