### PR TITLE
config: disable BareExcept warnings

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,5 +1,6 @@
 switch("styleCheck", "error")
 hint("Name", on)
+warning("BareExcept", off)
 # switch("experimental", "strictEffects") # TODO: re-enable when possible with `parsetoml`
 switch("experimental", "strictFuncs")
 switch("define", "nimStrictDelete")


### PR DESCRIPTION
The bump to Nim 1.6.12 [caused][1] warnings to appear in the output of `nimble build` and `nimble test`, due to the usage of bare `except` in pkg/jsony and std/unittest.

These warnings will be [disabled by default in the next Nim release][2], and [jsony may resolve the underlying issue][3], but let's disable them explicitly in the meantime.

[1]: https://github.com/nim-lang/Nim/commit/f01ffbf6f1f6
[2]: https://github.com/nim-lang/Nim/commit/69c193e5e2db
[3]: https://www.github.com/treeform/jsony/pull/58

---

Follow-up to https://github.com/exercism/configlet/pull/739#issuecomment-1480238713.

Without this PR, see the large amount of [noise in `nimble test`](https://github.com/exercism/configlet/actions/runs/5078434422/jobs/9122932759#step:6:19).