### PR TITLE
.github(workflows): bump `iffy/install-nim` from 4.4.0 to 4.5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         run: ./.github/bin/linux-install-build-tools
 
       - name: Install Nim
-        uses: iffy/install-nim@1ab2fcc1d8294b3956d5696f45cd470c9fe69466
+        uses: iffy/install-nim@560f0647083257e632182be888862d69eeb6f2c4
         with:
           version: "binary:1.6.8"
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./.github/bin/linux-install-build-tools
 
       - name: Install Nim
-        uses: iffy/install-nim@1ab2fcc1d8294b3956d5696f45cd470c9fe69466
+        uses: iffy/install-nim@560f0647083257e632182be888862d69eeb6f2c4
         with:
           version: "binary:1.6.8"
         env:


### PR DESCRIPTION
Support Nim 1.6.10 (2022-11-23).

See the [changelog][changelog] and [commits][changes] since our previously used version.

[changelog]: https://github.com/iffy/install-nim/blob/560f06470832/CHANGELOG.md
[changes]: https://github.com/iffy/install-nim/compare/1ab2fcc1d829...560f06470832