### PR TITLE
.github, cli, completion: cross-compile arm64 Windows asset

### DIFF
--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -44,7 +44,12 @@ cross_compile() {
   nimble --verbose build "${build_options[@]}"
 
   local binary_name='configlet'
+  if command -v llvm-strip &> /dev/null; then
+    echo "stripping large comment section from executable..." >&2
+    llvm-strip --strip-all-gnu -R .comment "${binary_name}"
+  fi
   file "${binary_name}"
+
   mkdir -p "${archives_dir}"
   local archive_base="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}"
   case "${os}" in

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -51,7 +51,7 @@ cross_compile() {
 
   if command -v llvm-strip &> /dev/null; then
     echo "stripping large comment section from executable..." >&2
-    llvm-strip --strip-all-gnu -R .comment "${binary_name}${executable_ext}"
+    llvm-strip --strip-all -R .comment "${binary_name}${executable_ext}"
   fi
   mkdir -p "${archives_dir}"
   local archive="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}.tar.gz"

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -42,16 +42,18 @@ cross_compile() {
   fi
 
   nimble --verbose build "${build_options[@]}"
-  local binary_name='configlet'
-  local executable_ext
-  case "${os}" in
-    windows) executable_ext='.exe' ;;
-    *)       executable_ext=''     ;;
-  esac
 
+  local binary_name='configlet'
   mkdir -p "${archives_dir}"
-  local archive="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}.tar.gz"
-  tar -cvzf "${archive}" "${binary_name}${executable_ext}"
+  local archive_base="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}"
+  case "${os}" in
+    linux | macos)
+      tar -cvzf "${archive_base}.tar.gz" "${binary_name}"
+      ;;
+    windows)
+      7z a "${archive_base}.zip" "${binary_name}.exe"
+      ;;
+  esac
 }
 
 main() {

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -48,7 +48,12 @@ cross_compile() {
     echo "stripping large comment section from executable..." >&2
     llvm-strip --strip-all-gnu -R .comment "${binary_name}"
   fi
-  file "${binary_name}"
+  if command -v file &> /dev/null; then
+    file "${binary_name}"
+  fi
+  if command -v llvm-readobj &> /dev/null; then
+    llvm-readobj "${binary_name}"
+  fi
 
   mkdir -p "${archives_dir}"
   local archive_base="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}"

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -49,10 +49,6 @@ cross_compile() {
     *)       executable_ext=''     ;;
   esac
 
-  if command -v llvm-strip &> /dev/null; then
-    echo "stripping large comment section from executable..." >&2
-    llvm-strip --strip-all "${binary_name}${executable_ext}"
-  fi
   mkdir -p "${archives_dir}"
   local archive="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}.tar.gz"
   tar -cvzf "${archive}" "${binary_name}${executable_ext}"

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -51,7 +51,7 @@ cross_compile() {
 
   if command -v llvm-strip &> /dev/null; then
     echo "stripping large comment section from executable..." >&2
-    llvm-strip --strip-all -R .comment "${binary_name}${executable_ext}"
+    llvm-strip --strip-all "${binary_name}${executable_ext}"
   fi
   mkdir -p "${archives_dir}"
   local archive="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}.tar.gz"

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -51,7 +51,7 @@ cross_compile() {
 
   if command -v llvm-strip &> /dev/null; then
     echo "stripping large comment section from executable..." >&2
-    llvm-strip -R .comment "${binary_name}${executable_ext}"
+    llvm-strip --strip-all-gnu -R .comment "${binary_name}${executable_ext}"
   fi
   mkdir -p "${archives_dir}"
   local archive="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}.tar.gz"

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -44,15 +44,15 @@ cross_compile() {
   nimble --verbose build "${build_options[@]}"
 
   local binary_name='configlet'
+  file "${binary_name}"
   mkdir -p "${archives_dir}"
   local archive_base="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}"
   case "${os}" in
     linux | macos)
-      file "${binary_name}"
       tar -cvzf "${archive_base}.tar.gz" "${binary_name}"
       ;;
     windows)
-      llvm-readobj "${binary_name}.exe"
+      mv "${binary_name}" "${binary_name}".exe
       7z a "${archive_base}.zip" "${binary_name}.exe"
       ;;
   esac

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -48,9 +48,11 @@ cross_compile() {
   local archive_base="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}"
   case "${os}" in
     linux | macos)
+      file "${binary_name}"
       tar -cvzf "${archive_base}.tar.gz" "${binary_name}"
       ;;
     windows)
+      dumpbin /headers "${binary_name}.exe"
       7z a "${archive_base}.zip" "${binary_name}.exe"
       ;;
   esac

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -46,7 +46,7 @@ cross_compile() {
   local binary_name='configlet'
   if command -v llvm-strip &> /dev/null; then
     echo "stripping large comment section from executable..." >&2
-    llvm-strip --strip-all-gnu -R .comment "${binary_name}"
+    llvm-strip -R .comment "${binary_name}"
   fi
   if command -v file &> /dev/null; then
     file "${binary_name}"

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -25,19 +25,12 @@ cross_compile() {
     *)     nim_os="${os}"  ;;
   esac
 
-  local binary_name
-  case "${os}" in
-    linux | macos) binary_name='configlet'     ;;
-    windows)       binary_name='configlet.exe' ;;
-  esac
-
   local build_options=(
     -d:release
     --cpu:"${arch}"
     --os:"${nim_os}"
     -d:zig
     -d:target:"${target}"
-    -o:"${binary_name}"
   )
   # On macOS, add to the compiler's and linker's framework search path.
   dir='/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/System/Library/Frameworks'
@@ -49,13 +42,19 @@ cross_compile() {
   fi
 
   nimble --verbose build "${build_options[@]}"
-  file "${binary_name}"
 
+  local binary_name='configlet'
   mkdir -p "${archives_dir}"
-  local archive_base="${archives_dir}/configlet_${build_tag}_${os}_${arch}"
+  local archive_base="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}"
   case "${os}" in
-    linux | macos) tar -cvzf "${archive_base}.tar.gz" "${binary_name}" ;;
-    windows)       7z a "${archive_base}.zip" "${binary_name}"         ;;
+    linux | macos)
+      file "${binary_name}"
+      tar -cvzf "${archive_base}.tar.gz" "${binary_name}"
+      ;;
+    windows)
+      llvm-readobj "${binary_name}.exe"
+      7z a "${archive_base}.zip" "${binary_name}.exe"
+      ;;
   esac
 }
 

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -43,13 +43,19 @@ cross_compile() {
 
   nimble --verbose build "${build_options[@]}"
   local binary_name='configlet'
+  local executable_ext
+  case "${os}" in
+    windows) executable_ext='.exe' ;;
+    *)       executable_ext=''     ;;
+  esac
+
   if command -v llvm-strip &> /dev/null; then
     echo "stripping large comment section from executable..." >&2
-    llvm-strip -R .comment "${binary_name}"
+    llvm-strip -R .comment "${binary_name}${executable_ext}"
   fi
   mkdir -p "${archives_dir}"
   local archive="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}.tar.gz"
-  tar -cvzf "${archive}" "${binary_name}"
+  tar -cvzf "${archive}" "${binary_name}${executable_ext}"
 }
 
 main() {

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -25,12 +25,19 @@ cross_compile() {
     *)     nim_os="${os}"  ;;
   esac
 
+  local binary_name
+  case "${os}" in
+    linux | macos) binary_name='configlet'     ;;
+    windows)       binary_name='configlet.exe' ;;
+  esac
+
   local build_options=(
     -d:release
     --cpu:"${arch}"
     --os:"${nim_os}"
     -d:zig
     -d:target:"${target}"
+    -o:"${binary_name}"
   )
   # On macOS, add to the compiler's and linker's framework search path.
   dir='/Library/Developer/CommandLineTools/SDKs/MacOSX13.1.sdk/System/Library/Frameworks'
@@ -42,19 +49,13 @@ cross_compile() {
   fi
 
   nimble --verbose build "${build_options[@]}"
+  file "${binary_name}"
 
-  local binary_name='configlet'
   mkdir -p "${archives_dir}"
-  local archive_base="${archives_dir}/${binary_name}_${build_tag}_${os}_${arch}"
+  local archive_base="${archives_dir}/configlet_${build_tag}_${os}_${arch}"
   case "${os}" in
-    linux | macos)
-      file "${binary_name}"
-      tar -cvzf "${archive_base}.tar.gz" "${binary_name}"
-      ;;
-    windows)
-      llvm-readobj "${binary_name}.exe"
-      7z a "${archive_base}.zip" "${binary_name}.exe"
-      ;;
+    linux | macos) tar -cvzf "${archive_base}.tar.gz" "${binary_name}" ;;
+    windows)       7z a "${archive_base}.zip" "${binary_name}"         ;;
   esac
 }
 

--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -52,7 +52,7 @@ cross_compile() {
       tar -cvzf "${archive_base}.tar.gz" "${binary_name}"
       ;;
     windows)
-      dumpbin /headers "${binary_name}.exe"
+      llvm-readobj "${binary_name}.exe"
       7z a "${archive_base}.zip" "${binary_name}.exe"
       ;;
   esac

--- a/.github/bin/install-zig
+++ b/.github/bin/install-zig
@@ -53,7 +53,7 @@ esac
 # Extract the archive, then remove it.
 echo "Extracting archive..." >&2
 case "${ext}" in
-  *zip) unzip "${archive}"   ;;
+  *zip) unzip -q "${archive}"   ;;
   *)    tar xJf "${archive}" ;;
 esac
 rm "${archive}"

--- a/.github/bin/install-zig
+++ b/.github/bin/install-zig
@@ -44,9 +44,9 @@ case "${os}" in
     archive_sha256='1c1c6b9a906b42baae73656e24e108fd8444bb50b6e8fd03e9e7a3f8b5f05686'
     shasum -a 256 -c <<< "${archive_sha256} *${archive}"
     ;;
-  *)
-    echo "${os} not yet supported" >&2
-    exit 1
+  windows)
+    archive_sha256='142caa3b804d86b4752556c9b6b039b7517a08afa3af842645c7e2dcd125f652'
+    # TODO: check windows archive checksum
     ;;
 esac
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           - runs-on: macos-12
             zig_target: aarch64-macos-none
 
-          - runs-on: windows-2022
+          - runs-on: ubuntu-22.04
             zig_target: aarch64-windows-gnu
 
     name: "${{ matrix.zig_target }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,9 @@ jobs:
           - runs-on: macos-12
             zig_target: aarch64-macos-none
 
+          - runs-on: windows-2022
+            zig_target: aarch64-windows-gnu
+
     name: "${{ matrix.zig_target }}"
     runs-on: ${{ matrix.runs-on }}
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,9 +106,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Zig
+        shell: bash
         run: ./.github/bin/install-zig
 
       - name: Cross-compile
+        shell: bash
         run: ./.github/bin/cross-compile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config.nims
+++ b/config.nims
@@ -33,6 +33,8 @@ if defined(release):
 
   if defined(linux) or defined(windows):
     switch("passL", "-s")
+
+  if defined(linux):
     switch("passL", "-static")
 
   if defined(linux) and not defined(zig):

--- a/config.nims
+++ b/config.nims
@@ -33,8 +33,6 @@ if defined(release):
 
   if defined(linux) or defined(windows):
     switch("passL", "-s")
-
-  if defined(linux):
     switch("passL", "-static")
 
   if defined(linux) and not defined(zig):

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -116,8 +116,7 @@ func genShortKeys: array[Opt, char] =
       result[opt] = ($opt)[0]
 
 const
-  repoRootDir = currentSourcePath().parentDir().parentDir()
-  configletVersion = staticRead(repoRootDir / "configlet.version").strip()
+  configletVersion = staticRead("../configlet.version").strip()
   short = genShortKeys()
   optsNoVal = {optHelp, optVersion, optFmtSyncUpdate, optFmtSyncYes,
                optInfoSyncOffline, optSyncDocs, optSyncFilepaths, optSyncMetadata}

--- a/src/completion/completion.nim
+++ b/src/completion/completion.nim
@@ -6,7 +6,13 @@ proc readCompletions: array[Shell, string] =
   const repoRootDir = currentSourcePath().parentDir().parentDir().parentDir()
   const completionsDir = repoRootDir / "completions"
   for shell in sBash .. result.high:
-    result[shell] = staticRead(completionsDir / &"configlet.{shell}").compress()
+    # When cross-compiling for Windows from Linux, replace the `\\` DirSep with `/`.
+    var path = completionsDir / &"configlet.{shell}"
+    when defined(windows) and defined(zig) and staticExec("uname") == "Linux":
+      for c in path.mitems:
+        if c == '\\':
+          c = '/'
+    result[shell] = staticRead(path).compress()
 
 proc completion*(shellKind: Shell) =
   const completions = readCompletions()


### PR DESCRIPTION
Continue the [recent `zig cc` work][1], such that the next configlet release will have two new release assets:

```text
configlet_4.0.0-beta.14_windows_arm64.zip
configlet_4.0.0-beta.14_windows_arm64.zip.minisig
```

where the archive contains the executable:

```console
$ file ./configlet.exe
./configlet: PE32+ executable (console) Aarch64, for MS Windows, 6 sections
```

The `aarch64-windows-gnu` target [will have Tier 1 Zig support][2].

Refs: #24
Refs: #122
Closes: #764

[1]: https://github.com/exercism/configlet/commit/0e8d6659e43dbf0628abcd5ba477e0a011a7058a
[2]: https://ziglang.org/download/0.11.0/release-notes.html#Support-Table

---

To-do:

- [x] Compress as `.zip`, not `.tar.gz`
- [x] Make it actually output a Windows arm64 executable, not x86_64
- [x] Final nitpicks