### PR TITLE
fetch-configlet: support fetching arm64 assets

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -24,10 +24,11 @@ get_download_url() {
   local latest='https://api.github.com/repos/exercism/configlet/releases/latest'
   local arch
   case "$(uname -m)" in
-    x86_64) arch='x86-64' ;;
-    *686*)  arch='i386'   ;;
-    *386*)  arch='i386'   ;;
-    *)      arch='x86-64' ;;
+    aarch64|arm64) arch='arm64'  ;;
+    x86_64)        arch='x86-64' ;;
+    *686*)         arch='i386'   ;;
+    *386*)         arch='i386'   ;;
+    *)             arch='x86-64' ;;
   esac
   local suffix="${os}_${arch}.${ext}"
   curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${latest}" |


### PR DESCRIPTION
The [most recent configlet release](https://github.com/exercism/configlet/releases/tag/4.0.0-beta.14) includes pre-built binaries for:

- [arm64 Linux][1]
- [arm64 macOS][2]
- [arm64 Windows][3]
- [riscv64 Linux][4]

Support arm64 in the bash fetch-configlet script.

Refs: #122
Follow-up from: https://github.com/exercism/configlet/issues/764#issuecomment-1685080166

[1]: https://github.com/exercism/configlet/commit/0e8d6659e43d
[2]: https://github.com/exercism/configlet/commit/f280445978c1
[3]: https://github.com/exercism/configlet/commit/3824299df1dd
[4]: https://github.com/exercism/configlet/commit/a962b181b54e

---

I'll change the logic in this script in a later PR. I think we shouldn't hardcode the available binaries in the fetch scripts. Instead, we should try to download the configlet release for the user's machine, and error if the asset does not exist. Then we can add assets to the configlet releases without updating the fetch scripts on every track. That'll also make the fetch script support riscv64 Linux.

I suggest delaying the Exercism-wide PRs until we've done that.