### PR TITLE
config, src: enable nimPreviewSlimSystem

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -5,6 +5,7 @@ warning("ProveInit", off)
 warning("Uninit", off)
 switch("experimental", "strictDefs")
 switch("experimental", "strictFuncs")
+switch("define", "nimPreviewSlimSystem")
 switch("define", "nimStrictDelete")
 switch("mm", "refc")
 

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -1,4 +1,4 @@
-import std/[os, parseutils, strformat, strutils, terminal]
+import std/[os, parseutils, strformat, strutils, syncio, terminal]
 import pkg/supersnappy
 import patched_libs/parseopt3
 

--- a/src/completion/completion.nim
+++ b/src/completion/completion.nim
@@ -1,4 +1,4 @@
-import std/[os, strformat]
+import std/[os, strformat, syncio]
 import pkg/supersnappy
 import ../cli
 


### PR DESCRIPTION
From the Nim 2.0.0 [detailed changelog][1] (emphasis added):

>- Certain definitions from the default `system` module have been moved to the following new modules:
>
>   - `std/syncio`
>   - `std/assertions`
>   - `std/formatfloat`
>   - `std/objectdollar`
>   - `std/widestrs`
>   - `std/typedthreads`
>   - `std/sysatomics`
>
>   In the future, **these definitions will be removed from the `system` module, and their respective modules will have to be imported to use them**. Currently, to make these imports required, the `-d:nimPreviewSlimSystem` option may be used.
>
>- Enabling `-d:nimPreviewSlimSystem` also removes the following deprecated symbols in the `system` module:
>   - Aliases with an `Error` suffix to exception types that have a `Defect` suffix (see [exceptions](https://nim-lang.github.io/Nim/exceptions.html)):
>    `ArithmeticError`, `DivByZeroError`, `OverflowError`, `AccessViolationError`, `AssertionError`, `OutOfMemError`, `IndexError`, `FieldError`, `RangeError`, `StackOverflowError`, `ReraiseError`, `ObjectAssignmentError`, `ObjectConversionError`, `FloatingPointError`, `FloatOverflowError`, `FloatUnderflowError`, `FloatInexactError`, `DeadThreadError`, `NilAccessError`
>   - `addQuitProc`, replaced by `exitprocs.addExitProc`
>   - Legacy unsigned conversion operations: `ze`, `ze64`, `toU8`, `toU16`, `toU32`
>   - `TaintedString`, formerly a distinct alias to `string`
>   - `PInt32`, `PInt64`, `PFloat32`, `PFloat64`, aliases to `ptr int32`, `ptr int64`, `ptr float32`, `ptr float64`
>
>- Enabling `-d:nimPreviewSlimSystem` removes the import of `channels_builtin` in the `system` module, which is replaced by `threading/channels`. Use the command `nimble install threading` and import `threading/channels`.

Closes: #760

[1]: https://github.com/nim-lang/Nim/blob/v2.0.0/changelogs/changelog_2_0_0_details.md#changes-affecting-backward-compatibility

---

To-do:

- [ ] Add the remaining required imports.

This PR is currently blocked by (at least) jsony not supporting this.