### PR TITLE
.github: bump `ludeeus/action-shellcheck` from 6d3f514 to 2.0.0

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,6 +11,6 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
 
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@6d3f514f44620b9d4488e380339edc0d9bbe2fba
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
         with:
           ignore_names: configlet.zsh


### PR DESCRIPTION
There wasn't a release of this action for a while, so we previously needed to pin to a non-release commit. See commits 1fdffc3283f4 and e4c86435d284 for context.

See also the [release notes][1] and [changes][2].

[1]: https://github.com/ludeeus/action-shellcheck/releases/tag/2.0.0
[2]: https://github.com/ludeeus/action-shellcheck/compare/6d3f514f4462...00cae500b08a

Closes: #729