### PR TITLE
config: explicitly use mm:refc

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -6,6 +6,7 @@ switch("experimental", "strictFuncs")
 switch("define", "nimStrictDelete")
 when defined(nimHasOutParams):
   switch("experimental", "strictDefs")
+switch("mm", "refc")
 
 # Replace the stdlib JSON modules with our own stricter versions.
 patchFile("stdlib", "json", "src/patched_stdlib/json")


### PR DESCRIPTION
Nim 2.0 will change the default memory management strategy from refc to orc. To simplify the Nim 2.0 transition, explicitly specify refc for now.

One reason: otherwise, we get a large number of ProveInit warnings, which are easier to handle separately. If I recall correctly, some of them are from jsony. We may also have to tweak our usage of `requiresInit` in some places.