### PR TITLE
README: add example minisign output, and clarify

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ minisign -Vm configlet_4.0.0-beta.13_linux_x86-64.tar.gz -P RWQGj6DTXgYLhKvWJMGt
 where the above argument to `-P` is the configlet public key.
 
 The above command has verified the release archive if (and only if) the command's output contains `Signature and comment signature verified`.
+For example:
+
+```text
+Signature and comment signature verified
+Trusted comment: timestamp:2023-08-09T10:27:15Z  file:configlet_4.0.0-beta.13_linux_x86-64.tar.gz  hashed
+```
 
 Then extract the archive to obtain the (now-verified) configlet executable.
 You may delete the archive and the `.minisig` file.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then run a `minisign` command in that directory:
 minisign -Vm configlet_4.0.0-beta.13_linux_x86-64.tar.gz -P RWQGj6DTXgYLhKvWJMGtbDUrZerawUcyWnti9MGuWMx7VDW9DqZn2tMZ
 ```
 
-where the above argument to `-P` is the configlet public key.
+where the above argument to `-P` is the [configlet public key](https://github.com/exercism/configlet/blob/009dc9df9d947e71ff039ac2af0f82315dbf9073/configlet-minisign.pub).
 
 The above command has verified the release archive if (and only if) the command's output begins with `Signature and comment signature verified`.
 For example:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ minisign -Vm configlet_4.0.0-beta.13_linux_x86-64.tar.gz -P RWQGj6DTXgYLhKvWJMGt
 
 where the above argument to `-P` is the configlet public key.
 
-The above command has verified the release archive if (and only if) the command's output contains `Signature and comment signature verified`.
+The above command has verified the release archive if (and only if) the command's output begins with `Signature and comment signature verified`.
 For example:
 
 ```text


### PR DESCRIPTION
Part of this was already approved in #557, but I [removed it](https://github.com/exercism/configlet/pull/557/commits/7f0668f9410b46841dca64b8e9e92c6a94d84954) before merging because I didn't want to use a placeholder filename, and wanted this timestamp to match the one from the release.

The wording change from "contains" to "begins with" isn't important. But I guess the previous wording wasn't strictly true: a filename could contain "Signature and comment signature verified".