### PR TITLE
fmt, lint: support `icon` key for practice exercise `config.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,8 +329,8 @@ The canonical key order for an exercise `.meta/config.json` file is:
   - [invalidator]
 - [language_versions]
 - [forked_from]        (Concept Exercises only)
-- [icon]               (Concept Exercises only)
 - [test_runner]        (Practice Exercises only)
+- [icon]
 - blurb
 - [source]
 - [source_url]

--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ The canonical key order for an exercise `.meta/config.json` file is:
 - [language_versions]
 - [forked_from]        (Concept Exercises only)
 - [test_runner]        (Practice Exercises only)
+- [representer]
+  - version
 - [icon]
 - blurb
 - [source]

--- a/src/lint/concept_exercises.nim
+++ b/src/lint/concept_exercises.nim
@@ -36,9 +36,9 @@ proc isValidConceptExerciseConfig(data: JsonNode;
       hasArrayOfStrings(data, "contributors", path, isRequired = false,
                         uniqueValues = true),
       hasValidFiles(data, path, exerciseDir),
+      hasString(data, "language_versions", path, isRequired = false),
       hasArrayOfStrings(data, "forked_from", path, isRequired = false,
                         uniqueValues = true),
-      hasString(data, "language_versions", path, isRequired = false),
       hasValidRepresenter(data, path),
       hasString(data, "icon", path, isRequired = false, checkIsKebab = true),
     ]

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -38,9 +38,9 @@ proc isValidPracticeExerciseConfig(data: JsonNode;
                         uniqueValues = true),
       hasValidFiles(data, path, exerciseDir),
       hasString(data, "language_versions", path, isRequired = false),
-      hasString(data, "icon", path, isRequired = false, checkIsKebab = true),
       hasBoolean(data, "test_runner", path, isRequired = false),
       hasValidRepresenter(data, path),
+      hasString(data, "icon", path, isRequired = false, checkIsKebab = true),
     ]
     result = allTrue(checks)
 

--- a/src/lint/practice_exercises.nim
+++ b/src/lint/practice_exercises.nim
@@ -38,6 +38,7 @@ proc isValidPracticeExerciseConfig(data: JsonNode;
                         uniqueValues = true),
       hasValidFiles(data, path, exerciseDir),
       hasString(data, "language_versions", path, isRequired = false),
+      hasString(data, "icon", path, isRequired = false, checkIsKebab = true),
       hasBoolean(data, "test_runner", path, isRequired = false),
       hasValidRepresenter(data, path),
     ]

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -396,14 +396,14 @@ proc pretty*(e: ConceptExerciseConfig | PracticeExerciseConfig,
     of eckForkedFrom:
       when e is ConceptExerciseConfig:
         addValOrNull(forked_from, addArray)
-    of eckIcon:
-      result.addString("icon", e.icon)
     of eckTestRunner:
       when e is PracticeExerciseConfig:
         addValOrNull(test_runner, addBool)
     of eckRepresenter:
       if e.representer.isSome():
         result.addRepresenter(e.representer.get());
+    of eckIcon:
+      result.addString("icon", e.icon)
     of eckBlurb:
       result.addString("blurb", e.blurb)
     of eckSource:

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -336,14 +336,14 @@ func keyOrderForFmt(e: ConceptExerciseConfig |
   when e is ConceptExerciseConfig:
     if e.forked_from.isSome() and e.forked_from.get().len > 0:
       result.add eckForkedFrom
-    if e.icon.len > 0:
-      result.add eckIcon
   when e is PracticeExerciseConfig:
     # Strips `"test_runner": true`.
     if e.test_runner.isSome() and not e.test_runner.get():
       result.add eckTestRunner
   if e.representer.isSome():
     result.add eckRepresenter
+  if e.icon.len > 0:
+    result.add eckIcon
   result.add eckBlurb
   if e.source.isSome():
     result.add eckSource
@@ -397,8 +397,7 @@ proc pretty*(e: ConceptExerciseConfig | PracticeExerciseConfig,
       when e is ConceptExerciseConfig:
         addValOrNull(forked_from, addArray)
     of eckIcon:
-      when e is ConceptExerciseConfig:
-        result.addString("icon", e.icon)
+      result.addString("icon", e.icon)
     of eckTestRunner:
       when e is PracticeExerciseConfig:
         addValOrNull(test_runner, addBool)

--- a/src/types_exercise_config.nim
+++ b/src/types_exercise_config.nim
@@ -102,7 +102,7 @@ type
     language_versions*: string
     representer*: Option[Representer]
     forked_from*: Option[seq[string]] ## Allowed only for a Concept Exercise.
-    icon*: string                     ## Allowed only for a Concept Exercise.
+    icon*: string
     blurb*: string
     source*: Option[string]
     source_url*: Option[string]
@@ -116,6 +116,7 @@ type
     language_versions*: string
     test_runner*: Option[bool] ## Allowed only for a Practice Exercise.
     representer*: Option[Representer]
+    icon*: string
     # The below fields are synced for a Practice Exercise that exists in the
     # `exercism/problem-specifications` repo.
     blurb*: string

--- a/src/types_exercise_config.nim
+++ b/src/types_exercise_config.nim
@@ -19,9 +19,9 @@ type
   #     case kind*: ExerciseKind
   #     of ekConcept:
   #       forked_from: Option[seq[string]]
-  #       icon: string
   #     of ekPractice:
   #       test_runner: Option[bool]
+  #     icon: string
   #     blurb*: string
   #     source*: string
   #     source_url*: string
@@ -59,9 +59,9 @@ type
     eckFiles = "files"
     eckLanguageVersions = "language_versions"
     eckForkedFrom = "forked_from"
-    eckIcon = "icon"
     eckTestRunner = "test_runner"
     eckRepresenter = "representer"
+    eckIcon = "icon"
     eckBlurb = "blurb"
     eckSource = "source"
     eckSourceUrl = "source_url"

--- a/src/types_exercise_config.nim
+++ b/src/types_exercise_config.nim
@@ -100,8 +100,8 @@ type
     contributors*: Option[seq[string]]
     files*: ConceptExerciseFiles
     language_versions*: string
-    representer*: Option[Representer]
     forked_from*: Option[seq[string]] ## Allowed only for a Concept Exercise.
+    representer*: Option[Representer]
     icon*: string
     blurb*: string
     source*: Option[string]

--- a/tests/test_fmt.nim
+++ b/tests/test_fmt.nim
@@ -72,7 +72,7 @@ proc testFmt =
     test "omits optional keys that have an empty value - Concept Exercise":
       let p = ConceptExerciseConfig(
         originalKeyOrder: @[eckContributors, eckFiles, eckLanguageVersions,
-                            eckForkedFrom, eckIcon, eckRepresenter, eckSource,
+                            eckForkedFrom, eckRepresenter, eckIcon, eckSource,
                             eckSourceUrl, eckCustom],
         contributors: some(newSeq[string]()),
         files: ConceptExerciseFiles(
@@ -96,7 +96,8 @@ proc testFmt =
     test "omits optional keys that have an empty value - Practice Exercise":
       let p = PracticeExerciseConfig(
         originalKeyOrder: @[eckContributors, eckFiles, eckLanguageVersions,
-                            eckRepresenter, eckSource, eckSourceUrl, eckCustom],
+                            eckRepresenter, eckIcon, eckSource, eckSourceUrl,
+                            eckCustom],
         contributors: some(newSeq[string]()),
         files: PracticeExerciseFiles(
           originalKeyOrder: @[fkEditor],
@@ -148,8 +149,8 @@ proc testFmt =
           ),
           language_versions: ">=1.2.3",
           forked_from: some(@["bar/lovely-lasagna"]),
-          icon: "myicon",
           representer: some(Representer(version: 42)),
+          icon: "myicon",
           blurb: "Learn about the basics of Foo by following a lasagna recipe.",
           source: some("mysource"),
           source_url: some("https://example.com"),
@@ -180,10 +181,10 @@ proc testFmt =
           "forked_from": [
             "bar/lovely-lasagna"
           ],
-          "icon": "myicon",
           "representer": {
             "version": 42
           },
+          "icon": "myicon",
           "blurb": "Learn about the basics of Foo by following a lasagna recipe.",
           "source": "mysource",
           "source_url": "https://example.com",
@@ -217,7 +218,7 @@ proc testFmt =
       test "populated config with random key order - Practice Exercise":
         var exerciseConfig = PracticeExerciseConfig(
           originalKeyOrder: @[eckAuthors, eckContributors, eckFiles,
-                              eckLanguageVersions, eckTestRunner,
+                              eckLanguageVersions, eckTestRunner, eckIcon,
                               eckRepresenter, eckBlurb, eckSource, eckSourceUrl,
                               eckCustom],
           authors: @["author1"],
@@ -231,6 +232,7 @@ proc testFmt =
           ),
           language_versions: ">=1.2.3",
           test_runner: some(false),
+          icon: "myicon",
           representer: some(Representer(version: 42)),
           blurb: "Write a function that returns the earned points in a single toss of a Darts game.",
           source: some("Inspired by an exercise created by a professor Della Paolera in Argentina"),
@@ -263,6 +265,7 @@ proc testFmt =
           "representer": {
             "version": 42
           },
+          "icon": "myicon",
           "blurb": "Write a function that returns the earned points in a single toss of a Darts game.",
           "source": "Inspired by an exercise created by a professor Della Paolera in Argentina",
           "source_url": "https://example.com",

--- a/tests/test_fmt.nim
+++ b/tests/test_fmt.nim
@@ -337,8 +337,6 @@ proc testFmt =
           let val = j["forked_from"]
           if val.kind == JNull or (val.kind == JArray and val.len == 0):
             delete(j, "forked_from")
-          if j["icon"].getStr().len == 0:
-            delete(j, "icon")
         when e is PracticeExerciseConfig:
           let val = j["test_runner"]
           # Strip `"test_runner": true`
@@ -346,6 +344,8 @@ proc testFmt =
             delete(j, "test_runner")
         if j["representer"].kind != JObject or j["representer"].len == 0:
           delete(j, "representer")
+        if j["icon"].getStr().len == 0:
+            delete(j, "icon")
         for k in ["language_versions", "source", "source_url"]:
           if j[k].getStr().len == 0:
             delete(j, k)

--- a/tests/test_sync.nim
+++ b/tests/test_sync.nim
@@ -222,8 +222,9 @@ proc testSyncCommon =
     test "populated Practice Exercise":
       let exerciseConfig = PracticeExerciseConfig(
         originalKeyOrder: @[eckAuthors, eckContributors, eckFiles,
-                            eckLanguageVersions, eckTestRunner, eckRepresenter,
-                            eckBlurb, eckSource, eckSourceUrl, eckCustom],
+                            eckLanguageVersions, eckTestRunner, eckIcon,
+                            eckRepresenter, eckBlurb, eckSource, eckSourceUrl,
+                            eckCustom],
         authors: @["author1"],
         contributors: some(@["contributor1"]),
         files: PracticeExerciseFiles(
@@ -235,6 +236,7 @@ proc testSyncCommon =
         ),
         language_versions: ">=1.2.3",
         test_runner: some(false),
+        icon: "myicon",
         representer: some(Representer(version: 42)),
         blurb: "Write a function that returns the earned points in a single toss of a Darts game.",
         source: some("Inspired by an exercise created by a professor Della Paolera in Argentina"),
@@ -264,6 +266,7 @@ proc testSyncCommon =
         },
         "language_versions": ">=1.2.3",
         "test_runner": false,
+        "icon": "myicon",
         "representer": {
           "version": 42
         },


### PR DESCRIPTION
See https://github.com/exercism/docs/pull/421