### PR TITLE
.github(cross-compile, upload-archive): rename to archive

### DIFF
--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-artifacts_dir='artifacts'
+archives_dir='archives'
 build_tag="${GITHUB_REF_NAME}"
 
 cross_compile() {
@@ -21,9 +21,9 @@ cross_compile() {
     echo "stripping large comment section from executable..." >&2
     llvm-strip -R .comment "${binary_name}"
   fi
-  mkdir -p "${artifacts_dir}"
-  local artifact_file="${artifacts_dir}/${binary_name}_${build_tag}_${os}_${arch}.tar.gz"
-  tar -cvzf "${artifact_file}" "${binary_name}"
+  mkdir -p "${archives_dir}"
+  local archive="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}.tar.gz"
+  tar -cvzf "${archive}" "${binary_name}"
 }
 
 main() {
@@ -39,7 +39,7 @@ main() {
     cross_compile "${target}"
   done
 
-  gh release upload "${build_tag}" "${artifacts_dir}"/*
+  gh release upload "${build_tag}" "${archives_dir}"/*
 }
 
 main

--- a/.github/bin/upload-archive
+++ b/.github/bin/upload-archive
@@ -1,20 +1,20 @@
 #!/usr/bin/env sh
 
-artifacts_dir='artifacts'
-mkdir -p "${artifacts_dir}"
+archives_dir='archives'
+mkdir -p "${archives_dir}"
 
 binary_name='configlet'
 build_tag="${GITHUB_REF_NAME}"
 
 case "${OS}" in
   windows)
-    artifact_file="${artifacts_dir}/${binary_name}_${build_tag}_${OS}_${ARCH}.zip"
-    7z a "${artifact_file}" "${binary_name}.exe"
+    archive="${archives_dir}/${binary_name}_${build_tag}_${OS}_${ARCH}.zip"
+    7z a "${archive}" "${binary_name}.exe"
     ;;
   linux | macos)
-    artifact_file="${artifacts_dir}/${binary_name}_${build_tag}_${OS}_${ARCH}.tar.gz"
-    tar -cvzf "${artifact_file}" "${binary_name}"
+    archive="${archives_dir}/${binary_name}_${build_tag}_${OS}_${ARCH}.tar.gz"
+    tar -cvzf "${archive}" "${binary_name}"
     ;;
 esac
 
-gh release upload "${build_tag}" "${artifact_file}"
+gh release upload "${build_tag}" "${archive}"


### PR DESCRIPTION
This also helps clarify that there's a separate script for the other "artifacts" - the checksums file and minisig files.