### PR TITLE
fmt, lint: support `representer` key in exercise `config.json`

### DIFF
--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -3,10 +3,10 @@ import ".."/helpers
 import "."/validators
 
 proc hasValidRepresenter(data: JsonNode; path: Path): bool =
-  const s = "representer"
-  if data.hasKey(s):
-    if hasObject(data, s, path):
-      result = hasInteger(data[s], "version", path, s, isRequired = true,
+  const k = "representer"
+  if data.hasKey(k):
+    if hasObject(data, k, path):
+      result = hasInteger(data[k], "version", path, k, isRequired = true,
                           allowed = 1..int.high)
 
 proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -7,7 +7,7 @@ proc hasValidRepresenter(data: JsonNode; path: Path): bool =
   if data.hasKey(k):
     if hasObject(data, k, path):
       result = hasInteger(data[k], "version", path, k, isRequired = true,
-                          allowed = 1..int.high)
+                          allowed = 1..1000)
   else:
     result = true
 

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -8,6 +8,8 @@ proc hasValidRepresenter(data: JsonNode; path: Path): bool =
     if hasObject(data, k, path):
       result = hasInteger(data[k], "version", path, k, isRequired = true,
                           allowed = 1..int.high)
+  else:
+    result = true
 
 proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
   const k = "files"

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -2,6 +2,12 @@ import std/[json, os]
 import ".."/helpers
 import "."/validators
 
+proc hasValidRepresenter(data: JsonNode; path: Path): bool =
+  const s = "representer"
+  if data.hasKey(s):
+    if hasObject(data, s, path):
+      result = hasInteger(data[s], "version", path, s, isRequired = true, allowed = 1..int.high)
+
 proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
   const k = "files"
   if hasObject(data, k, path):
@@ -30,6 +36,7 @@ proc isValidConceptExerciseConfig(data: JsonNode;
       hasArrayOfStrings(data, "forked_from", path, isRequired = false,
                         uniqueValues = true),
       hasString(data, "language_versions", path, isRequired = false),
+      hasValidRepresenter(data, path),
       hasString(data, "icon", path, isRequired = false, checkIsKebab = true),
     ]
     result = allTrue(checks)

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -6,7 +6,8 @@ proc hasValidRepresenter(data: JsonNode; path: Path): bool =
   const s = "representer"
   if data.hasKey(s):
     if hasObject(data, s, path):
-      result = hasInteger(data[s], "version", path, s, isRequired = true, allowed = 1..int.high)
+      result = hasInteger(data[s], "version", path, s, isRequired = true,
+                          allowed = 1..int.high)
 
 proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
   const k = "files"

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -3,10 +3,10 @@ import ".."/helpers
 import "."/validators
 
 proc hasValidRepresenter(data: JsonNode; path: Path): bool =
-  const s = "representer"
-  if data.hasKey(s):
-    if hasObject(data, s, path):
-      result = hasInteger(data[s], "version", path, s, isRequired = true,
+  const k = "representer"
+  if data.hasKey(k):
+    if hasObject(data, k, path):
+      result = hasInteger(data[k], "version", path, k, isRequired = true,
                           allowed = 1..int.high)
 
 proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -7,7 +7,7 @@ proc hasValidRepresenter(data: JsonNode; path: Path): bool =
   if data.hasKey(k):
     if hasObject(data, k, path):
       result = hasInteger(data[k], "version", path, k, isRequired = true,
-                          allowed = 1..int.high)
+                          allowed = 1..1000)
   else:
     result = true
 

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -8,6 +8,8 @@ proc hasValidRepresenter(data: JsonNode; path: Path): bool =
     if hasObject(data, k, path):
       result = hasInteger(data[k], "version", path, k, isRequired = true,
                           allowed = 1..int.high)
+  else:
+    result = true
 
 proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
   const k = "files"

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -39,7 +39,7 @@ proc isValidPracticeExerciseConfig(data: JsonNode;
       hasValidFiles(data, path, exerciseDir),
       hasString(data, "language_versions", path, isRequired = false),
       hasBoolean(data, "test_runner", path, isRequired = false),
-      hasValidRepresenter(data, path)
+      hasValidRepresenter(data, path),
     ]
     result = allTrue(checks)
 

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -2,6 +2,12 @@ import std/[json, os]
 import ".."/helpers
 import "."/validators
 
+proc hasValidRepresenter(data: JsonNode; path: Path): bool =
+  const s = "representer"
+  if data.hasKey(s):
+    if hasObject(data, s, path):
+      result = hasInteger(data[s], "version", path, s, isRequired = true, allowed = 1..int.high)
+
 proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
   const k = "files"
   if hasObject(data, k, path):
@@ -30,6 +36,7 @@ proc isValidPracticeExerciseConfig(data: JsonNode;
       hasValidFiles(data, path, exerciseDir),
       hasString(data, "language_versions", path, isRequired = false),
       hasBoolean(data, "test_runner", path, isRequired = false),
+      hasValidRepresenter(data, path)
     ]
     result = allTrue(checks)
 

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -6,7 +6,8 @@ proc hasValidRepresenter(data: JsonNode; path: Path): bool =
   const s = "representer"
   if data.hasKey(s):
     if hasObject(data, s, path):
-      result = hasInteger(data[s], "version", path, s, isRequired = true, allowed = 1..int.high)
+      result = hasInteger(data[s], "version", path, s, isRequired = true,
+                          allowed = 1..int.high)
 
 proc hasValidFiles(data: JsonNode; path, exerciseDir: Path): bool =
   const k = "files"

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -262,8 +262,7 @@ func addFiles(s: var string; val: ConceptExerciseFiles | PracticeExerciseFiles;
   s.addNewlineAndIndent(indentLevel)
   s.add "},"
 
-func addRepresenter(s: var string; val: Representer;
-                    prettyMode: PrettyMode; indentLevel = 1) =
+func addRepresenter(s: var string; val: Representer; indentLevel = 1) =
   ## Appends the pretty-printed JSON for a `representer` key with value `val` to
   ## `s`.
   s.addNewlineAndIndent(indentLevel)
@@ -405,7 +404,7 @@ proc pretty*(e: ConceptExerciseConfig | PracticeExerciseConfig,
         addValOrNull(test_runner, addBool)
     of eckRepresenter:
       if e.representer.isSome():
-        result.addRepresenter(e.representer.get(), prettyMode);
+        result.addRepresenter(e.representer.get());
     of eckBlurb:
       result.addString("blurb", e.blurb)
     of eckSource:

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -264,7 +264,8 @@ func addFiles(s: var string; val: ConceptExerciseFiles | PracticeExerciseFiles;
 
 func addRepresenter(s: var string; val: Representer;
                     prettyMode: PrettyMode; indentLevel = 1) =
-  ## Appends the pretty-printed JSON for a `files` key with value `val` to `s`.
+  ## Appends the pretty-printed JSON for a `representer` key with value `val` to
+  ## `s`.
   s.addNewlineAndIndent(indentLevel)
   escapeJson("representer", s)
   s.add ": {"

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -180,6 +180,14 @@ func addBool(s: var string; key: string; val: bool; indentLevel = 1) =
     s.add "false"
   s.add ','
 
+func addInt(s: var string; key: string; val: int; indentLevel = 1) =
+  ## Appends the pretty-printed JSON for a `key` and its int `val` to `s`.
+  s.addNewlineAndIndent(indentLevel)
+  escapeJson(key, s)
+  s.add ": "
+  s.add $val
+  s.add ','
+
 func removeComma(s: var string) =
   ## Removes the final character from `s`, if that character is a comma.
   if s[^1] == ',':
@@ -254,6 +262,17 @@ func addFiles(s: var string; val: ConceptExerciseFiles | PracticeExerciseFiles;
   s.addNewlineAndIndent(indentLevel)
   s.add "},"
 
+func addRepresenter(s: var string; val: Representer;
+                    prettyMode: PrettyMode; indentLevel = 1) =
+  ## Appends the pretty-printed JSON for a `files` key with value `val` to `s`.
+  s.addNewlineAndIndent(indentLevel)
+  escapeJson("representer", s)
+  s.add ": {"
+  s.addInt("version", val.version, indentLevel = indentLevel + 1)
+  s.removeComma()
+  s.addNewlineAndIndent(indentLevel)
+  s.add "},"
+
 proc addObject(s: var string; key: string; val: JsonNode; indentLevel = 1) =
   ## Appends the pretty-printed JSON for a `key` and its JSON object `val` to
   ## `s`.
@@ -323,6 +342,8 @@ func keyOrderForFmt(e: ConceptExerciseConfig |
     # Strips `"test_runner": true`.
     if e.test_runner.isSome() and not e.test_runner.get():
       result.add eckTestRunner
+  if e.representer.isSome():
+    result.add eckRepresenter
   result.add eckBlurb
   if e.source.isSome():
     result.add eckSource
@@ -381,6 +402,9 @@ proc pretty*(e: ConceptExerciseConfig | PracticeExerciseConfig,
     of eckTestRunner:
       when e is PracticeExerciseConfig:
         addValOrNull(test_runner, addBool)
+    of eckRepresenter:
+      if e.representer.isSome():
+        result.addRepresenter(e.representer.get(), prettyMode);
     of eckBlurb:
       result.addString("blurb", e.blurb)
     of eckSource:

--- a/src/types_exercise_config.nim
+++ b/src/types_exercise_config.nim
@@ -61,6 +61,7 @@ type
     eckForkedFrom = "forked_from"
     eckIcon = "icon"
     eckTestRunner = "test_runner"
+    eckRepresenter = "representer"
     eckBlurb = "blurb"
     eckSource = "source"
     eckSourceUrl = "source_url"
@@ -73,6 +74,9 @@ type
     fkExample = "example"
     fkEditor = "editor"
     fkInvalidator = "invalidator"
+
+  Representer* = object
+    version*: int
 
   ConceptExerciseFiles* = object
     originalKeyOrder*: seq[FilesKey]
@@ -96,6 +100,7 @@ type
     contributors*: Option[seq[string]]
     files*: ConceptExerciseFiles
     language_versions*: string
+    representer*: Option[Representer]
     forked_from*: Option[seq[string]] ## Allowed only for a Concept Exercise.
     icon*: string                     ## Allowed only for a Concept Exercise.
     blurb*: string
@@ -110,6 +115,7 @@ type
     files*: PracticeExerciseFiles
     language_versions*: string
     test_runner*: Option[bool] ## Allowed only for a Practice Exercise.
+    representer*: Option[Representer]
     # The below fields are synced for a Practice Exercise that exists in the
     # `exercism/problem-specifications` repo.
     blurb*: string

--- a/tests/test_fmt.nim
+++ b/tests/test_fmt.nim
@@ -72,8 +72,8 @@ proc testFmt =
     test "omits optional keys that have an empty value - Concept Exercise":
       let p = ConceptExerciseConfig(
         originalKeyOrder: @[eckContributors, eckFiles, eckLanguageVersions,
-                            eckForkedFrom, eckIcon, eckSource, eckSourceUrl,
-                            eckCustom],
+                            eckForkedFrom, eckIcon, eckRepresenter, eckSource,
+                            eckSourceUrl, eckCustom],
         contributors: some(newSeq[string]()),
         files: ConceptExerciseFiles(
           originalKeyOrder: @[fkEditor],
@@ -96,7 +96,7 @@ proc testFmt =
     test "omits optional keys that have an empty value - Practice Exercise":
       let p = PracticeExerciseConfig(
         originalKeyOrder: @[eckContributors, eckFiles, eckLanguageVersions,
-                            eckSource, eckSourceUrl, eckCustom],
+                            eckRepresenter, eckSource, eckSourceUrl, eckCustom],
         contributors: some(newSeq[string]()),
         files: PracticeExerciseFiles(
           originalKeyOrder: @[fkEditor],
@@ -135,7 +135,7 @@ proc testFmt =
         var exerciseConfig = ConceptExerciseConfig(
           originalKeyOrder: @[eckAuthors, eckContributors, eckFiles,
                               eckLanguageVersions, eckForkedFrom, eckIcon,
-                              eckBlurb, eckSource, eckSourceUrl,
+                              eckRepresenter, eckBlurb, eckSource, eckSourceUrl,
                               eckCustom],
           authors: @["author1"],
           contributors: some(@["contributor1"]),
@@ -149,6 +149,7 @@ proc testFmt =
           language_versions: ">=1.2.3",
           forked_from: some(@["bar/lovely-lasagna"]),
           icon: "myicon",
+          representer: some(Representer(version: 42)),
           blurb: "Learn about the basics of Foo by following a lasagna recipe.",
           source: some("mysource"),
           source_url: some("https://example.com"),
@@ -180,6 +181,9 @@ proc testFmt =
             "bar/lovely-lasagna"
           ],
           "icon": "myicon",
+          "representer": {
+            "version": 42
+          },
           "blurb": "Learn about the basics of Foo by following a lasagna recipe.",
           "source": "mysource",
           "source_url": "https://example.com",
@@ -214,7 +218,7 @@ proc testFmt =
         var exerciseConfig = PracticeExerciseConfig(
           originalKeyOrder: @[eckAuthors, eckContributors, eckFiles,
                               eckLanguageVersions, eckTestRunner,
-                              eckBlurb, eckSource, eckSourceUrl,
+                              eckRepresenter, eckBlurb, eckSource, eckSourceUrl,
                               eckCustom],
           authors: @["author1"],
           contributors: some(@["contributor1"]),
@@ -227,6 +231,7 @@ proc testFmt =
           ),
           language_versions: ">=1.2.3",
           test_runner: some(false),
+          representer: some(Representer(version: 42)),
           blurb: "Write a function that returns the earned points in a single toss of a Darts game.",
           source: some("Inspired by an exercise created by a professor Della Paolera in Argentina"),
           source_url: some("https://example.com"),
@@ -255,6 +260,9 @@ proc testFmt =
           },
           "language_versions": ">=1.2.3",
           "test_runner": false,
+          "representer": {
+            "version": 42
+          },
           "blurb": "Write a function that returns the earned points in a single toss of a Darts game.",
           "source": "Inspired by an exercise created by a professor Della Paolera in Argentina",
           "source_url": "https://example.com",

--- a/tests/test_fmt.nim
+++ b/tests/test_fmt.nim
@@ -336,6 +336,8 @@ proc testFmt =
           # Strip `"test_runner": true`
           if val.kind == JNull or (val.kind == JBool and val.getBool()):
             delete(j, "test_runner")
+        if j["representer"].kind != JObject or j["representer"].len == 0:
+          delete(j, "representer")
         for k in ["language_versions", "source", "source_url"]:
           if j[k].getStr().len == 0:
             delete(j, k)

--- a/tests/test_sync.nim
+++ b/tests/test_sync.nim
@@ -144,7 +144,8 @@ proc testSyncCommon =
       let exerciseConfig = ConceptExerciseConfig(
         originalKeyOrder: @[eckAuthors, eckContributors, eckFiles,
                             eckLanguageVersions, eckForkedFrom, eckIcon,
-                            eckBlurb, eckSource, eckSourceUrl, eckCustom],
+                            eckRepresenter, eckBlurb, eckSource, eckSourceUrl,
+                            eckCustom],
         authors: @["author1"],
         contributors: some(@["contributor1"]),
         files: ConceptExerciseFiles(
@@ -157,6 +158,7 @@ proc testSyncCommon =
         language_versions: ">=1.2.3",
         forked_from: some(@["bar/lovely-lasagna"]),
         icon: "myicon",
+        representer: some(Representer(version: 42)),
         blurb: "Learn about the basics of Foo by following a lasagna recipe.",
         source: some("mysource"),
         source_url: some("https://example.com"),
@@ -188,6 +190,9 @@ proc testSyncCommon =
           "bar/lovely-lasagna"
         ],
         "icon": "myicon",
+        "representer": {
+          "version": 42
+        },
         "blurb": "Learn about the basics of Foo by following a lasagna recipe.",
         "source": "mysource",
         "source_url": "https://example.com",
@@ -217,7 +222,7 @@ proc testSyncCommon =
     test "populated Practice Exercise":
       let exerciseConfig = PracticeExerciseConfig(
         originalKeyOrder: @[eckAuthors, eckContributors, eckFiles,
-                            eckLanguageVersions, eckTestRunner,
+                            eckLanguageVersions, eckTestRunner, eckRepresenter,
                             eckBlurb, eckSource, eckSourceUrl, eckCustom],
         authors: @["author1"],
         contributors: some(@["contributor1"]),
@@ -230,6 +235,7 @@ proc testSyncCommon =
         ),
         language_versions: ">=1.2.3",
         test_runner: some(false),
+        representer: some(Representer(version: 42)),
         blurb: "Write a function that returns the earned points in a single toss of a Darts game.",
         source: some("Inspired by an exercise created by a professor Della Paolera in Argentina"),
         source_url: some("https://example.com"),
@@ -258,6 +264,9 @@ proc testSyncCommon =
         },
         "language_versions": ">=1.2.3",
         "test_runner": false,
+        "representer": {
+          "version": 42
+        },
         "blurb": "Write a function that returns the earned points in a single toss of a Darts game.",
         "source": "Inspired by an exercise created by a professor Della Paolera in Argentina",
         "source_url": "https://example.com",


### PR DESCRIPTION
See https://github.com/exercism/docs/commit/24881b8ed14b9ad03aa0f0a1d36e1309b4b5ff5a

@ee7 I've not bothered with individual commits, as I was unsure how to structure it. I'm happy for you to tweak it as desired.
