### PR TITLE
.github: bump iffy/install-nim from 4.7.2 to 4.7.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         run: ./.github/bin/linux-install-build-tools
 
       - name: Install Nim
-        uses: iffy/install-nim@bea090a732f3e1918187bac8dd05ab1ab87a569f
+        uses: iffy/install-nim@ac410af52523f06e0fa037ee81d06ead7b95692c
         with:
           version: "binary:1.6.12"
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./.github/bin/linux-install-build-tools
 
       - name: Install Nim
-        uses: iffy/install-nim@bea090a732f3e1918187bac8dd05ab1ab87a569f
+        uses: iffy/install-nim@ac410af52523f06e0fa037ee81d06ead7b95692c
         with:
           version: "binary:1.6.12"
         env:


### PR DESCRIPTION
This adds support for Nim 2.0.

See the [changes since the previous release][1].

[1]: https://github.com/iffy/install-nim/compare/bea090a732f3...ac410af52523

---

Previous bump: #766