### PR TITLE
.github: cross-compile riscv64 Linux asset

### DIFF
--- a/.github/bin/cross-compile
+++ b/.github/bin/cross-compile
@@ -8,7 +8,15 @@ zig_target="${ZIG_TARGET}"
 
 cross_compile() {
   local target="$1"
-  local arch='arm64'
+
+  local zig_arch
+  zig_arch="$(cut -d'-' -f1 <<< "${target}")"
+  local arch
+  case "${zig_arch}" in
+    aarch64) arch='arm64'       ;;
+    *)       arch="${zig_arch}" ;;
+  esac
+
   local os
   os="$(cut -d'-' -f2 <<< "${target}")"
   local nim_os

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,9 @@ jobs:
           - runs-on: ubuntu-22.04
             zig_target: aarch64-linux-musl
 
+          - runs-on: ubuntu-22.04
+            zig_target: riscv64-linux-musl
+
           - runs-on: macos-12
             zig_target: aarch64-macos-none
 


### PR DESCRIPTION
Continue the [recent `zig cc` work][1], such that the next configlet release will have two new release assets:

```text
configlet_4.0.0-beta.14_linux_riscv64.tar.gz
configlet_4.0.0-beta.14_linux_riscv64.tar.gz.minisig
```

where the archive contains the executable:

```console
$ file ./configlet
./configlet: ELF 64-bit LSB executable, UCB RISC-V, RVC, double-float ABI, version 1 (SYSV), statically linked, stripped
```

The `riscv64-linux-musl` target [will have Tier 1 Zig support][2].

Refs: #24

[1]: https://github.com/exercism/configlet/commit/0e8d6659e43dbf0628abcd5ba477e0a011a7058a
[2]: https://ziglang.org/download/0.11.0/release-notes.html#Support-Table