### PR TITLE
.github: cross-compile powerpc64 Linux asset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,9 @@ jobs:
             zig_target: aarch64-linux-musl
 
           - runs-on: ubuntu-22.04
+            zig_target: powerpc64-linux-musl
+
+          - runs-on: ubuntu-22.04
             zig_target: riscv64-linux-musl
 
           - runs-on: macos-12


### PR DESCRIPTION
Continue the [recent `zig cc` work][1], such that the next configlet release will have two new release assets:

```text
configlet_4.0.0-beta.n_linux_powerpc64.tar.gz
configlet_4.0.0-beta.n_linux_powerpc64.tar.gz.minisig
```

where the archive contains the executable:

```console
$ file ./configlet
./configlet: ELF 64-bit MSB executable, 64-bit PowerPC or cisco 7500, OpenPOWER ELF V2 ABI, version 1 (SYSV), statically linked, stripped
```

The `powerpc64-linux-musl` target [will have Tier 1 Zig support][2].

Note that powerpc64 is big endian.

Refs: #24
Closes: #810

[1]: https://github.com/exercism/configlet/commit/0e8d6659e43dbf0628abcd5ba477e0a011a7058a
[2]: https://ziglang.org/download/0.11.0/release-notes.html#Support-Table

---

To-do:

- [ ] Fix `configlet lint`
- [ ] Fix `configlet --help`
- [ ] Fix `configlet completion`
- [ ] Re-check `configlet create|fmt|generate|info|sync|uuid|--version`