### PR TITLE
nimble: bump jsony from 1.1.3 to 1.1.5

### DIFF
--- a/configlet.nimble
+++ b/configlet.nimble
@@ -20,7 +20,7 @@ bin           = @["configlet"]
 # Dependencies
 requires "nim >= 1.6.12"
 requires "cligen#8d4e5fb58917eb681d3babd8561ddd175f01df3d"      # 1.6.13 (2023-07-29)
-requires "jsony#2a2cc4331720b7695c8b66529dbfea6952727e7b"       # 1.1.3  (2022-01-03)
+requires "jsony#ea811bec7fa50f5abd3088ba94cda74285e93f18"       # 1.1.5  (2023-02-09)
 requires "parsetoml#6e5e16179fa2db60f2f37d8b1af4128aaa9c8aaf"   # 0.7.1  (2023-08-06)
 requires "supersnappy#e4df8cb5468dd96fc5a4764028e20c8a3942f16a" # 2.1.3  (2022-06-12)
 


### PR DESCRIPTION
See the releases [1.1.4][1] and [1.1.5][2] and the [list of changes][3].

[1]: https://github.com/treeform/jsony/releases/tag/1.1.4
[2]: https://github.com/treeform/jsony/releases/tag/1.1.5
[3]: https://github.com/treeform/jsony/compare/1.1.3...1.1.5