### PR TITLE
nimble, patches: bump cligen from 1.5.19 to 1.6.13

### DIFF
--- a/configlet.nimble
+++ b/configlet.nimble
@@ -19,7 +19,7 @@ bin           = @["configlet"]
 
 # Dependencies
 requires "nim >= 1.6.12"
-requires "cligen#b962cf8bc0be847cbc1b4f77952775de765e9689"      # 1.5.19 (2021-09-13)
+requires "cligen#8d4e5fb58917eb681d3babd8561ddd175f01df3d"      # 1.6.13 (2023-07-29)
 requires "jsony#2a2cc4331720b7695c8b66529dbfea6952727e7b"       # 1.1.3  (2022-01-03)
 requires "parsetoml#6e5e16179fa2db60f2f37d8b1af4128aaa9c8aaf"   # 0.7.1  (2023-08-06)
 requires "supersnappy#e4df8cb5468dd96fc5a4764028e20c8a3942f16a" # 2.1.3  (2022-06-12)

--- a/patches/parseopt3_allow_long_option_optional_value.patch
+++ b/patches/parseopt3_allow_long_option_optional_value.patch
@@ -1,5 +1,5 @@
 diff --git a/cligen/parseopt3.nim b/cligen/parseopt3.nim
-index a865952..850d016 100644
+index 1ab2f22..045025b 100644
 --- a/cligen/parseopt3.nim
 +++ b/cligen/parseopt3.nim
 @@ -267,8 +267,17 @@ proc doLong(p: var OptParser) =

--- a/patches/patch.nim
+++ b/patches/patch.nim
@@ -53,7 +53,7 @@ proc patchCligen(packagePaths: PackagePaths) =
   patch(
     packagePaths.cligen,
     thisDir / "parseopt3_allow_long_option_optional_value.patch",
-    ("cligen" / "parseopt3.nim", 1647921161'i64)
+    ("cligen" / "parseopt3.nim", 3589591455'i64)
   )
 
 proc ensureThatNimblePackagesArePatched* =


### PR DESCRIPTION
Recall that we use cligen only for `parseopt3.nim`, which is [rarely changed][1].

But it **has** changed slightly since the last bump, so we must also update the expected post-patch hash.

[1]: https://github.com/c-blake/cligen/commits/1.6.13/cligen/parseopt3.nim

---

Try to resolve the Nim 2.0 bump causing the patch to fail on Windows. ~I think it's using a later version of cligen when there's no lock file yet.~

Edit: this PR doesn't help with that issue, but it's fine anyway.