### PR TITLE
.github: separate release creation from uploading assets

### DIFF
--- a/.github/bin/create-artifact
+++ b/.github/bin/create-artifact
@@ -17,4 +17,4 @@ case "${OS}" in
     ;;
 esac
 
-echo "ARTIFACT_FILE=${artifact_file}" >> "${GITHUB_ENV}"
+gh release upload "${build_tag}" "${artifact_file}"

--- a/.github/bin/publish-release
+++ b/.github/bin/publish-release
@@ -2,27 +2,22 @@
 
 build_tag="${GITHUB_REF_NAME}"
 
-if ! gh release view "${build_tag}"; then
-  # Generate a list of commits for the release notes, without assuming that the
-  # tag for the previous official configlet release:
-  # - is the most recent (or second most recent) local tag.
-  # - exists locally (so we support creating test releases on a forked repo).
-  # The `gh release create` command does have a `--generate-notes` option,
-  # but the below gives full control over the format, and includes commit refs.
-  previous_release_sha="$(gh api graphql --jq 'recurse | strings' -f query='
-    {
-      repository(owner: "exercism", name: "configlet") {
-        latestRelease {
-          tagCommit {
-            oid
-          }
+# Generate a list of commits for the release notes, without assuming that the
+# tag for the previous official configlet release:
+# - is the most recent (or second most recent) local tag.
+# - exists locally (so we support creating test releases on a forked repo).
+# The `gh release create` command does have a `--generate-notes` option,
+# but the below gives full control over the format, and includes commit refs.
+previous_release_sha="$(gh api graphql --jq 'recurse | strings' -f query='
+  {
+    repository(owner: "exercism", name: "configlet") {
+      latestRelease {
+        tagCommit {
+          oid
         }
       }
-    }')"
-  commits="$(git log --format='- %h %s' "${previous_release_sha}..${build_tag}")"
-  body="$(printf '### Changes\n\n%s' "${commits}")"
-  gh release create --draft --title "${build_tag}" --notes "${body}" \
-    "${build_tag}" "${ARTIFACT_FILE}"
-else
-  gh release upload "${build_tag}" "${ARTIFACT_FILE}"
-fi
+    }
+  }')"
+commits="$(git log --format='- %h %s' "${previous_release_sha}..${build_tag}")"
+body="$(printf '### Changes\n\n%s' "${commits}")"
+gh release create --draft --title "${build_tag}" --notes "${body}" "${build_tag}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  create-empty-release:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          fetch-depth: 0 # Allows using `git log` to set initial release notes.
+
+      - name: Create empty release
+        shell: bash
+        run: ./.github/bin/publish-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
+    needs: [create-empty-release]
     strategy:
       fail-fast: false
       matrix:
@@ -31,8 +48,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-        with:
-          fetch-depth: 0 # Allows using `git log` to set initial release notes.
 
       - name: On Linux, install musl
         if: matrix.os == 'linux'
@@ -55,11 +70,6 @@ jobs:
         env:
           OS: ${{ matrix.os }}
           ARCH: ${{ matrix.arch }}
-
-      - name: Publish release
-        shell: bash
-        run: ./.github/bin/publish-release
-        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   cross-compile:


### PR DESCRIPTION
Before this commit, the `.github/bin/publish-release` script handled both:
- creating the draft release
- uploading assets to the release

with the intention that the first build job to finish would create the release with one asset, and each later job would upload an asset.

The logic was like:
```shell
if ! gh release view "${build_tag}"; then
  gh release create [...]
else
  gh release upload [...]
fi
```
But this had a race. For example, if two build jobs finished at nearly the same moment, they could each create a draft release. This race was almost never encountered in practice, and was easily resolved by deleting a draft release and restarting a build job, but it's worth resolving.

Add an initial build job to create a draft release that has no assets, and make the later build jobs only upload to that release.

This fixes the race, and makes it easier to share logic between the native build jobs and the cross-compiling build jobs.

Fixes: #551
Refs: #789

---

To-do:

- [x] Test build job
- [x] Follow-up PR: rename build scripts (do separately to ensure that git can track the rename)
- [x] Follow-up PR: make cross-compilation job run in parallel with native build jobs