### PR TITLE
nimble, sync(tracks): bump parsetoml from 0.6.0 to 0.7.1

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -2,7 +2,7 @@ switch("styleCheck", "error")
 hint("Name", on)
 warning("BareExcept", off)
 switch("experimental", "strictEffects")
-# switch("experimental", "strictFuncs") # TODO: re-enable when possible with `parsetoml`
+switch("experimental", "strictFuncs")
 switch("define", "nimStrictDelete")
 when defined(nimHasOutParams):
   switch("experimental", "strictDefs")

--- a/config.nims
+++ b/config.nims
@@ -1,8 +1,8 @@
 switch("styleCheck", "error")
 hint("Name", on)
 warning("BareExcept", off)
-# switch("experimental", "strictEffects") # TODO: re-enable when possible with `parsetoml`
-switch("experimental", "strictFuncs")
+switch("experimental", "strictEffects")
+# switch("experimental", "strictFuncs") # TODO: re-enable when possible with `parsetoml`
 switch("define", "nimStrictDelete")
 when defined(nimHasOutParams):
   switch("experimental", "strictDefs")

--- a/config.nims
+++ b/config.nims
@@ -1,7 +1,7 @@
 switch("styleCheck", "error")
 hint("Name", on)
 warning("BareExcept", off)
-switch("experimental", "strictEffects")
+# switch("experimental", "strictEffects") # TODO: re-enable when possible with `parsetoml`
 switch("experimental", "strictFuncs")
 switch("define", "nimStrictDelete")
 when defined(nimHasOutParams):

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -21,7 +21,7 @@ bin           = @["configlet"]
 requires "nim >= 1.6.12"
 requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"      # 1.5.19 (2021-09-13)
 requires "jsony#2a2cc4331720b7695c8b66529dbfea6952727e7b"       # 1.1.3  (2022-01-03)
-requires "parsetoml#9cdeb3f65fd10302da157db8a8bac5c42f055249"   # 0.6.0  (2021-06-07)
+requires "parsetoml#33520d8e6d2e993157eeb08d46b6c5f058a32cb7"   # 0.7.0  (2022-12-31)
 requires "supersnappy#e4df8cb5468dd96fc5a4764028e20c8a3942f16a" # 2.1.3  (2022-06-12)
 requires "uuids#8cb8720b567c6bcb261bd1c0f7491bdb5209ad06"       # 0.1.11 (2021-01-15)
 # To make Nimble use the pinned `isaac` version, we must pin `isaac` after `uuids`

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -21,7 +21,7 @@ bin           = @["configlet"]
 requires "nim >= 1.6.12"
 requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"      # 1.5.19 (2021-09-13)
 requires "jsony#2a2cc4331720b7695c8b66529dbfea6952727e7b"       # 1.1.3  (2022-01-03)
-requires "parsetoml#ed6ca4ee9fdd41bfc3cb0974612a85e7dff26b97"   #        (2023-05-08)
+requires "parsetoml#6e5e16179fa2db60f2f37d8b1af4128aaa9c8aaf"   # 0.7.1  (2023-08-06)
 requires "supersnappy#e4df8cb5468dd96fc5a4764028e20c8a3942f16a" # 2.1.3  (2022-06-12)
 requires "uuids#8cb8720b567c6bcb261bd1c0f7491bdb5209ad06"       # 0.1.11 (2021-01-15)
 # To make Nimble use the pinned `isaac` version, we must pin `isaac` after `uuids`

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -21,7 +21,7 @@ bin           = @["configlet"]
 requires "nim >= 1.6.12"
 requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"      # 1.5.19 (2021-09-13)
 requires "jsony#2a2cc4331720b7695c8b66529dbfea6952727e7b"       # 1.1.3  (2022-01-03)
-requires "parsetoml#33520d8e6d2e993157eeb08d46b6c5f058a32cb7"   # 0.7.0  (2022-12-31)
+requires "parsetoml#ed6ca4ee9fdd41bfc3cb0974612a85e7dff26b97"   #        (2023-05-08)
 requires "supersnappy#e4df8cb5468dd96fc5a4764028e20c8a3942f16a" # 2.1.3  (2022-06-12)
 requires "uuids#8cb8720b567c6bcb261bd1c0f7491bdb5209ad06"       # 0.1.11 (2021-01-15)
 # To make Nimble use the pinned `isaac` version, we must pin `isaac` after `uuids`

--- a/src/sync/tracks.nim
+++ b/src/sync/tracks.nim
@@ -71,7 +71,7 @@ proc init(T: typedesc[PracticeExerciseTests], testsPath: string): T =
     let tests =
       try:
         parsetoml.parseFile(testsPath)
-      except TomlError: # Note that `TomlError` inherits from `Defect`.
+      except TomlError:
         stderr.writeLine fmt"""
 
           Error: A 'tests.toml' file contains invalid TOML:


### PR DESCRIPTION
Parsetoml merged these commits:

- https://github.com/NimParsers/parsetoml/commit/ed6ca4ee9fdd41bfc3cb0974612a85e7dff26b97
- https://github.com/NimParsers/parsetoml/commit/d0890980ab913e563600fc2f8a003c43eb087eb0

Bump parsetoml so that we get these commits, which allows us to re-enable strictEffects (which are enabled by default in Nim 2.0).

---

Before merging this PR, let's try to do all of the below:

- [x] Wait for [NimParsers/parsetoml#61](https://www.github.com/NimParsers/parsetoml/issues/61) to be resolved
- [x] Re-enable `strictFuncs`
- [x] Bump to 0.7.1/0.8.0 if a new parsetoml tag is created