### PR TITLE
lint(track_config): change `average_run_time` from a float to an int

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -62,8 +62,8 @@ proc hasValidTestRunner(data: JsonNode; path: Path): bool =
       # Only check the `test_runner` object if `status.test_runner` is `true`.
       if data[s][k].getBool():
         if hasObject(data, k, path):
-          result = hasFloat(data[k], "average_run_time", path, k,
-                            requirePositive = true, decimalPlaces = 1)
+          result = hasInteger(data[k], "average_run_time", path, k,
+                              allowed = 1..20)
       else:
         result = true
 


### PR DESCRIPTION
Having the average run time as a float gives the impression of being
exact, whereas the actual run time wildly varies due to a wide variety
of reasons.

A second downside is that `jq`, which is often used to work with
track config files, will remove any trailing `.0` from a number,
which caused linting to fail.

When we release this, I'll do a bulk update of the track configs.

See https://github.com/exercism/docs/pull/430

Closes: https://github.com/exercism/configlet/issues/734