### PR TITLE
bin(upload-legacy-assets): add script

### DIFF
--- a/bin/upload-assets-with-old-names
+++ b/bin/upload-assets-with-old-names
@@ -29,7 +29,7 @@ main() {
   else
     err "You must call this script with exactly one argument."
     err "Usage:"
-    err "  upload-assets <tag>"
+    err "  upload-assets-with-old-names <tag>"
     exit 1
   fi
 }

--- a/bin/upload-assets-with-old-names
+++ b/bin/upload-assets-with-old-names
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+err() {
+  echo "$*" >&2
+}
+
+main() {
+  if [[ "$#" -eq 1 ]]; then
+    local tmp_dir='upload-assets-tmp'
+    local repo='github.com/exercism/configlet'
+    local tag="$1"
+    local arch='x86-64'
+    local pattern="*${arch}*"
+    local old_name_linux='configlet-linux-64bit.tgz'
+    local old_name_macos='configlet-mac-64bit.tgz'
+    local old_name_windows='configlet-windows-64bit.zip'
+
+    mkdir -v -p "${tmp_dir}"
+    cd "${tmp_dir}"
+    gh -R "${repo}" release download "${tag}" -p "${pattern}"
+    mv -v "configlet_${tag}_linux_${arch}.tar.gz" "${old_name_linux}"
+    mv -v "configlet_${tag}_macos_${arch}.tar.gz" "${old_name_macos}"
+    mv -v "configlet_${tag}_windows_${arch}.zip" "${old_name_windows}"
+    gh -R "${repo}" release upload "${tag}" "${old_name_linux}" "${old_name_macos}" "${old_name_windows}"
+    echo "After undrafting the new release, you can delete the assets with the old names"
+    echo "from the previous release"
+  else
+    err "You must call this script with exactly one argument."
+    err "Usage:"
+    err "  upload-assets <tag>"
+    exit 1
+  fi
+}
+
+main "$@"

--- a/bin/upload-legacy-assets
+++ b/bin/upload-legacy-assets
@@ -29,7 +29,7 @@ main() {
   else
     err "You must call this script with exactly one argument."
     err "Usage:"
-    err "  upload-assets-with-old-names <tag>"
+    err "  upload-legacy-assets <tag>"
     exit 1
   fi
 }

--- a/bin/upload-legacy-assets
+++ b/bin/upload-legacy-assets
@@ -13,31 +13,18 @@ main() {
     local tag="$1"
     local arch='x86-64'
     local pattern="*${arch}*"
-    local oses=('linux' 'macos' 'windows')
     mkdir -v -p "${tmp_dir}"
     cd "${tmp_dir}"
     gh -R "${repo}" release download "${tag}" -p "${pattern}"
-    for os in "${oses[@]}"; do
-      case "${os}" in
-        linux)
-          local ext_old='tar.gz'
-          local ext_new='tgz'
-          local os_old="${os}"
-          ;;
-        macos)
-          local ext_old='tar.gz'
-          local ext_new='tgz'
-          local os_old='mac'
-          ;;
-        windows)
-          local ext_new='zip'
-          local ext_old='zip'
-          local os_old="${os}"
-          ;;
-      esac
-      mv -v "configlet_${tag}_${os}_${arch}.${ext_new}" "configlet-${os_old}-64bit.${ext_old}"
+    declare -A assets=(
+      ["configlet_${tag}_linux_${arch}.tar.gz"]='configlet-linux-64bit.tgz'
+      ["configlet_${tag}_macos_${arch}.tar.gz"]='configlet-mac-64bit.tgz'
+      ["configlet_${tag}_windows_${arch}.zip"]='configlet-windows-64bit.zip'
+    )
+    for k in "${!assets[@]}"; do
+      mv -v "${k}" "${assets[${k}]}"
     done
-    gh -R "${repo}" release upload "${tag}" configlet-*-64bit*
+    gh -R "${repo}" release upload "${tag}" "${assets[@]}"
     echo "After undrafting the new release, you can delete the assets with the old names"
     echo "from the previous release"
   else

--- a/bin/upload-legacy-assets
+++ b/bin/upload-legacy-assets
@@ -13,17 +13,31 @@ main() {
     local tag="$1"
     local arch='x86-64'
     local pattern="*${arch}*"
-    local old_name_linux='configlet-linux-64bit.tgz'
-    local old_name_macos='configlet-mac-64bit.tgz'
-    local old_name_windows='configlet-windows-64bit.zip'
-
+    local oses=('linux' 'macos' 'windows')
     mkdir -v -p "${tmp_dir}"
     cd "${tmp_dir}"
     gh -R "${repo}" release download "${tag}" -p "${pattern}"
-    mv -v "configlet_${tag}_linux_${arch}.tar.gz" "${old_name_linux}"
-    mv -v "configlet_${tag}_macos_${arch}.tar.gz" "${old_name_macos}"
-    mv -v "configlet_${tag}_windows_${arch}.zip" "${old_name_windows}"
-    gh -R "${repo}" release upload "${tag}" "${old_name_linux}" "${old_name_macos}" "${old_name_windows}"
+    for os in "${oses[@]}"; do
+      case "${os}" in
+        linux)
+          local ext_old='tar.gz'
+          local ext_new='tgz'
+          local os_old="${os}"
+          ;;
+        macos)
+          local ext_old='tar.gz'
+          local ext_new='tgz'
+          local os_old='mac'
+          ;;
+        windows)
+          local ext_new='zip'
+          local ext_old='zip'
+          local os_old="${os}"
+          ;;
+      esac
+      mv -v "configlet_${tag}_${os}_${arch}.${ext_new}" "configlet-${os_old}-64bit.${ext_old}"
+    done
+    gh -R "${repo}" release upload "${tag}" configlet-*-64bit*
     echo "After undrafting the new release, you can delete the assets with the old names"
     echo "from the previous release"
   else


### PR DESCRIPTION
Add the script that I wrote for supporting old `fetch-configlet` scripts during a transition period.

We can remove this script later. Due to https://github.com/exercism/github-actions/commit/a63d5ca894377ec82fe62569a3f7f69c9fb167d2, track CI no longer requires the linux asset with the old name to exist.

Assets in the [latest release](https://github.com/exercism/configlet/releases/tag/4.0.0-beta.9) at the time of writing:

```text
configlet-linux-64bit.tgz
configlet-mac-64bit.tgz
configlet-windows-64bit.zip
configlet_4.0.0-beta.9_checksums_sha256.txt
configlet_4.0.0-beta.9_linux_x86-64.tar.gz
configlet_4.0.0-beta.9_macos_x86-64.tar.gz
configlet_4.0.0-beta.9_windows_x86-64.zip
```