### PR TITLE
generate: don't move link reference definition out of block

### DIFF
--- a/src/generate/generate.nim
+++ b/src/generate/generate.nim
@@ -32,7 +32,8 @@ func alterHeadings(s: string, linkDefs: var seq[string], h2 = ""): string =
       if s.continuesWith("#", i+1) and not (inFencedCodeBlock or
                                             inFencedCodeBlockTildes or inCommentBlock):
         result.add '#'
-      elif s.continuesWith("[", i+1):
+      elif s.continuesWith("[", i+1) and not (inFencedCodeBlock or
+                                              inFencedCodeBlockTildes or inCommentBlock):
         let j = s.find("]:", i+2)
         if j > i+2 and j < s.find('\n', i+2):
           var line = ""

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -74,6 +74,28 @@ proc testGenerate =
       check alterHeadings(s, linkDefs, "Maps") == "## Maps\n\n" & expected
       check linkDefs.len == 0
 
+    test "alterHeadings: keeps link reference definition inside block":
+      const s = """
+        # Heading 1
+
+        ~~~~note
+        See the [foo docs][foo-docs] for more details.
+
+        [foo-docs]: http://example.com
+        ~~~~
+      """.unindent()
+
+      const expected = """
+        ~~~~note
+        See the [foo docs][foo-docs] for more details.
+
+        [foo-docs]: http://example.com
+        ~~~~""".unindent()
+
+      var linkDefs = newSeq[string]()
+      check alterHeadings(s, linkDefs) == expected
+      check linkDefs.len == 0
+
 proc main =
   testGenerate()
 

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -81,7 +81,7 @@ proc testGenerate =
         ~~~~exercism/note
         See the [foo docs][foo-docs] for more details.
 
-        [foo-docs]: http://example.com
+        [foo-docs]: https://example.com
         ~~~~
       """.unindent()
 
@@ -89,7 +89,7 @@ proc testGenerate =
         ~~~~exercism/note
         See the [foo docs][foo-docs] for more details.
 
-        [foo-docs]: http://example.com
+        [foo-docs]: https://example.com
         ~~~~""".unindent()
 
       var linkDefs = newSeq[string]()

--- a/tests/test_generate.nim
+++ b/tests/test_generate.nim
@@ -78,7 +78,7 @@ proc testGenerate =
       const s = """
         # Heading 1
 
-        ~~~~note
+        ~~~~exercism/note
         See the [foo docs][foo-docs] for more details.
 
         [foo-docs]: http://example.com
@@ -86,7 +86,7 @@ proc testGenerate =
       """.unindent()
 
       const expected = """
-        ~~~~note
+        ~~~~exercism/note
         See the [foo docs][foo-docs] for more details.
 
         [foo-docs]: http://example.com


### PR DESCRIPTION
Closes: #737

---

I've checked that, with this PR, `configlet generate` will no longer make a change to the current state of the Julia track.