### PR TITLE
sync(exercises): resolve ProveInit warning

### DIFF
--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -51,7 +51,7 @@ proc new(T: typedesc[ExerciseTestCase], testCase: ProbSpecsTestCase): T =
     uuid: uuid(testCase),
     description: description(testCase),
     json: testCase,
-    reimplements: none(ExerciseTestCase),
+    reimplements: Option[ExerciseTestCase](), # `none` produces a ProveInit warning
   )
 
 proc getReimplementations(testCases: ProbSpecsTestCases): Table[string, string] =


### PR DESCRIPTION
Before this commit, running `nimble build` would produce a ProveInit warning:

```console
$ nimble build
  Verifying dependencies for configlet@4.0.0
  [...]
   Building configlet/configlet using c backend
/foo/configlet/src/sync/exercises.nim(93, 37) template/generic instantiation of `init` from here
/foo/configlet/src/sync/exercises.nim(71, 33) template/generic instantiation of `new` from here
/foo/configlet/src/sync/exercises.nim(54, 23) template/generic instantiation of `none` from here
/path/to/nim-1.6.12/lib/pure/options.nim(140, 3) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
```

---

IIRC this warning becomes a compile error in Nim 2.0 in some situations. It happens because `options.nim` implements `none` with a `discard`, and because we wrote `requiresInit` on this type. Alternatively, we could remove the `requiresInit`.