### PR TITLE
.github: bump `iffy/install-nim` from 4.7.1 to 4.7.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         run: ./.github/bin/linux-install-build-tools
 
       - name: Install Nim
-        uses: iffy/install-nim@9e500b9ddc377c597719e98821acbd1f5925c056
+        uses: iffy/install-nim@bea090a732f3e1918187bac8dd05ab1ab87a569f
         with:
           version: "binary:1.6.12"
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./.github/bin/linux-install-build-tools
 
       - name: Install Nim
-        uses: iffy/install-nim@9e500b9ddc377c597719e98821acbd1f5925c056
+        uses: iffy/install-nim@bea090a732f3e1918187bac8dd05ab1ab87a569f
         with:
           version: "binary:1.6.12"
         env:


### PR DESCRIPTION
This is required to bump to Nim 1.6.14.

Dependabot didn't make a PR for this because iffy created only a tag, not a release.

Previous bump: https://github.com/exercism/configlet/pull/744/

---

See the [changes since the previous release][1].

[1]: https://github.com/iffy/install-nim/compare/9e500b9ddc37...bea090a732f3