### PR TITLE
.github, nimble: bump Nim from 1.6.12 to 1.6.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@bea090a732f3e1918187bac8dd05ab1ab87a569f
         with:
-          version: "binary:1.6.12"
+          version: "binary:1.6.14"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@bea090a732f3e1918187bac8dd05ab1ab87a569f
         with:
-          version: "binary:1.6.12"
+          version: "binary:1.6.14"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -18,7 +18,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 1.6.12"
+requires "nim >= 1.6.14"
 requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"      # 1.5.19 (2021-09-13)
 requires "jsony#2a2cc4331720b7695c8b66529dbfea6952727e7b"       # 1.1.3  (2022-01-03)
 requires "parsetoml#9cdeb3f65fd10302da157db8a8bac5c42f055249"   # 0.6.0  (2021-06-07)


### PR DESCRIPTION
See the [release blog post][1] and [changes since 1.6.12][2].

[1]: https://nim-lang.org/blog/2023/06/27/version-1614-released.html
[2]: https://github.com/nim-lang/Nim/compare/v1.6.12...v1.6.14

Previous bump: https://github.com/exercism/configlet/pull/739