### PR TITLE
.github(workflows), nimble: bump Nim from 1.6.10 to 1.6.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@9e500b9ddc377c597719e98821acbd1f5925c056
         with:
-          version: "binary:1.6.10"
+          version: "binary:1.6.12"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@9e500b9ddc377c597719e98821acbd1f5925c056
         with:
-          version: "binary:1.6.10"
+          version: "binary:1.6.12"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -18,7 +18,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 1.6.10"
+requires "nim >= 1.6.12"
 requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"      # 1.5.19 (2021-09-13)
 requires "jsony#2a2cc4331720b7695c8b66529dbfea6952727e7b"       # 1.1.3  (2022-01-03)
 requires "parsetoml#9cdeb3f65fd10302da157db8a8bac5c42f055249"   # 0.6.0  (2021-06-07)


### PR DESCRIPTION
See the [release blog post][1] and [changes since 1.6.10][2].

[1]: https://nim-lang.org/blog/2023/03/10/version-1612-released.html
[2]: https://github.com/nim-lang/Nim/compare/v1.6.10...v1.6.12

---

Previous bump: #707