### PR TITLE
config: re-enable strictEffects

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,7 +1,7 @@
 switch("styleCheck", "error")
 hint("Name", on)
 warning("BareExcept", off)
-# switch("experimental", "strictEffects") # TODO: re-enable when possible with `parsetoml`
+switch("experimental", "strictEffects")
 switch("experimental", "strictFuncs")
 switch("define", "nimStrictDelete")
 when defined(nimHasOutParams):


### PR DESCRIPTION
This change was already approved in https://github.com/exercism/configlet/pull/759, but I decided that I want it in a separate commit, and without merging that PR with "rebase and merge".

Follow-up from https://github.com/exercism/configlet/pull/759#issuecomment-1666783443

---

We had to disable strictEffects in 708f75bec4fa, but parsetoml has once again [made it possible to compile with both strictEffects and strictFuncs][2], and we've bumped to the latest parsetoml in dcb0df05afcc.

In Nim 2.0, [strictEffects is the default][4].

[2]: https://github.com/NimParsers/parsetoml/commit/d0890980ab91
[4]: https://nim-lang.org/blog/2023/08/01/nim-v20-released.html#strict-effects
