### PR TITLE
.github, config, json, nimble: bump Nim from 1.6.12 to 2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@ac410af52523f06e0fa037ee81d06ead7b95692c
         with:
-          version: "binary:1.6.12"
+          version: "binary:2.0.0"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@ac410af52523f06e0fa037ee81d06ead7b95692c
         with:
-          version: "binary:1.6.12"
+          version: "binary:2.0.0"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/config.nims
+++ b/config.nims
@@ -1,6 +1,8 @@
 switch("styleCheck", "error")
 hint("Name", on)
 warning("BareExcept", off)
+warning("ProveInit", off)
+warning("Uninit", off)
 switch("experimental", "strictEffects")
 switch("experimental", "strictFuncs")
 switch("define", "nimStrictDelete")

--- a/config.nims
+++ b/config.nims
@@ -3,7 +3,6 @@ hint("Name", on)
 warning("BareExcept", off)
 warning("ProveInit", off)
 warning("Uninit", off)
-switch("experimental", "strictEffects")
 switch("experimental", "strictFuncs")
 switch("define", "nimStrictDelete")
 when defined(nimHasOutParams):

--- a/config.nims
+++ b/config.nims
@@ -3,10 +3,9 @@ hint("Name", on)
 warning("BareExcept", off)
 warning("ProveInit", off)
 warning("Uninit", off)
+switch("experimental", "strictDefs")
 switch("experimental", "strictFuncs")
 switch("define", "nimStrictDelete")
-when defined(nimHasOutParams):
-  switch("experimental", "strictDefs")
 switch("mm", "refc")
 
 # Replace the stdlib JSON modules with our own stricter versions.

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -16,7 +16,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 1.6.12"
+requires "nim >= 2.0.0"
 requires "jsony#ea811bec7fa50f5abd3088ba94cda74285e93f18"       # 1.1.5  (2023-02-09)
 requires "parsetoml#6e5e16179fa2db60f2f37d8b1af4128aaa9c8aaf"   # 0.7.1  (2023-08-06)
 requires "supersnappy#e4df8cb5468dd96fc5a4764028e20c8a3942f16a" # 2.1.3  (2022-06-12)

--- a/src/patched_stdlib/json.nim
+++ b/src/patched_stdlib/json.nim
@@ -1,5 +1,5 @@
 # This file is minimally adapted from this version in the Nim standard library:
-# https://github.com/nim-lang/Nim/blob/b6bfe38ff528/lib/pure/json.nim
+# https://github.com/nim-lang/Nim/blob/a488067a4130/lib/pure/json.nim
 # The standard library version is lenient: it silently allows a trailing comma.
 # The below version is stricter: it raises a `JsonParsingError` for a trailing
 # comma.
@@ -455,7 +455,7 @@ macro `%*`*(x: untyped): untyped =
   ## `%` for every element.
   result = toJsonImpl(x)
 
-proc `==`*(a, b: JsonNode): bool {.noSideEffect.} =
+proc `==`*(a, b: JsonNode): bool {.noSideEffect, raises: [].} =
   ## Check two nodes for equality
   if a.isNil:
     if b.isNil: return true
@@ -475,18 +475,20 @@ proc `==`*(a, b: JsonNode): bool {.noSideEffect.} =
     of JNull:
       result = true
     of JArray:
-      result = a.elems == b.elems
+      {.cast(raises: []).}: # bug #19303
+        result = a.elems == b.elems
     of JObject:
       # we cannot use OrderedTable's equality here as
       # the order does not matter for equality here.
       if a.fields.len != b.fields.len: return false
       for key, val in a.fields:
         if not b.fields.hasKey(key): return false
-        when defined(nimHasEffectsOf):
-          {.noSideEffect.}:
+        {.cast(raises: []).}:
+          when defined(nimHasEffectsOf):
+            {.noSideEffect.}:
+              if b.fields[key] != val: return false
+          else:
             if b.fields[key] != val: return false
-        else:
-          if b.fields[key] != val: return false
       result = true
 
 proc hash*(n: OrderedTable[string, JsonNode]): Hash {.noSideEffect.}
@@ -872,7 +874,7 @@ proc parseJson(p: var JsonParser; rawIntegers, rawFloats: bool, depth = 0): Json
   case p.tok
   of tkString:
     # we capture 'p.a' here, so we need to give it a fresh buffer afterwards:
-    when defined(gcArc) or defined(gcOrc):
+    when defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc):
       result = JsonNode(kind: JString, str: move p.a)
     else:
       result = JsonNode(kind: JString)
@@ -1082,310 +1084,303 @@ template verifyJsonKind(node: JsonNode, kinds: set[JsonNodeKind],
     ]
     raise newException(JsonKindError, msg)
 
-when defined(nimFixedForwardGeneric):
+macro isRefSkipDistinct*(arg: typed): untyped =
+  ## internal only, do not use
+  var impl = getTypeImpl(arg)
+  if impl.kind == nnkBracketExpr and impl[0].eqIdent("typeDesc"):
+    impl = getTypeImpl(impl[1])
+  while impl.kind == nnkDistinctTy:
+    impl = getTypeImpl(impl[0])
+  result = newLit(impl.kind == nnkRefTy)
 
-  macro isRefSkipDistinct*(arg: typed): untyped =
-    ## internal only, do not use
-    var impl = getTypeImpl(arg)
-    if impl.kind == nnkBracketExpr and impl[0].eqIdent("typeDesc"):
-      impl = getTypeImpl(impl[1])
-    while impl.kind == nnkDistinctTy:
-      impl = getTypeImpl(impl[0])
-    result = newLit(impl.kind == nnkRefTy)
+# The following forward declarations don't work in older versions of Nim
 
-  # The following forward declarations don't work in older versions of Nim
+# forward declare all initFromJson
 
-  # forward declare all initFromJson
+proc initFromJson(dst: var string; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson(dst: var bool; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson(dst: var JsonNode; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson[T: SomeInteger](dst: var T; jsonNode: JsonNode, jsonPath: var string)
+proc initFromJson[T: SomeFloat](dst: var T; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson[T: enum](dst: var T; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson[T](dst: var seq[T]; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson[S, T](dst: var array[S, T]; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson[T](dst: var Table[string, T]; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson[T](dst: var OrderedTable[string, T]; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson[T](dst: var ref T; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson[T](dst: var Option[T]; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson[T: distinct](dst: var T; jsonNode: JsonNode; jsonPath: var string)
+proc initFromJson[T: object|tuple](dst: var T; jsonNode: JsonNode; jsonPath: var string)
 
-  proc initFromJson(dst: var string; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson(dst: var bool; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson(dst: var JsonNode; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson[T: SomeInteger](dst: var T; jsonNode: JsonNode, jsonPath: var string)
-  proc initFromJson[T: SomeFloat](dst: var T; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson[T: enum](dst: var T; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson[T](dst: var seq[T]; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson[S, T](dst: var array[S, T]; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson[T](dst: var Table[string, T]; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson[T](dst: var OrderedTable[string, T]; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson[T](dst: var ref T; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson[T](dst: var Option[T]; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson[T: distinct](dst: var T; jsonNode: JsonNode; jsonPath: var string)
-  proc initFromJson[T: object|tuple](dst: var T; jsonNode: JsonNode; jsonPath: var string)
+# initFromJson definitions
 
-  # initFromJson definitions
+proc initFromJson(dst: var string; jsonNode: JsonNode; jsonPath: var string) =
+  verifyJsonKind(jsonNode, {JString, JNull}, jsonPath)
+  # since strings don't have a nil state anymore, this mapping of
+  # JNull to the default string is questionable. `none(string)` and
+  # `some("")` have the same potentional json value `JNull`.
+  if jsonNode.kind == JNull:
+    dst = ""
+  else:
+    dst = jsonNode.str
 
-  proc initFromJson(dst: var string; jsonNode: JsonNode; jsonPath: var string) =
-    verifyJsonKind(jsonNode, {JString, JNull}, jsonPath)
-    # since strings don't have a nil state anymore, this mapping of
-    # JNull to the default string is questionable. `none(string)` and
-    # `some("")` have the same potentional json value `JNull`.
-    if jsonNode.kind == JNull:
-      dst = ""
+proc initFromJson(dst: var bool; jsonNode: JsonNode; jsonPath: var string) =
+  verifyJsonKind(jsonNode, {JBool}, jsonPath)
+  dst = jsonNode.bval
+
+proc initFromJson(dst: var JsonNode; jsonNode: JsonNode; jsonPath: var string) =
+  if jsonNode == nil:
+    raise newException(KeyError, "key not found: " & jsonPath)
+  dst = jsonNode.copy
+
+proc initFromJson[T: SomeInteger](dst: var T; jsonNode: JsonNode, jsonPath: var string) =
+  when T is uint|uint64 or int.sizeof == 4:
+    verifyJsonKind(jsonNode, {JInt, JString}, jsonPath)
+    case jsonNode.kind
+    of JString:
+      let x = parseBiggestUInt(jsonNode.str)
+      dst = cast[T](x)
     else:
-      dst = jsonNode.str
+      dst = T(jsonNode.num)
+  else:
+    verifyJsonKind(jsonNode, {JInt}, jsonPath)
+    dst = cast[T](jsonNode.num)
 
-  proc initFromJson(dst: var bool; jsonNode: JsonNode; jsonPath: var string) =
-    verifyJsonKind(jsonNode, {JBool}, jsonPath)
-    dst = jsonNode.bval
-
-  proc initFromJson(dst: var JsonNode; jsonNode: JsonNode; jsonPath: var string) =
-    if jsonNode == nil:
-      raise newException(KeyError, "key not found: " & jsonPath)
-    dst = jsonNode.copy
-
-  proc initFromJson[T: SomeInteger](dst: var T; jsonNode: JsonNode, jsonPath: var string) =
-    when T is uint|uint64 or (not defined(js) and int.sizeof == 4):
-      verifyJsonKind(jsonNode, {JInt, JString}, jsonPath)
-      case jsonNode.kind
-      of JString:
-        let x = parseBiggestUInt(jsonNode.str)
-        dst = cast[T](x)
-      else:
-        dst = T(jsonNode.num)
+proc initFromJson[T: SomeFloat](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
+  verifyJsonKind(jsonNode, {JInt, JFloat, JString}, jsonPath)
+  if jsonNode.kind == JString:
+    case jsonNode.str
+    of "nan":
+      let b = NaN
+      dst = T(b)
+      # dst = NaN # would fail some tests because range conversions would cause CT error
+      # in some cases; but this is not a hot-spot inside this branch and backend can optimize this.
+    of "inf":
+      let b = Inf
+      dst = T(b)
+    of "-inf":
+      let b = -Inf
+      dst = T(b)
+    else: raise newException(JsonKindError, "expected 'nan|inf|-inf', got " & jsonNode.str)
+  else:
+    if jsonNode.kind == JFloat:
+      dst = T(jsonNode.fnum)
     else:
-      verifyJsonKind(jsonNode, {JInt}, jsonPath)
-      dst = cast[T](jsonNode.num)
+      dst = T(jsonNode.num)
 
-  proc initFromJson[T: SomeFloat](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
-    if jsonNode.kind == JString:
-      case jsonNode.str
-      of "nan":
-        let b = NaN
-        dst = T(b)
-        # dst = NaN # would fail some tests because range conversions would cause CT error
-        # in some cases; but this is not a hot-spot inside this branch and backend can optimize this.
-      of "inf":
-        let b = Inf
-        dst = T(b)
-      of "-inf":
-        let b = -Inf
-        dst = T(b)
-      else: raise newException(JsonKindError, "expected 'nan|inf|-inf', got " & jsonNode.str)
+proc initFromJson[T: enum](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
+  verifyJsonKind(jsonNode, {JString}, jsonPath)
+  dst = parseEnum[T](jsonNode.getStr)
+
+proc initFromJson[T](dst: var seq[T]; jsonNode: JsonNode; jsonPath: var string) =
+  verifyJsonKind(jsonNode, {JArray}, jsonPath)
+  dst.setLen jsonNode.len
+  let orignalJsonPathLen = jsonPath.len
+  for i in 0 ..< jsonNode.len:
+    jsonPath.add '['
+    jsonPath.addInt i
+    jsonPath.add ']'
+    initFromJson(dst[i], jsonNode[i], jsonPath)
+    jsonPath.setLen orignalJsonPathLen
+
+proc initFromJson[S,T](dst: var array[S,T]; jsonNode: JsonNode; jsonPath: var string) =
+  verifyJsonKind(jsonNode, {JArray}, jsonPath)
+  let originalJsonPathLen = jsonPath.len
+  for i in 0 ..< jsonNode.len:
+    jsonPath.add '['
+    jsonPath.addInt i
+    jsonPath.add ']'
+    initFromJson(dst[i.S], jsonNode[i], jsonPath) # `.S` for enum indexed arrays
+    jsonPath.setLen originalJsonPathLen
+
+proc initFromJson[T](dst: var Table[string,T]; jsonNode: JsonNode; jsonPath: var string) =
+  dst = initTable[string, T]()
+  verifyJsonKind(jsonNode, {JObject}, jsonPath)
+  let originalJsonPathLen = jsonPath.len
+  for key in keys(jsonNode.fields):
+    jsonPath.add '.'
+    jsonPath.add key
+    initFromJson(mgetOrPut(dst, key, default(T)), jsonNode[key], jsonPath)
+    jsonPath.setLen originalJsonPathLen
+
+proc initFromJson[T](dst: var OrderedTable[string,T]; jsonNode: JsonNode; jsonPath: var string) =
+  dst = initOrderedTable[string,T]()
+  verifyJsonKind(jsonNode, {JObject}, jsonPath)
+  let originalJsonPathLen = jsonPath.len
+  for key in keys(jsonNode.fields):
+    jsonPath.add '.'
+    jsonPath.add key
+    initFromJson(mgetOrPut(dst, key, default(T)), jsonNode[key], jsonPath)
+    jsonPath.setLen originalJsonPathLen
+
+proc initFromJson[T](dst: var ref T; jsonNode: JsonNode; jsonPath: var string) =
+  verifyJsonKind(jsonNode, {JObject, JNull}, jsonPath)
+  if jsonNode.kind == JNull:
+    dst = nil
+  else:
+    dst = new(T)
+    initFromJson(dst[], jsonNode, jsonPath)
+
+proc initFromJson[T](dst: var Option[T]; jsonNode: JsonNode; jsonPath: var string) =
+  if jsonNode != nil and jsonNode.kind != JNull:
+    when T is ref:
+      dst = some(new(T))
     else:
-      verifyJsonKind(jsonNode, {JInt, JFloat}, jsonPath)
-      if jsonNode.kind == JFloat:
-        dst = T(jsonNode.fnum)
-      else:
-        dst = T(jsonNode.num)
+      dst = some(default(T))
+    initFromJson(dst.get, jsonNode, jsonPath)
 
-  proc initFromJson[T: enum](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
-    verifyJsonKind(jsonNode, {JString}, jsonPath)
-    dst = parseEnum[T](jsonNode.getStr)
+macro assignDistinctImpl[T: distinct](dst: var T;jsonNode: JsonNode; jsonPath: var string) =
+  let typInst = getTypeInst(dst)
+  let typImpl = getTypeImpl(dst)
+  let baseTyp = typImpl[0]
 
-  proc initFromJson[T](dst: var seq[T]; jsonNode: JsonNode; jsonPath: var string) =
-    verifyJsonKind(jsonNode, {JArray}, jsonPath)
-    dst.setLen jsonNode.len
-    let orignalJsonPathLen = jsonPath.len
-    for i in 0 ..< jsonNode.len:
-      jsonPath.add '['
-      jsonPath.addInt i
-      jsonPath.add ']'
-      initFromJson(dst[i], jsonNode[i], jsonPath)
-      jsonPath.setLen orignalJsonPathLen
+  result = quote do:
+    initFromJson(`baseTyp`(`dst`), `jsonNode`, `jsonPath`)
 
-  proc initFromJson[S,T](dst: var array[S,T]; jsonNode: JsonNode; jsonPath: var string) =
-    verifyJsonKind(jsonNode, {JArray}, jsonPath)
-    let originalJsonPathLen = jsonPath.len
-    for i in 0 ..< jsonNode.len:
-      jsonPath.add '['
-      jsonPath.addInt i
-      jsonPath.add ']'
-      initFromJson(dst[i.S], jsonNode[i], jsonPath) # `.S` for enum indexed arrays
-      jsonPath.setLen originalJsonPathLen
+proc initFromJson[T: distinct](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
+  assignDistinctImpl(dst, jsonNode, jsonPath)
 
-  proc initFromJson[T](dst: var Table[string,T]; jsonNode: JsonNode; jsonPath: var string) =
-    dst = initTable[string, T]()
-    verifyJsonKind(jsonNode, {JObject}, jsonPath)
-    let originalJsonPathLen = jsonPath.len
-    for key in keys(jsonNode.fields):
-      jsonPath.add '.'
-      jsonPath.add key
-      initFromJson(mgetOrPut(dst, key, default(T)), jsonNode[key], jsonPath)
-      jsonPath.setLen originalJsonPathLen
+proc detectIncompatibleType(typeExpr, lineinfoNode: NimNode) =
+  if typeExpr.kind == nnkTupleConstr:
+    error("Use a named tuple instead of: " & typeExpr.repr, lineinfoNode)
 
-  proc initFromJson[T](dst: var OrderedTable[string,T]; jsonNode: JsonNode; jsonPath: var string) =
-    dst = initOrderedTable[string,T]()
-    verifyJsonKind(jsonNode, {JObject}, jsonPath)
-    let originalJsonPathLen = jsonPath.len
-    for key in keys(jsonNode.fields):
-      jsonPath.add '.'
-      jsonPath.add key
-      initFromJson(mgetOrPut(dst, key, default(T)), jsonNode[key], jsonPath)
-      jsonPath.setLen originalJsonPathLen
+proc foldObjectBody(dst, typeNode, tmpSym, jsonNode, jsonPath, originalJsonPathLen: NimNode) =
+  case typeNode.kind
+  of nnkEmpty:
+    discard
+  of nnkRecList, nnkTupleTy:
+    for it in typeNode:
+      foldObjectBody(dst, it, tmpSym, jsonNode, jsonPath, originalJsonPathLen)
 
-  proc initFromJson[T](dst: var ref T; jsonNode: JsonNode; jsonPath: var string) =
-    verifyJsonKind(jsonNode, {JObject, JNull}, jsonPath)
-    if jsonNode.kind == JNull:
-      dst = nil
-    else:
-      dst = new(T)
-      initFromJson(dst[], jsonNode, jsonPath)
+  of nnkIdentDefs:
+    typeNode.expectLen 3
+    let fieldSym = typeNode[0]
+    let fieldNameLit = newLit(fieldSym.strVal)
+    let fieldPathLit = newLit("." & fieldSym.strVal)
+    let fieldType = typeNode[1]
 
-  proc initFromJson[T](dst: var Option[T]; jsonNode: JsonNode; jsonPath: var string) =
-    if jsonNode != nil and jsonNode.kind != JNull:
-      when T is ref:
-        dst = some(new(T))
-      else:
-        dst = some(default(T))
-      initFromJson(dst.get, jsonNode, jsonPath)
+    # Detecting incompatiple tuple types in `assignObjectImpl` only
+    # would be much cleaner, but the ast for tuple types does not
+    # contain usable type information.
+    detectIncompatibleType(fieldType, fieldSym)
 
-  macro assignDistinctImpl[T: distinct](dst: var T;jsonNode: JsonNode; jsonPath: var string) =
-    let typInst = getTypeInst(dst)
-    let typImpl = getTypeImpl(dst)
-    let baseTyp = typImpl[0]
-
-    result = quote do:
+    dst.add quote do:
+      jsonPath.add `fieldPathLit`
       when nimvm:
-        # workaround #12282
-        var tmp: `baseTyp`
-        initFromJson( tmp, `jsonNode`, `jsonPath`)
-        `dst` = `typInst`(tmp)
-      else:
-        initFromJson( `baseTyp`(`dst`), `jsonNode`, `jsonPath`)
-
-  proc initFromJson[T: distinct](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
-    assignDistinctImpl(dst, jsonNode, jsonPath)
-
-  proc detectIncompatibleType(typeExpr, lineinfoNode: NimNode) =
-    if typeExpr.kind == nnkTupleConstr:
-      error("Use a named tuple instead of: " & typeExpr.repr, lineinfoNode)
-
-  proc foldObjectBody(dst, typeNode, tmpSym, jsonNode, jsonPath, originalJsonPathLen: NimNode) =
-    case typeNode.kind
-    of nnkEmpty:
-      discard
-    of nnkRecList, nnkTupleTy:
-      for it in typeNode:
-        foldObjectBody(dst, it, tmpSym, jsonNode, jsonPath, originalJsonPathLen)
-
-    of nnkIdentDefs:
-      typeNode.expectLen 3
-      let fieldSym = typeNode[0]
-      let fieldNameLit = newLit(fieldSym.strVal)
-      let fieldPathLit = newLit("." & fieldSym.strVal)
-      let fieldType = typeNode[1]
-
-      # Detecting incompatiple tuple types in `assignObjectImpl` only
-      # would be much cleaner, but the ast for tuple types does not
-      # contain usable type information.
-      detectIncompatibleType(fieldType, fieldSym)
-
-      dst.add quote do:
-        jsonPath.add `fieldPathLit`
-        when nimvm:
-          when isRefSkipDistinct(`tmpSym`.`fieldSym`):
-            # workaround #12489
-            var tmp: `fieldType`
-            initFromJson(tmp, getOrDefault(`jsonNode`,`fieldNameLit`), `jsonPath`)
-            `tmpSym`.`fieldSym` = tmp
-          else:
-            initFromJson(`tmpSym`.`fieldSym`, getOrDefault(`jsonNode`,`fieldNameLit`), `jsonPath`)
+        when isRefSkipDistinct(`tmpSym`.`fieldSym`):
+          # workaround #12489
+          var tmp: `fieldType`
+          initFromJson(tmp, getOrDefault(`jsonNode`,`fieldNameLit`), `jsonPath`)
+          `tmpSym`.`fieldSym` = tmp
         else:
           initFromJson(`tmpSym`.`fieldSym`, getOrDefault(`jsonNode`,`fieldNameLit`), `jsonPath`)
-        jsonPath.setLen `originalJsonPathLen`
+      else:
+        initFromJson(`tmpSym`.`fieldSym`, getOrDefault(`jsonNode`,`fieldNameLit`), `jsonPath`)
+      jsonPath.setLen `originalJsonPathLen`
 
-    of nnkRecCase:
-      let kindSym = typeNode[0][0]
-      let kindNameLit = newLit(kindSym.strVal)
-      let kindPathLit = newLit("." & kindSym.strVal)
-      let kindType = typeNode[0][1]
-      let kindOffsetLit = newLit(uint(getOffset(kindSym)))
-      dst.add quote do:
-        var kindTmp: `kindType`
-        jsonPath.add `kindPathLit`
-        initFromJson(kindTmp, `jsonNode`[`kindNameLit`], `jsonPath`)
-        jsonPath.setLen `originalJsonPathLen`
-        when defined js:
+  of nnkRecCase:
+    let kindSym = typeNode[0][0]
+    let kindNameLit = newLit(kindSym.strVal)
+    let kindPathLit = newLit("." & kindSym.strVal)
+    let kindType = typeNode[0][1]
+    let kindOffsetLit = newLit(uint(getOffset(kindSym)))
+    dst.add quote do:
+      var kindTmp: `kindType`
+      jsonPath.add `kindPathLit`
+      initFromJson(kindTmp, `jsonNode`[`kindNameLit`], `jsonPath`)
+      jsonPath.setLen `originalJsonPathLen`
+      when defined js:
+        `tmpSym`.`kindSym` = kindTmp
+      else:
+        when nimvm:
           `tmpSym`.`kindSym` = kindTmp
         else:
-          when nimvm:
-            `tmpSym`.`kindSym` = kindTmp
-          else:
-            # fuck it, assign kind field anyway
-            ((cast[ptr `kindType`](cast[uint](`tmpSym`.addr) + `kindOffsetLit`))[]) = kindTmp
-      dst.add nnkCaseStmt.newTree(nnkDotExpr.newTree(tmpSym, kindSym))
-      for i in 1 ..< typeNode.len:
-        foldObjectBody(dst, typeNode[i], tmpSym, jsonNode, jsonPath, originalJsonPathLen)
+          # fuck it, assign kind field anyway
+          ((cast[ptr `kindType`](cast[uint](`tmpSym`.addr) + `kindOffsetLit`))[]) = kindTmp
+    dst.add nnkCaseStmt.newTree(nnkDotExpr.newTree(tmpSym, kindSym))
+    for i in 1 ..< typeNode.len:
+      foldObjectBody(dst, typeNode[i], tmpSym, jsonNode, jsonPath, originalJsonPathLen)
 
-    of nnkOfBranch, nnkElse:
-      let ofBranch = newNimNode(typeNode.kind)
-      for i in 0 ..< typeNode.len-1:
-        ofBranch.add copyNimTree(typeNode[i])
-      let dstInner = newNimNode(nnkStmtListExpr)
-      foldObjectBody(dstInner, typeNode[^1], tmpSym, jsonNode, jsonPath, originalJsonPathLen)
-      # resOuter now contains the inner stmtList
-      ofBranch.add dstInner
-      dst[^1].expectKind nnkCaseStmt
-      dst[^1].add ofBranch
+  of nnkOfBranch, nnkElse:
+    let ofBranch = newNimNode(typeNode.kind)
+    for i in 0 ..< typeNode.len-1:
+      ofBranch.add copyNimTree(typeNode[i])
+    let dstInner = newNimNode(nnkStmtListExpr)
+    foldObjectBody(dstInner, typeNode[^1], tmpSym, jsonNode, jsonPath, originalJsonPathLen)
+    # resOuter now contains the inner stmtList
+    ofBranch.add dstInner
+    dst[^1].expectKind nnkCaseStmt
+    dst[^1].add ofBranch
 
-    of nnkObjectTy:
-      typeNode[0].expectKind nnkEmpty
-      typeNode[1].expectKind {nnkEmpty, nnkOfInherit}
-      if typeNode[1].kind == nnkOfInherit:
-        let base = typeNode[1][0]
-        var impl = getTypeImpl(base)
-        while impl.kind in {nnkRefTy, nnkPtrTy}:
-          impl = getTypeImpl(impl[0])
-        foldObjectBody(dst, impl, tmpSym, jsonNode, jsonPath, originalJsonPathLen)
-      let body = typeNode[2]
-      foldObjectBody(dst, body, tmpSym, jsonNode, jsonPath, originalJsonPathLen)
+  of nnkObjectTy:
+    typeNode[0].expectKind nnkEmpty
+    typeNode[1].expectKind {nnkEmpty, nnkOfInherit}
+    if typeNode[1].kind == nnkOfInherit:
+      let base = typeNode[1][0]
+      var impl = getTypeImpl(base)
+      while impl.kind in {nnkRefTy, nnkPtrTy}:
+        impl = getTypeImpl(impl[0])
+      foldObjectBody(dst, impl, tmpSym, jsonNode, jsonPath, originalJsonPathLen)
+    let body = typeNode[2]
+    foldObjectBody(dst, body, tmpSym, jsonNode, jsonPath, originalJsonPathLen)
 
-    else:
-      error("unhandled kind: " & $typeNode.kind, typeNode)
+  else:
+    error("unhandled kind: " & $typeNode.kind, typeNode)
 
-  macro assignObjectImpl[T](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
-    let typeSym = getTypeInst(dst)
-    let originalJsonPathLen = genSym(nskLet, "originalJsonPathLen")
-    result = newStmtList()
-    result.add quote do:
-      let `originalJsonPathLen` = len(`jsonPath`)
-    if typeSym.kind in {nnkTupleTy, nnkTupleConstr}:
-      # both, `dst` and `typeSym` don't have good lineinfo. But nothing
-      # else is available here.
-      detectIncompatibleType(typeSym, dst)
-      foldObjectBody(result, typeSym, dst, jsonNode, jsonPath, originalJsonPathLen)
-    else:
-      foldObjectBody(result, typeSym.getTypeImpl, dst, jsonNode, jsonPath, originalJsonPathLen)
+macro assignObjectImpl[T](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
+  let typeSym = getTypeInst(dst)
+  let originalJsonPathLen = genSym(nskLet, "originalJsonPathLen")
+  result = newStmtList()
+  result.add quote do:
+    let `originalJsonPathLen` = len(`jsonPath`)
+  if typeSym.kind in {nnkTupleTy, nnkTupleConstr}:
+    # both, `dst` and `typeSym` don't have good lineinfo. But nothing
+    # else is available here.
+    detectIncompatibleType(typeSym, dst)
+    foldObjectBody(result, typeSym, dst, jsonNode, jsonPath, originalJsonPathLen)
+  else:
+    foldObjectBody(result, typeSym.getTypeImpl, dst, jsonNode, jsonPath, originalJsonPathLen)
 
-  proc initFromJson[T: object|tuple](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
-    assignObjectImpl(dst, jsonNode, jsonPath)
+proc initFromJson[T: object|tuple](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
+  assignObjectImpl(dst, jsonNode, jsonPath)
 
-  proc to*[T](node: JsonNode, t: typedesc[T]): T =
-    ## `Unmarshals`:idx: the specified node into the object type specified.
-    ##
-    ## Known limitations:
-    ##
-    ##   * Heterogeneous arrays are not supported.
-    ##   * Sets in object variants are not supported.
-    ##   * Not nil annotations are not supported.
-    ##
-    runnableExamples:
-      let jsonNode = parseJson("""
-        {
-          "person": {
-            "name": "Nimmer",
-            "age": 21
-          },
-          "list": [1, 2, 3, 4]
-        }
-      """)
+proc to*[T](node: JsonNode, t: typedesc[T]): T =
+  ## `Unmarshals`:idx: the specified node into the object type specified.
+  ##
+  ## Known limitations:
+  ##
+  ##   * Heterogeneous arrays are not supported.
+  ##   * Sets in object variants are not supported.
+  ##   * Not nil annotations are not supported.
+  ##
+  runnableExamples:
+    let jsonNode = parseJson("""
+      {
+        "person": {
+          "name": "Nimmer",
+          "age": 21
+        },
+        "list": [1, 2, 3, 4]
+      }
+    """)
 
-      type
-        Person = object
-          name: string
-          age: int
+    type
+      Person = object
+        name: string
+        age: int
 
-        Data = object
-          person: Person
-          list: seq[int]
+      Data = object
+        person: Person
+        list: seq[int]
 
-      var data = to(jsonNode, Data)
-      doAssert data.person.name == "Nimmer"
-      doAssert data.person.age == 21
-      doAssert data.list == @[1, 2, 3, 4]
+    var data = to(jsonNode, Data)
+    doAssert data.person.name == "Nimmer"
+    doAssert data.person.age == 21
+    doAssert data.list == @[1, 2, 3, 4]
 
-    var jsonPath = ""
-    initFromJson(result, node, jsonPath)
+  var jsonPath = ""
+  result = default(T)
+  initFromJson(result, node, jsonPath)
 
 when false:
   import os

--- a/src/patched_stdlib/parsejson.nim
+++ b/src/patched_stdlib/parsejson.nim
@@ -1,5 +1,5 @@
 # This file is minimally adapted from this version in the Nim standard library:
-# https://github.com/nim-lang/Nim/blob/e8657c710776/lib/pure/parsejson.nim
+# https://github.com/nim-lang/Nim/blob/a488067a4130/lib/pure/parsejson.nim
 # The standard library version is lenient: it silently allows line comments
 # with `//`, and long comments with `/* */`.
 # The below version is stricter: it raises a `JsonParsingError` for such

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -1,5 +1,5 @@
 import std/[macros, os]
-import "."/helpers
+import helpers
 
 proc genBracket: NimNode =
   const thisDir = currentSourcePath().parentDir().Path()

--- a/tests/test_binary.nim
+++ b/tests/test_binary.nim
@@ -1,5 +1,5 @@
 import std/[os, osproc, strformat, strscans, strutils, unittest]
-import "."/[exec, helpers, lint/validators, sync/probspecs]
+import exec, helpers, lint/validators, sync/probspecs
 
 const
   testsDir = currentSourcePath().parentDir()

--- a/tests/test_fmt.nim
+++ b/tests/test_fmt.nim
@@ -1,6 +1,6 @@
 import std/[importutils, json, os, options, random, strutils, unittest]
 import pkg/jsony
-import "."/[exec, helpers, sync/sync_common, types_exercise_config]
+import exec, helpers, sync/sync_common, types_exercise_config
 
 const
   testsDir = currentSourcePath().parentDir()

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -1,5 +1,5 @@
 import std/[strutils, unittest]
-from "."/generate/generate {.all.} import alterHeadings
+from generate/generate {.all.} import alterHeadings
 
 proc testGenerate =
   suite "generate":

--- a/tests/test_lint.nim
+++ b/tests/test_lint.nim
@@ -1,6 +1,6 @@
 import std/[strutils, unittest]
-import "."/lint/validators
-import "."/lint/approaches_and_articles {.all.}
+import lint/validators
+import lint/approaches_and_articles {.all.}
 
 proc testIsKebabCase =
   suite "isKebabCase":

--- a/tests/test_probspecs.nim
+++ b/tests/test_probspecs.nim
@@ -1,6 +1,6 @@
 # This module contains tests for `src/probspecs.nim`
 import std/[json, os, strformat, tables, unittest]
-import "."/[cli, exec, sync/probspecs]
+import cli, exec, sync/probspecs
 
 proc getProbSpecsExercises(probSpecsDir: ProbSpecsDir): Table[string,
     seq[ProbSpecsTestCase]] =

--- a/tests/test_sync.nim
+++ b/tests/test_sync.nim
@@ -1,7 +1,7 @@
 import std/[importutils, json, os, options, strutils, unittest]
-import "."/[exec, helpers, sync/sync_common, types_exercise_config, types_track_config]
-from "."/sync/sync_filepaths {.all.} import update
-from "."/sync/sync_metadata {.all.} import UpstreamMetadata, parseMetadataToml,
+import exec, helpers, sync/sync_common, types_exercise_config, types_track_config
+from sync/sync_filepaths {.all.} import update
+from sync/sync_metadata {.all.} import UpstreamMetadata, parseMetadataToml,
     metadataAreUpToDate, update
 
 const

--- a/tests/test_tracks.nim
+++ b/tests/test_tracks.nim
@@ -1,6 +1,6 @@
 # This file implements tests for `src/tracks.nim`
 import std/[os, sequtils, sets, unittest]
-import "."/[cli, exec, sync/tracks]
+import cli, exec, sync/tracks
 
 const
   testsDir = currentSourcePath().parentDir()

--- a/tests/test_uuid.nim
+++ b/tests/test_uuid.nim
@@ -1,5 +1,5 @@
 import std/[sets, strformat, strutils, unittest]
-import "."/[lint/validators, uuid/uuid]
+import lint/validators, uuid/uuid
 
 proc main =
   suite "genUuid":


### PR DESCRIPTION
See the release blog posts [rc1][1] and [rc2][2] and [2.0][3], detailed [changelog][4], and [changes since 1.6.12][5].

`config.nims` changes:

- Remove `strictEffects`, which Nim 2.0 [enables by default][6].
- Disable noisy `ProveInit` and `Uninit` warnings for now.
- Enable `strictDefs` unconditionally. It was previously conditional to support older versions of Nim that lacked `strictDefs`.

Update patched stdlib json and parsejson.

In the tests, reflect a Nim 2.0 change to imports. From the [changes affecting backward compatibility][7]:

> Relative imports will not resolve to searched paths anymore, e.g. `import ./tables` now reports an error properly.

[1]: https://nim-lang.org/blog/2022/12/21/version-20-rc.html
[2]: https://nim-lang.org/blog/2023/03/31/version-20-rc2.html
[3]: https://nim-lang.org/blog/2023/08/01/nim-v20-released.html
[4]: https://github.com/nim-lang/Nim/blob/v2.0.0/changelogs/changelog_2_0_0_details.md
[5]: https://github.com/nim-lang/Nim/compare/v1.6.12...v2.0.0
[6]: https://nim-lang.org/blog/2023/08/01/nim-v20-released.html#strict-effects
[7]: https://github.com/nim-lang/Nim/blob/v2.0.0/changelogs/changelog_2_0_0_details.md#changes-affecting-backward-compatibility


---

To-do:

- [x] Wait for Nim 2.0 release
- [x] Resolve `nimble test` errors, e.g.:
    `tests/all_tests.nim(2, 11) Error: cannot open file: ./helpers`
- [x] Windows: resolve uuids error (due to https://github.com/nim-lang/Nim/commit/612abda4f40b2a0fd8dd0e4ad119c4415b9c34cb):
      `C:\Users\runneradmin\.nimble\pkgs2\uuids-0.1.11-393f5fcefbc8ad3cf167e59760144208ff8f9f76\uuids\urandom.nim(15, 8) Error: undeclared identifier: 'useWinUnicode'`
    I've created [pragmagic/uuids#9](https://www.github.com/pragmagic/uuids/pull/9), but that may not be sufficient, and long-term I'd like to do https://github.com/exercism/configlet/issues/424 instead
- [x] Update patched `json.nim` and `parsejson.nim`
- [x] Windows: resolve patching error:

> ```text
> C:\Users\runneradmin\nimcache\all_tests_d\all_tests_EC059F07D9BFDE95FE3FAA825662EFD80E11A567.exe [SuccessX]
> Hint: C:\Users\runneradmin\nimcache\all_tests_d\all_tests_EC059F07D9BFDE95FE3FAA825662EFD80E11A567.exe [Exec]
> Running `nimble --verbose build -d:release`... failure
>      Info:  Nimble data file "C:\Users\runneradmin\.nimble\nimbledata2.json" has been loaded.
>   Verifying dependencies for configlet@4.0.0
>     Reading official package list
>    Checking for cligen@#b962cf8bc0be847cbc1b4f77952775de765e9689
>      Info:  Dependency on cligen@#b962cf8bc0be847cbc1b4f77952775de765e9689 already satisfied
>   Verifying dependencies for cligen@1.5.19
>     Reading official package list
>    Checking for jsony@#2a2cc4331720b7695c8b66529dbfea6952727e7b
>      Info:  Dependency on jsony@#2a2cc4331720b7695c8b66529dbfea6952727e7b already satisfied
>   Verifying dependencies for jsony@1.1.3
>     Reading official package list
>    Checking for parsetoml@#6e5e16179fa2db60f2f37d8b1af4128aaa9c8aaf
>      Info:  Dependency on parsetoml@#6e5e16179fa2db60f2f37d8b1af4128aaa9c8aaf already satisfied
>   Verifying dependencies for parsetoml@0.7.1
>     Reading official package list
>    Checking for supersnappy@#e4df8cb5468dd96fc5a4764028e20c8a3942f16a
>      Info:  Dependency on supersnappy@#e4df8cb5468dd96fc5a4764028e20c8a3942f16a already satisfied
>   Verifying dependencies for supersnappy@2.1.3
>  Attempting to execute hook buildBefore in D:\a\configlet\configlet\configlet.nimble
> Checking patch cligen/parseopt3.nim...
> error: while searching for:
>     p.kind = cmdError?
>     return?
>   if p.pos < p.cmd.len:                 # Take opt arg from next param?
>     p.val = p.cmd[p.pos]?
>     p.pos += 1?
>   elif p.longNoVal.len != 0:?
>     p.val = ""?
>     p.pos += 1?
> 
> error: patch failed: cligen/parseopt3.nim:267
> error: cligen/parseopt3.nim: patch does not apply
> stack trace: (most recent call last)
> C:\Users\RUNNER~1\AppData\Local\Temp\nimblecache-0\nimscriptapi_3135216885.nim(222, 29)
> D:\a\configlet\configlet\configlet.nimble(31, 37) buildBefore
> D:\a\configlet\configlet\patches\patch.nim(61, 3) ensureThatNimblePackagesArePatched
> D:\a\configlet\configlet\patches\patch.nim(53, 8) patchCligen
> D:\a\configlet\configlet\patches\patch.nim(46, 25) patch
> D:\a\configlet\configlet\patches\patch.nim(12, 5) gorgeCheck
> D:\a\configlet\configlet\patches\patch.nim(12, 5) Error: unhandled exception: failed to apply patch [OSError]
> nimscriptwrapper.nim(160) execScript
> 
>     Error:  Exception raised during nimble script execution
>      Info:  Nimble data file "C:\Users\runneradmin\.nimble\nimbledata2.json" has been saved.
> 
> D:\a\configlet\configlet\tests\test_binary.nim([1165](https://github.com/exercism/configlet/actions/runs/5785968697/job/15679844551#step:6:1166)) test_binary
> D:\a\configlet\configlet\tests\test_binary.nim(1026) main
> D:\a\configlet\configlet\src\exec.nim(68) execAndCheck
> Error: unhandled exception:  [OSError]
> Error: execution of an external program failed: 'C:\Users\runneradmin\nimcache\all_tests_d\all_tests_EC059F07D9BFDE95FE3FAA825662EFD80E11A567.exe'
> stack trace: (most recent call last)
> C:\Users\RUNNER~1\AppData\Local\Temp\nimblecache-0\nimscriptapi_3135216885.nim(210, 16)
> D:\a\configlet\configlet\configlet.nimble(28, 3) testTask
> D:\a\configlet\configlet\nimdir\lib\system\nimscript.nim(265, 7) exec
> D:\a\configlet\configlet\nimdir\lib\system\nimscript.nim(265, 7) Error: unhandled exception: FAILED: nim r ./tests/all_tests.nim [OSError]
>        Tip: 9 messages have been suppressed, use --verbose to show them.
> nimscriptwrapper.nim(160) execScript
> ```