### PR TITLE
lint: make `online_editor.highlightjs_language` optional

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -22,7 +22,7 @@ proc hasValidOnlineEditor(data: JsonNode; path: Path): bool =
     let checks = [
       hasString(d, "indent_style", path, k, allowed = indentStyles),
       hasInteger(d, "indent_size", path, k, allowed = 0..8),
-      hasString(d, "highlightjs_language", path, k),
+      hasString(d, "highlightjs_language", path, k, isRequired = false),
     ]
     result = allTrue(checks)
 


### PR DESCRIPTION
We've recently changed the spec a bit (see https://github.com/exercism/docs/pull/450), which makes `online_editor.highlightjs_language` optional.