### PR TITLE
fmt: format config files for approaches and articles

### DIFF
--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -123,7 +123,7 @@ proc writeFormatted(prettyPairs: seq[PathAndFormattedDocument]) =
     logDetailed(&"Writing formatted: {path}")
     writeFile(path, prettyPair.formattedDocument)
   let s = if prettyPairs.len > 1: "s" else: ""
-  logNormal(&"Formatted the exercise config for {prettyPairs.len} exercise{s}")
+  logNormal(&"Formatted {prettyPairs.len} file{s}")
 
 proc fmt*(conf: Conf) =
   ## Prints a list of `.meta/config.json` paths in `conf.trackDir` where the

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -106,7 +106,7 @@ proc userSaysYes(userExercise: string): bool =
   ## confirm.
   let s = if userExercise.len > 0: "" else: "s"
   while true:
-    stderr.write &"Format the above exercise config{s} ([y]es/[n]o)? "
+    stderr.write &"Format the above file{s} ([y]es/[n]o)? "
     case stdin.readLine().toLowerAscii()
     of "y", "yes":
       return true

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -1,10 +1,14 @@
-import std/[os, strformat, strutils]
+import std/[options, os, strformat, strutils]
 import ".."/[cli, logger, sync/sync_common, sync/sync_filepaths, sync/sync, types_track_config]
 
 type
   PathAndFormattedExerciseConfig = object
     path: string
     formattedExerciseConfig: string
+
+  PathAndFormattedApproachesConfig = object
+    path: string
+    formattedApproachesConfig: string
 
 iterator getConfigPaths(trackExerciseSlugs: TrackExerciseSlugs,
                         trackExercisesDir: string): (ExerciseKind, string) =
@@ -98,7 +102,7 @@ proc fmt*(conf: Conf) =
             trackConfigPath)
   let trackExerciseSlugs = getSlugs(trackConfig.exercises, conf, trackConfigPath)
   logNormal("Looking for exercises that lack a formatted '.meta/config.json' " &
-            "file...")
+            "or '.approaches/config.json' file...")
 
   let pairs = fmtImpl(trackExerciseSlugs, conf.trackDir)
 

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -136,7 +136,7 @@ proc fmt*(conf: Conf) =
             trackConfigPath)
   let trackExerciseSlugs = getSlugs(trackConfig.exercises, conf, trackConfigPath)
   logNormal("Looking for exercises that lack a formatted '.meta/config.json', " &
-            "'.approaches/config.json'\nor '.approaches/config.json' file...")
+            "'.approaches/config.json'\nor '.articles/config.json' file...")
 
   let pairs = fmtImpl(trackExerciseSlugs, conf.trackDir)
 

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -1,4 +1,4 @@
-import std/[options, os, strformat, strutils]
+import std/[os, strformat, strutils]
 import ".."/[cli, helpers, logger, sync/sync_common, sync/sync_filepaths, sync/sync, types_track_config,
              types_approaches_config, types_articles_config]
 

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -60,7 +60,6 @@ proc formatApproachesConfigFile(configPath: string): string =
   ## Parses the `.approaches/config.json` file at `configPath` and
   ## returns it in the canonical form.
   let approachesConfig = ApproachesConfig.init(configPath)
-  echo $approachesConfig
   prettyApproachesConfig(approachesConfig)
 
 proc formatArticlesConfigFile(configPath: string): string =

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -136,7 +136,7 @@ proc fmt*(conf: Conf) =
             trackConfigPath)
   let trackExerciseSlugs = getSlugs(trackConfig.exercises, conf, trackConfigPath)
   logNormal("Looking for exercises that lack a formatted '.meta/config.json', " &
-            "'.approaches/config.json' or '.approaches/config.json' file...")
+            "'.approaches/config.json'\nor '.approaches/config.json' file...")
 
   let pairs = fmtImpl(trackExerciseSlugs, conf.trackDir)
 

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -81,7 +81,6 @@ proc fmtImpl(trackExerciseSlugs: TrackExerciseSlugs,
   var seenUnformatted = false
   for (exerciseKind, documentKind, configPath) in getConfigPaths(trackExerciseSlugs,
                                                                  trackExercisesDir):
-
     let formatted =
       case documentKind
       of dkExerciseConfig: formatExerciseConfigFile(exerciseKind, configPath)

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -10,6 +10,10 @@ type
     path: string
     formattedApproachesConfig: string
 
+  PathAndFormattedArticlesConfig = object
+    path: string
+    formattedArticlesConfig: string
+
 iterator getConfigPaths(trackExerciseSlugs: TrackExerciseSlugs,
                         trackExercisesDir: string): (ExerciseKind, string) =
   ## Yields the `.meta/config.json` path for each exercise in
@@ -101,8 +105,8 @@ proc fmt*(conf: Conf) =
             &"and {trackConfig.exercises.practice.len} Practice Exercises in " &
             trackConfigPath)
   let trackExerciseSlugs = getSlugs(trackConfig.exercises, conf, trackConfigPath)
-  logNormal("Looking for exercises that lack a formatted '.meta/config.json' " &
-            "or '.approaches/config.json' file...")
+  logNormal("Looking for exercises that lack a formatted '.meta/config.json', " &
+            "or '.approaches/config.json'or '.approaches/config.json' file...")
 
   let pairs = fmtImpl(trackExerciseSlugs, conf.trackDir)
 

--- a/src/fmt/fmt.nim
+++ b/src/fmt/fmt.nim
@@ -75,7 +75,7 @@ proc fmtImpl(trackExerciseSlugs: TrackExerciseSlugs,
   ## This includes `.meta/config.json`, `.approaches/config.json`
   ## and `.articles/config.json`.
   ##
-  ## Returns a seq of (docuement kind, path, formatted document) objects
+  ## Returns a seq of (document kind, path, formatted document) objects
   ## containing every exercise's configs that are not already formatted.
   let trackExercisesDir = trackDir / "exercises"
   var seenUnformatted = false

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -48,8 +48,7 @@ func w*(s: string; start: int): int =
   ## A matcher for `scanf`. Similar to `$w`, but only skips (does not bind).
   s.skipWhile(IdentChars, start)
 
-proc setFalseAndPrint*(b: var bool; description: string; path: Path;
-    annotation = "") =
+proc setFalseAndPrint*(b: var bool; description: string; path: Path, annotation = "") =
   ## Sets `b` to `false` and writes a message to stdout containing `description`
   ## and `path`.
   b = false

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -1,5 +1,5 @@
-import std/[json, os, strformat, strutils]
-import ".."/helpers
+import std/[json, options, os, strformat, strutils]
+import ".."/[helpers, types_approaches_config]
 import "."/validators
 
 type

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -1,5 +1,5 @@
-import std/[json, options, os, strformat, strutils]
-import ".."/[helpers, sync/sync_common, types_approaches_config, types_articles_config]
+import std/[json, os, strformat, strutils]
+import ".."/helpers
 import "."/validators
 
 type

--- a/src/lint/approaches_and_articles.nim
+++ b/src/lint/approaches_and_articles.nim
@@ -7,12 +7,6 @@ type
     dkApproaches = ".approaches"
     dkArticles = ".articles"
 
-proc initApproaches*(exerciseApproachesConfigPath: string): ApproachesConfig =
-  parseFile(exerciseApproachesConfigPath, ApproachesConfig)
-
-proc initArticles*(exerciseArticlesConfigPath: string): ArticlesConfig =
-  parseFile(exerciseArticlesConfigPath, ArticlesConfig)
-
 proc setFalseIfFileMissingOrEmpty(b: var bool, path: Path, msgMissing: string) =
   if fileExists(path):
     if path.readFile().len == 0:

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -1,5 +1,5 @@
 import std/[os, sequtils, strformat, strutils, terminal]
-import ".."/[cli, logger, types_track_config]
+import ".."/[cli, helpers, logger, types_track_config]
 import "."/[exercises, probspecs, sync_common, sync_docs, sync_filepaths,
             sync_metadata, sync_tests]
 

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -292,7 +292,8 @@ proc addObject(s: var string; key: string; val: JsonNode; indentLevel = 1) =
     stderr.writeLine val.pretty()
     quit 1
 
-func keyOrderForSync(originalKeyOrder: seq[ExerciseConfigKey]): seq[ExerciseConfigKey] =
+func keyOrderForSync(originalKeyOrder: seq[ExerciseConfigKey]): seq[
+    ExerciseConfigKey] =
   if originalKeyOrder.len == 0:
     return @[eckAuthors, eckFiles, eckBlurb]
   else:
@@ -358,8 +359,8 @@ template addValOrNull(key, f: untyped) =
   else:
     result.addNull(&"{key}")
 
-proc pretty*(e: ConceptExerciseConfig | PracticeExerciseConfig,
-             prettyMode: PrettyMode): string =
+proc prettyExerciseConfig*(e: ConceptExerciseConfig | PracticeExerciseConfig,
+                           prettyMode: PrettyMode): string =
   ## Serializes `e` as pretty-printed JSON, using:
   ## - the original key order if `prettyMode` is `pmSync`.
   ## - the canonical key order if `prettyMode` is `pmFmt`.

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -477,36 +477,40 @@ proc prettyApproachesConfig*(e: ApproachesConfig): string =
       if e.introduction.authors.len > 0 or e.introduction.contributors.len > 0:
         result.addApproachesIntroduction(e.introduction)
     of ackApproaches:
-      result.addApproaches(e.approaches)
-    # of eckContributors:
-    #   addValOrNull(contributors, addArray)
-    # of eckFiles:
-    #   result.addFiles(e.files, prettyMode)
-    # of eckLanguageVersions:
-    #   result.addString("language_versions", e.language_versions)
-    # of eckForkedFrom:
-    #   when e is ConceptExerciseConfig:
-    #     addValOrNull(forked_from, addArray)
-    # of eckTestRunner:
-    #   when e is PracticeExerciseConfig:
-    #     addValOrNull(test_runner, addBool)
-    # of eckRepresenter:
-    #   if e.representer.isSome():
-    #     result.addRepresenter(e.representer.get());
-    # of eckIcon:
-    #   result.addString("icon", e.icon)
-    # of eckBlurb:
-    #   result.addString("blurb", e.blurb)
-    # of eckSource:
-    #   if e.source.isSome():
-    #     result.addString("source", e.source.get())
-    # of eckSourceUrl:
-    #   if e.source_url.isSome():
-    #     result.addString("source_url", e.source_url.get())
-    # of eckCustom:
-    #   addValOrNull(custom, addObject)
+      if e.approaches.len > 0:
+        result.addApproaches(e.approaches)
   result.removeComma()
   result.add "\n}\n"
+
+func addArticle(result: var string;
+    val: ArticleConfig; indentLevel = 1) =
+  ## Appends the pretty-printed JSON for an `article` element with value `val` to
+  ## `result`.
+  result.addNewlineAndIndent(indentLevel)
+  result.add "{"
+  result.addString("uuid", val.uuid, indentLevel + 1)
+  result.addString("slug", val.slug, indentLevel + 1)
+  result.addString("title", val.title, indentLevel + 1)
+  result.addString("blurb", val.blurb, indentLevel + 1)
+  result.addArray("authors", val.authors, indentLevel + 1)
+  if val.contributors.len > 0:
+    result.addArray("contributors", val.contributors, indentLevel + 1)
+  result.removeComma()
+  result.addNewlineAndIndent(indentLevel)
+  result.add "},"
+
+func addArticles(result: var string;
+    val: seq[ArticleConfig]; indentLevel = 1) =
+  ## Appends the pretty-printed JSON for an `articles` key with value `val` to
+  ## `result`.
+  result.addNewlineAndIndent(indentLevel)
+  escapeJson("articles", result)
+  result.add ": ["
+  for article in val:
+    result.addArticle(article, indentLevel + 1)
+  result.removeComma()
+  result.addNewlineAndIndent(indentLevel)
+  result.add "]"
 
 proc prettyArticlesConfig*(e: ArticlesConfig): string =
   ## Serializes `e` as pretty-printed JSON, using the canonical key order.
@@ -517,34 +521,7 @@ proc prettyArticlesConfig*(e: ArticlesConfig): string =
   for key in keys:
     case key
     of ackArticles:
-      discard # TODO
-      # result.addArray("introduction", e.authors)
-    # of eckContributors:
-    #   addValOrNull(contributors, addArray)
-    # of eckFiles:
-    #   result.addFiles(e.files, prettyMode)
-    # of eckLanguageVersions:
-    #   result.addString("language_versions", e.language_versions)
-    # of eckForkedFrom:
-    #   when e is ConceptExerciseConfig:
-    #     addValOrNull(forked_from, addArray)
-    # of eckTestRunner:
-    #   when e is PracticeExerciseConfig:
-    #     addValOrNull(test_runner, addBool)
-    # of eckRepresenter:
-    #   if e.representer.isSome():
-    #     result.addRepresenter(e.representer.get());
-    # of eckIcon:
-    #   result.addString("icon", e.icon)
-    # of eckBlurb:
-    #   result.addString("blurb", e.blurb)
-    # of eckSource:
-    #   if e.source.isSome():
-    #     result.addString("source", e.source.get())
-    # of eckSourceUrl:
-    #   if e.source_url.isSome():
-    #     result.addString("source_url", e.source_url.get())
-    # of eckCustom:
-    #   addValOrNull(custom, addObject)
+      if e.articles.len > 0:
+        result.addArticles(e.articles)
   result.removeComma()
   result.add "\n}\n"

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -496,8 +496,7 @@ func addArticle(result: var string; val: ArticleConfig; indentLevel = 1) =
   result.addNewlineAndIndent(indentLevel)
   result.add "},"
 
-func addArticles(result: var string;
-    val: seq[ArticleConfig]; indentLevel = 1) =
+func addArticles(result: var string; val: seq[ArticleConfig]; indentLevel = 1) =
   ## Appends the pretty-printed JSON for an `articles` key with value `val` to
   ## `result`.
   result.addNewlineAndIndent(indentLevel)

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -420,7 +420,6 @@ proc prettyExerciseConfig*(e: ConceptExerciseConfig | PracticeExerciseConfig,
   result.removeComma()
   result.add "\n}\n"
 
-
 func addApproachesIntroduction(result: var string;
     val: ApproachesIntroductionConfig; indentLevel = 1) =
   ## Appends the pretty-printed JSON for an `introduction` key with value `val` to

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -434,7 +434,7 @@ func addApproachesIntroduction(result: var string;
   result.add "},"
 
 func addApproach(result: var string; val: ApproachConfig; indentLevel = 1) =
-  ## Appends the pretty-printed JSON for an `approach` element with value `val` to
+  ## Appends the pretty-printed JSON for an `approach` object with value `val` to
   ## `result`.
   result.addNewlineAndIndent(indentLevel)
   result.add "{"
@@ -481,7 +481,7 @@ func prettyApproachesConfig*(e: ApproachesConfig): string =
   result.add "\n}\n"
 
 func addArticle(result: var string; val: ArticleConfig; indentLevel = 1) =
-  ## Appends the pretty-printed JSON for an `article` element with value `val` to
+  ## Appends the pretty-printed JSON for an `article` object with value `val` to
   ## `result`.
   result.addNewlineAndIndent(indentLevel)
   result.add "{"

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -423,7 +423,7 @@ proc prettyExerciseConfig*(e: ConceptExerciseConfig | PracticeExerciseConfig,
 
 func addApproachesIntroduction(result: var string;
     val: ApproachesIntroductionConfig; indentLevel = 1) =
-  ## Appends the pretty-printed JSON for a `representer` key with value `val` to
+  ## Appends the pretty-printed JSON for an `introduction` key with value `val` to
   ## `result`.
   result.addNewlineAndIndent(indentLevel)
   escapeJson("introduction", result)
@@ -434,6 +434,36 @@ func addApproachesIntroduction(result: var string;
   result.removeComma()
   result.addNewlineAndIndent(indentLevel)
   result.add "},"
+
+func addApproach(result: var string;
+    val: ApproachConfig; indentLevel = 1) =
+  ## Appends the pretty-printed JSON for an `approach` element with value `val` to
+  ## `result`.
+  result.addNewlineAndIndent(indentLevel)
+  result.add "{"
+  result.addString("uuid", val.uuid, indentLevel + 1)
+  result.addString("slug", val.slug, indentLevel + 1)
+  result.addString("title", val.title, indentLevel + 1)
+  result.addString("blurb", val.blurb, indentLevel + 1)
+  result.addArray("authors", val.authors, indentLevel + 1)
+  if val.contributors.len > 0:
+    result.addArray("contributors", val.contributors, indentLevel + 1)
+  result.removeComma()
+  result.addNewlineAndIndent(indentLevel)
+  result.add "},"
+
+func addApproaches(result: var string;
+    val: seq[ApproachConfig]; indentLevel = 1) =
+  ## Appends the pretty-printed JSON for an `approaches` key with value `val` to
+  ## `result`.
+  result.addNewlineAndIndent(indentLevel)
+  escapeJson("approaches", result)
+  result.add ": ["
+  for approach in val:
+    result.addApproach(approach, indentLevel + 1)
+  result.removeComma()
+  result.addNewlineAndIndent(indentLevel)
+  result.add "]"
 
 proc prettyApproachesConfig*(e: ApproachesConfig): string =
   ## Serializes `e` as pretty-printed JSON, using the canonical key order.
@@ -447,8 +477,7 @@ proc prettyApproachesConfig*(e: ApproachesConfig): string =
       if e.introduction.authors.len > 0 or e.introduction.contributors.len > 0:
         result.addApproachesIntroduction(e.introduction)
     of ackApproaches:
-      discard # TODO
-      # result.addArray("introduction", e.authors)
+      result.addApproaches(e.approaches)
     # of eckContributors:
     #   addValOrNull(contributors, addArray)
     # of eckFiles:

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -341,16 +341,14 @@ func exerciseConfigKeyOrderForFmt(e: ConceptExerciseConfig |
   if e.custom.isSome() and e.custom.get().len > 0:
     result.add eckCustom
 
-func approachesConfigKeyOrderForFmt(e: ApproachesConfig): seq[
-    ApproachesConfigKey] =
+func approachesConfigKeyOrderForFmt(e: ApproachesConfig): seq[ApproachesConfigKey] =
   result = @[]
   if e.introduction.authors.len > 0:
     result.add ackIntroduction
   if e.approaches.len > 0:
     result.add ackApproaches
 
-func articlesConfigKeyOrderForFmt(e: ArticlesConfig): seq[
-    ArticlesConfigKey] =
+func articlesConfigKeyOrderForFmt(e: ArticlesConfig): seq[ArticlesConfigKey] =
   result = @[]
   if e.articles.len > 0:
     result.add ackArticles
@@ -421,7 +419,8 @@ proc prettyExerciseConfig*(e: ConceptExerciseConfig | PracticeExerciseConfig,
   result.add "\n}\n"
 
 func addApproachesIntroduction(result: var string;
-    val: ApproachesIntroductionConfig; indentLevel = 1) =
+                               val: ApproachesIntroductionConfig;
+                               indentLevel = 1) =
   ## Appends the pretty-printed JSON for an `introduction` key with value `val` to
   ## `result`.
   result.addNewlineAndIndent(indentLevel)
@@ -434,8 +433,7 @@ func addApproachesIntroduction(result: var string;
   result.addNewlineAndIndent(indentLevel)
   result.add "},"
 
-func addApproach(result: var string;
-    val: ApproachConfig; indentLevel = 1) =
+func addApproach(result: var string; val: ApproachConfig; indentLevel = 1) =
   ## Appends the pretty-printed JSON for an `approach` element with value `val` to
   ## `result`.
   result.addNewlineAndIndent(indentLevel)
@@ -452,7 +450,8 @@ func addApproach(result: var string;
   result.add "},"
 
 func addApproaches(result: var string;
-    val: seq[ApproachConfig]; indentLevel = 1) =
+                   val: seq[ApproachConfig];
+                   indentLevel = 1) =
   ## Appends the pretty-printed JSON for an `approaches` key with value `val` to
   ## `result`.
   result.addNewlineAndIndent(indentLevel)
@@ -481,8 +480,7 @@ func prettyApproachesConfig*(e: ApproachesConfig): string =
   result.removeComma()
   result.add "\n}\n"
 
-func addArticle(result: var string;
-    val: ArticleConfig; indentLevel = 1) =
+func addArticle(result: var string; val: ArticleConfig; indentLevel = 1) =
   ## Appends the pretty-printed JSON for an `article` element with value `val` to
   ## `result`.
   result.addNewlineAndIndent(indentLevel)

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -1,5 +1,4 @@
 import std/[algorithm, enumutils, json, options, os, sets, strformat, strutils]
-import pkg/jsony
 import ".."/[cli, helpers, lint/validators, types_exercise_config, types_track_config,
              types_approaches_config, types_articles_config]
 
@@ -113,27 +112,6 @@ func renameHook*(f: var (ConceptExerciseFiles | PracticeExerciseFiles); key: str
     f.originalKeyOrder.add fk
   except ValueError:
     discard
-
-proc parseFile*(path: string, T: typedesc): T =
-  ## Parses the JSON file at `path` into `T`.
-  let contents =
-    try:
-      readFile(path)
-    except IOError:
-      let msg = getCurrentExceptionMsg()
-      stderr.writeLine &"Error: {msg}"
-      quit 1
-  if contents.len > 0:
-    try:
-      contents.fromJson(T)
-    except jsony.JsonError:
-      let jsonyMsg = getCurrentExceptionMsg()
-      let details = tidyJsonyMessage(jsonyMsg, contents)
-      let msg = &"JSON parsing error:\n{path}{details}"
-      stderr.writeLine msg
-      quit 1
-  else:
-    T()
 
 func addNewlineAndIndent(s: var string, indentLevel: int) =
   ## Appends a newline and spaces (given by `indentLevel` multiplied by 2) to
@@ -366,7 +344,7 @@ func exerciseConfigKeyOrderForFmt(e: ConceptExerciseConfig |
 func approachesConfigKeyOrderForFmt(e: ApproachesConfig): seq[
     ApproachesConfigKey] =
   result = @[]
-  if e.introduction.isSome():
+  if e.introduction.authors.len > 0:
     result.add ackIntroduction
   if e.approaches.len > 0:
     result.add ackApproaches

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -465,7 +465,7 @@ func addApproaches(result: var string;
   result.addNewlineAndIndent(indentLevel)
   result.add "]"
 
-proc prettyApproachesConfig*(e: ApproachesConfig): string =
+func prettyApproachesConfig*(e: ApproachesConfig): string =
   ## Serializes `e` as pretty-printed JSON, using the canonical key order.
   let keys = approachesConfigKeyOrderForFmt(e)
 
@@ -512,7 +512,7 @@ func addArticles(result: var string;
   result.addNewlineAndIndent(indentLevel)
   result.add "]"
 
-proc prettyArticlesConfig*(e: ArticlesConfig): string =
+func prettyArticlesConfig*(e: ArticlesConfig): string =
   ## Serializes `e` as pretty-printed JSON, using the canonical key order.
   let keys = articlesConfigKeyOrderForFmt(e)
 

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -420,6 +420,21 @@ proc prettyExerciseConfig*(e: ConceptExerciseConfig | PracticeExerciseConfig,
   result.removeComma()
   result.add "\n}\n"
 
+
+func addApproachesIntroduction(result: var string;
+    val: ApproachesIntroductionConfig; indentLevel = 1) =
+  ## Appends the pretty-printed JSON for a `representer` key with value `val` to
+  ## `result`.
+  result.addNewlineAndIndent(indentLevel)
+  escapeJson("introduction", result)
+  result.add ": {"
+  result.addArray("authors", val.authors, indentLevel + 1)
+  if val.contributors.len > 0:
+    result.addArray("contributors", val.contributors, indentLevel + 1)
+  result.removeComma()
+  result.addNewlineAndIndent(indentLevel)
+  result.add "},"
+
 proc prettyApproachesConfig*(e: ApproachesConfig): string =
   ## Serializes `e` as pretty-printed JSON, using the canonical key order.
   let keys = approachesConfigKeyOrderForFmt(e)
@@ -429,8 +444,8 @@ proc prettyApproachesConfig*(e: ApproachesConfig): string =
   for key in keys:
     case key
     of ackIntroduction:
-      discard # TODO
-      # result.addArray("introduction", e.authors)
+      if e.introduction.authors.len > 0 or e.introduction.contributors.len > 0:
+        result.addApproachesIntroduction(e.introduction)
     of ackApproaches:
       discard # TODO
       # result.addArray("introduction", e.authors)

--- a/src/sync/sync_filepaths.nim
+++ b/src/sync/sync_filepaths.nim
@@ -1,6 +1,6 @@
 import std/[os, strformat, strutils]
 import pkg/jsony
-import ".."/[cli, logger, types_exercise_config, types_track_config]
+import ".."/[cli, helpers, logger, types_exercise_config, types_track_config]
 import "."/sync_common
 
 func replace(slug: Slug, sub: char, by: char): string {.borrow.}

--- a/src/sync/sync_filepaths.nim
+++ b/src/sync/sync_filepaths.nim
@@ -62,8 +62,7 @@ func isSynced(f: ConceptExerciseFiles | PracticeExerciseFiles,
       genCond(exemplar)
     else:
       genCond(example)
-  uniqueCond and genCond(solution) and genCond(test) and genCond(editor) and
-      genCond(invalidator)
+  uniqueCond and genCond(solution) and genCond(test) and genCond(editor) and genCond(invalidator)
 
 type
   ExerciseConfig* = object

--- a/src/sync/sync_filepaths.nim
+++ b/src/sync/sync_filepaths.nim
@@ -62,7 +62,8 @@ func isSynced(f: ConceptExerciseFiles | PracticeExerciseFiles,
       genCond(exemplar)
     else:
       genCond(example)
-  uniqueCond and genCond(solution) and genCond(test) and genCond(editor) and genCond(invalidator)
+  uniqueCond and genCond(solution) and genCond(test) and genCond(editor) and
+      genCond(invalidator)
 
 type
   ExerciseConfig* = object
@@ -142,9 +143,9 @@ proc write(configPairs: seq[PathAndUpdatedExerciseConfig]) =
       let contents =
         case configPair.exerciseConfig.kind
         of ekConcept:
-          configPair.exerciseConfig.c.pretty(prettyMode = pmSync)
+          configPair.exerciseConfig.c.prettyExerciseConfig(prettyMode = pmSync)
         of ekPractice:
-          configPair.exerciseConfig.p.pretty(prettyMode = pmSync)
+          configPair.exerciseConfig.p.prettyExerciseConfig(prettyMode = pmSync)
       writeFile(path, contents)
     else:
       stderr.writeLine &"Unexpected path before writing: {path}"

--- a/src/sync/sync_metadata.nim
+++ b/src/sync/sync_metadata.nim
@@ -24,11 +24,11 @@ proc parseMetadataToml(path: string): UpstreamMetadata =
   let t = parsetoml.parseFile(path)
   result = UpstreamMetadata(
     blurb:
-      if t.hasKey("blurb"): t["blurb"].getStr() else: "",
+    if t.hasKey("blurb"): t["blurb"].getStr() else: "",
     source:
-      if t.hasKey("source"): t["source"].getStr().some() else: none(string),
+    if t.hasKey("source"): t["source"].getStr().some() else: none(string),
     source_url:
-      if t.hasKey("source_url"): t["source_url"].getStr().some() else: none(string)
+    if t.hasKey("source_url"): t["source_url"].getStr().some() else: none(string)
   )
 
 func metadataAreUpToDate(p: PracticeExerciseConfig;
@@ -50,7 +50,8 @@ func update(p: var PracticeExerciseConfig;
     p.originalKeyOrder.add eckBlurb
   if upstreamMetadata.source.isSome() and eckSource notin p.originalKeyOrder:
     p.originalKeyOrder.add eckSource
-  if upstreamMetadata.source_url.isSome() and eckSourceUrl notin p.originalKeyOrder:
+  if upstreamMetadata.source_url.isSome() and eckSourceUrl notin
+      p.originalKeyOrder:
     p.originalKeyOrder.add eckSourceUrl
 
 proc addUnsynced(configPairs: var seq[PathAndUpdatedConfig];
@@ -94,7 +95,7 @@ proc addUnsynced(configPairs: var seq[PathAndUpdatedConfig];
 
 proc write(configPairs: seq[PathAndUpdatedConfig]) =
   for configPair in configPairs:
-    let updatedJson = pretty(configPair.practiceExerciseConfig, pmSync)
+    let updatedJson = prettyExerciseConfig(configPair.practiceExerciseConfig, pmSync)
     let path = configPair.path
     if path.endsWith(&".meta{DirSep}config.json"):
       createDir path.parentDir()

--- a/src/sync/sync_metadata.nim
+++ b/src/sync/sync_metadata.nim
@@ -1,6 +1,6 @@
 import std/[options, os, strformat, strutils]
 import pkg/parsetoml
-import ".."/[cli, logger, types_exercise_config, types_track_config]
+import ".."/[cli, helpers, logger, types_exercise_config, types_track_config]
 import "."/sync_common
 
 # Silence the styleCheck hint for `source_url`.

--- a/src/sync/sync_metadata.nim
+++ b/src/sync/sync_metadata.nim
@@ -24,11 +24,11 @@ proc parseMetadataToml(path: string): UpstreamMetadata =
   let t = parsetoml.parseFile(path)
   result = UpstreamMetadata(
     blurb:
-    if t.hasKey("blurb"): t["blurb"].getStr() else: "",
+      if t.hasKey("blurb"): t["blurb"].getStr() else: "",
     source:
-    if t.hasKey("source"): t["source"].getStr().some() else: none(string),
+      if t.hasKey("source"): t["source"].getStr().some() else: none(string),
     source_url:
-    if t.hasKey("source_url"): t["source_url"].getStr().some() else: none(string)
+      if t.hasKey("source_url"): t["source_url"].getStr().some() else: none(string)
   )
 
 func metadataAreUpToDate(p: PracticeExerciseConfig;
@@ -50,8 +50,7 @@ func update(p: var PracticeExerciseConfig;
     p.originalKeyOrder.add eckBlurb
   if upstreamMetadata.source.isSome() and eckSource notin p.originalKeyOrder:
     p.originalKeyOrder.add eckSource
-  if upstreamMetadata.source_url.isSome() and eckSourceUrl notin
-      p.originalKeyOrder:
+  if upstreamMetadata.source_url.isSome() and eckSourceUrl notin p.originalKeyOrder:
     p.originalKeyOrder.add eckSourceUrl
 
 proc addUnsynced(configPairs: var seq[PathAndUpdatedConfig];

--- a/src/types_approaches_config.nim
+++ b/src/types_approaches_config.nim
@@ -1,6 +1,24 @@
 import std/options
+import pkg/jsony
+import "."/[cli, helpers]
 
 type
+  ApproachesConfigKey* = enum
+    ackIntroduction = "introduction"
+    ackApproaches = "approaches"
+
+  ApproachKey* = enum
+    akUuid = "uuid"
+    akSlug = "slug"
+    akTitle = "title"
+    akBlurb = "blurb"
+    akAuthors = "authors"
+    akContributors = "contributors"
+
+  ApproachIntroductionKey* = enum
+    aiAuthors = "authors"
+    aiContributors = "contributors"
+
   ApproachesIntroductionConfig* = object
     authors*: seq[string]
     contributors*: Option[seq[string]]
@@ -16,3 +34,11 @@ type
   ApproachesConfig* = object
     introduction*: Option[ApproachesIntroductionConfig]
     approaches*: seq[ApproachConfig]
+
+proc init*(T: typedesc[ApproachesConfig]; approachesConfigContents: string): T =
+  ## Deserializes `approachesConfigContents` using `jsony` to a `ApproachesConfig` object.
+  try:
+    result = fromJson(approachesConfigContents, ApproachesConfig)
+  except jsony.JsonError:
+    let msg = tidyJsonyErrorMsg(approachesConfigContents)
+    showError(msg)

--- a/src/types_approaches_config.nim
+++ b/src/types_approaches_config.nim
@@ -1,4 +1,4 @@
-import "."/[helpers]
+import "."/helpers
 
 type
   ApproachesConfigKey* = enum

--- a/src/types_approaches_config.nim
+++ b/src/types_approaches_config.nim
@@ -1,0 +1,18 @@
+import std/options
+
+type
+  ApproachesIntroductionConfig* = object
+    authors*: seq[string]
+    contributors*: Option[seq[string]]
+
+  ApproachConfig* = object
+    uuid*: string
+    slug*: string
+    title*: string
+    blurb*: string
+    authors*: seq[string]
+    contributors*: Option[seq[string]]
+
+  ApproachesConfig* = object
+    introduction*: Option[ApproachesIntroductionConfig]
+    approaches*: seq[ApproachConfig]

--- a/src/types_approaches_config.nim
+++ b/src/types_approaches_config.nim
@@ -1,6 +1,5 @@
 import std/options
-import pkg/jsony
-import "."/[cli, helpers]
+import "."/[helpers]
 
 type
   ApproachesConfigKey* = enum
@@ -21,7 +20,7 @@ type
 
   ApproachesIntroductionConfig* = object
     authors*: seq[string]
-    contributors*: Option[seq[string]]
+    contributors*: seq[string]
 
   ApproachConfig* = object
     uuid*: string
@@ -29,16 +28,13 @@ type
     title*: string
     blurb*: string
     authors*: seq[string]
-    contributors*: Option[seq[string]]
+    contributors*: seq[string]
 
   ApproachesConfig* = object
-    introduction*: Option[ApproachesIntroductionConfig]
+    introduction*: ApproachesIntroductionConfig
     approaches*: seq[ApproachConfig]
 
-proc init*(T: typedesc[ApproachesConfig]; approachesConfigContents: string): T =
-  ## Deserializes `approachesConfigContents` using `jsony` to a `ApproachesConfig` object.
-  try:
-    result = fromJson(approachesConfigContents, ApproachesConfig)
-  except jsony.JsonError:
-    let msg = tidyJsonyErrorMsg(approachesConfigContents)
-    showError(msg)
+proc init*(T: typedesc[ApproachesConfig]; approachesConfigFilePath: string): T =
+  ## Deserializes contents of `approachesConfigFilePath` using `jsony` to
+  ## an `ApproachesConfig` object.
+  parseFile(approachesConfigFilePath, ApproachesConfig)

--- a/src/types_approaches_config.nim
+++ b/src/types_approaches_config.nim
@@ -1,4 +1,3 @@
-import std/options
 import "."/[helpers]
 
 type

--- a/src/types_articles_config.nim
+++ b/src/types_articles_config.nim
@@ -1,6 +1,19 @@
 import std/options
+import pkg/jsony
+import "."/[cli, helpers]
 
 type
+  ArticlesConfigKey* = enum
+    ackArticles = "articles"
+
+  ArticleKey* = enum
+    akUuid = "uuid"
+    akSlug = "slug"
+    akTitle = "title"
+    akBlurb = "blurb"
+    akAuthors = "authors"
+    akContributors = "contributors"
+
   ArticleConfig* = object
     uuid*: string
     slug*: string
@@ -11,3 +24,11 @@ type
 
   ArticlesConfig* = object
     articles*: seq[ArticleConfig]
+
+proc init*(T: typedesc[ArticlesConfig]; articlesConfigContents: string): T =
+  ## Deserializes `articlesConfigContents` using `jsony` to a `ArticlesConfig` object.
+  try:
+    result = fromJson(articlesConfigContents, ArticlesConfig)
+  except jsony.JsonError:
+    let msg = tidyJsonyErrorMsg(articlesConfigContents)
+    showError(msg)

--- a/src/types_articles_config.nim
+++ b/src/types_articles_config.nim
@@ -1,0 +1,13 @@
+import std/options
+
+type
+  ArticleConfig* = object
+    uuid*: string
+    slug*: string
+    title*: string
+    blurb*: string
+    authors*: seq[string]
+    contributors*: Option[seq[string]]
+
+  ArticlesConfig* = object
+    articles*: seq[ArticleConfig]

--- a/src/types_articles_config.nim
+++ b/src/types_articles_config.nim
@@ -1,4 +1,3 @@
-import std/options
 import "."/[helpers]
 
 type
@@ -19,7 +18,7 @@ type
     title*: string
     blurb*: string
     authors*: seq[string]
-    contributors*: Option[seq[string]]
+    contributors*: seq[string]
 
   ArticlesConfig* = object
     articles*: seq[ArticleConfig]

--- a/src/types_articles_config.nim
+++ b/src/types_articles_config.nim
@@ -1,6 +1,5 @@
 import std/options
-import pkg/jsony
-import "."/[cli, helpers]
+import "."/[helpers]
 
 type
   ArticlesConfigKey* = enum
@@ -25,10 +24,7 @@ type
   ArticlesConfig* = object
     articles*: seq[ArticleConfig]
 
-proc init*(T: typedesc[ArticlesConfig]; articlesConfigContents: string): T =
-  ## Deserializes `articlesConfigContents` using `jsony` to a `ArticlesConfig` object.
-  try:
-    result = fromJson(articlesConfigContents, ArticlesConfig)
-  except jsony.JsonError:
-    let msg = tidyJsonyErrorMsg(articlesConfigContents)
-    showError(msg)
+proc init*(T: typedesc[ArticlesConfig]; articlesConfigFilePath: string): T =
+  ## Deserializes contents of `articlesConfigFilePath` using `jsony` to
+  ## an `ArticlesConfig` object.
+  parseFile(articlesConfigFilePath, ArticlesConfig)

--- a/src/types_articles_config.nim
+++ b/src/types_articles_config.nim
@@ -1,4 +1,4 @@
-import "."/[helpers]
+import "."/helpers
 
 type
   ArticlesConfigKey* = enum

--- a/tests/test_fmt.nim
+++ b/tests/test_fmt.nim
@@ -48,26 +48,26 @@ proc testFmt =
       test "empty Concept Exercise":
         let empty = ConceptExerciseConfig()
         check:
-          empty.pretty(pmFmt) == emptyConceptExerciseContents
+          empty.prettyExerciseConfig(pmFmt) == emptyConceptExerciseContents
 
       test "empty Practice Exercise":
         let empty = PracticeExerciseConfig()
         check:
-          empty.pretty(pmFmt) == emptyPracticeExerciseContents
+          empty.prettyExerciseConfig(pmFmt) == emptyPracticeExerciseContents
 
       test "reorders mandatory keys - Concept Exercise":
         let empty = ConceptExerciseConfig(
           originalKeyOrder: @[eckBlurb, eckAuthors, eckFiles]
         )
         check:
-          empty.pretty(pmFmt) == emptyConceptExerciseContents
+          empty.prettyExerciseConfig(pmFmt) == emptyConceptExerciseContents
 
       test "reorders mandatory keys - Practice Exercise":
         let empty = PracticeExerciseConfig(
           originalKeyOrder: @[eckBlurb, eckAuthors, eckFiles]
         )
         check:
-          empty.pretty(pmFmt) == emptyPracticeExerciseContents
+          empty.prettyExerciseConfig(pmFmt) == emptyPracticeExerciseContents
 
     test "omits optional keys that have an empty value - Concept Exercise":
       let p = ConceptExerciseConfig(
@@ -91,7 +91,7 @@ proc testFmt =
       }
       """.dedent(6)
       check:
-        p.pretty(pmFmt) == expected
+        p.prettyExerciseConfig(pmFmt) == expected
 
     test "omits optional keys that have an empty value - Practice Exercise":
       let p = PracticeExerciseConfig(
@@ -115,7 +115,7 @@ proc testFmt =
       }
       """.dedent(6)
       check:
-        p.pretty(pmFmt) == expected
+        p.prettyExerciseConfig(pmFmt) == expected
 
     block:
       let customJson = """
@@ -213,7 +213,7 @@ proc testFmt =
           shuffle(exerciseConfig.originalKeyOrder)
           shuffle(exerciseConfig.files.originalKeyOrder)
           check:
-            exerciseConfig.pretty(pmFmt) == expected
+            exerciseConfig.prettyExerciseConfig(pmFmt) == expected
 
       test "populated config with random key order - Practice Exercise":
         var exerciseConfig = PracticeExerciseConfig(
@@ -294,7 +294,7 @@ proc testFmt =
           shuffle(exerciseConfig.originalKeyOrder)
           shuffle(exerciseConfig.files.originalKeyOrder)
           check:
-            exerciseConfig.pretty(pmFmt) == expected
+            exerciseConfig.prettyExerciseConfig(pmFmt) == expected
 
     test "fmt omits `test_runner: true`":
       let exerciseConfig = PracticeExerciseConfig(
@@ -312,7 +312,7 @@ proc testFmt =
       }
       """.dedent(6)
       check:
-        exerciseConfig.pretty(pmFmt) == expected
+        exerciseConfig.prettyExerciseConfig(pmFmt) == expected
 
     block:
       # This checks that we format every exercise `.meta/config.json` file in
@@ -361,7 +361,7 @@ proc testFmt =
         for exerciseDir in getSortedSubdirs(conceptExercisesDir.Path):
           let exerciseConfigPath = joinPath(exerciseDir.string, ".meta", "config.json")
           let exerciseConfig = parseFile(exerciseConfigPath, ConceptExerciseConfig)
-          let ourSerialization = exerciseConfig.pretty(pmFmt)
+          let ourSerialization = exerciseConfig.prettyExerciseConfig(pmFmt)
           let stdlibSerialization = fmtViaRoundtrip(exerciseConfig)
           check ourSerialization == stdlibSerialization
 
@@ -369,7 +369,7 @@ proc testFmt =
         for exerciseDir in getSortedSubdirs(practiceExercisesDir.Path):
           let exerciseConfigPath = joinPath(exerciseDir.string, ".meta", "config.json")
           let exerciseConfig = parseFile(exerciseConfigPath, PracticeExerciseConfig)
-          let ourSerialization = exerciseConfig.pretty(pmFmt)
+          let ourSerialization = exerciseConfig.prettyExerciseConfig(pmFmt)
           let stdlibSerialization = fmtViaRoundtrip(exerciseConfig)
           check ourSerialization == stdlibSerialization
 

--- a/tests/test_sync.nim
+++ b/tests/test_sync.nim
@@ -86,7 +86,7 @@ proc testSyncCommon =
       }
       """.dedent(6)
       check:
-        empty.pretty(pmSync) == expected
+        empty.prettyExerciseConfig(pmSync) == expected
 
     test "empty Practice Exercise":
       let empty = PracticeExerciseConfig()
@@ -102,7 +102,7 @@ proc testSyncCommon =
       }
       """.dedent(6)
       check:
-        empty.pretty(pmSync) == expected
+        empty.prettyExerciseConfig(pmSync) == expected
 
     test "Practice Exercise with `custom` key having value of the empty object":
       let p = PracticeExerciseConfig(
@@ -125,7 +125,7 @@ proc testSyncCommon =
       }
       """.dedent(6)
       check:
-        p.pretty(pmSync) == expected
+        p.prettyExerciseConfig(pmSync) == expected
 
     let customJson = """
       {
@@ -217,7 +217,7 @@ proc testSyncCommon =
       }
       """.dedent(6)
       check:
-        exerciseConfig.pretty(pmSync) == expected
+        exerciseConfig.prettyExerciseConfig(pmSync) == expected
 
     test "populated Practice Exercise":
       let exerciseConfig = PracticeExerciseConfig(
@@ -294,7 +294,7 @@ proc testSyncCommon =
       }
       """.dedent(6)
       check:
-        exerciseConfig.pretty(pmSync) == expected
+        exerciseConfig.prettyExerciseConfig(pmSync) == expected
 
     test "test_runner: true is not omitted when not formatting":
       let exerciseConfig = PracticeExerciseConfig(
@@ -313,7 +313,7 @@ proc testSyncCommon =
       }
       """.dedent(6)
       check:
-        exerciseConfig.pretty(pmSync) == expected
+        exerciseConfig.prettyExerciseConfig(pmSync) == expected
 
     test "pretty: can use `pmSync` when an optional key has the value `null`":
       let exerciseConfig = PracticeExerciseConfig(
@@ -332,7 +332,7 @@ proc testSyncCommon =
       }
       """.dedent(6)
       check:
-        exerciseConfig.pretty(pmSync) == expected
+        exerciseConfig.prettyExerciseConfig(pmSync) == expected
 
     proc stdlibSerialize(path: string): string =
       var j = json.parseFile(path)
@@ -346,7 +346,7 @@ proc testSyncCommon =
       for exerciseDir in getSortedSubdirs(conceptExercisesDir.Path):
         let exerciseConfigPath = joinPath(exerciseDir.string, ".meta", "config.json")
         let exerciseConfig = parseFile(exerciseConfigPath, ConceptExerciseConfig)
-        let ourSerialization = exerciseConfig.pretty(pmSync)
+        let ourSerialization = exerciseConfig.prettyExerciseConfig(pmSync)
         let stdlibSerialization = stdlibSerialize(exerciseConfigPath)
         check ourSerialization == stdlibSerialization
 
@@ -354,7 +354,7 @@ proc testSyncCommon =
       for exerciseDir in getSortedSubdirs(practiceExercisesDir.Path):
         let exerciseConfigPath = joinPath(exerciseDir.string, ".meta", "config.json")
         let exerciseConfig = parseFile(exerciseConfigPath, PracticeExerciseConfig)
-        let ourSerialization = exerciseConfig.pretty(pmSync)
+        let ourSerialization = exerciseConfig.prettyExerciseConfig(pmSync)
         let stdlibSerialization = stdlibSerialize(exerciseConfigPath)
         check ourSerialization == stdlibSerialization
 


### PR DESCRIPTION
This is an unpolished PR. What remains to be done is:

- Cleanup the code
- Add tests
- Tweak the wording of the formatted message displayed at the end of the run