### PR TITLE
fetch-configlet: remove wildcard from some patterns

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -58,8 +58,8 @@ main() {
 
   local ext
   case "${os}" in
-    windows*) ext='zip'    ;;
-    *)        ext='tar.gz' ;;
+    windows) ext='zip'    ;;
+    *)       ext='tar.gz' ;;
   esac
 
   echo "Fetching configlet..." >&2
@@ -69,16 +69,16 @@ main() {
   curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
 
   case "${ext}" in
-    *zip) unzip "${output_path}" -d "${output_dir}"   ;;
-    *)    tar xzf "${output_path}" -C "${output_dir}" ;;
+    zip) unzip "${output_path}" -d "${output_dir}"   ;;
+    *)   tar xzf "${output_path}" -C "${output_dir}" ;;
   esac
 
   rm -f "${output_path}"
 
   local executable_ext
   case "${os}" in
-    windows*) executable_ext='.exe' ;;
-    *)        executable_ext=''     ;;
+    windows) executable_ext='.exe' ;;
+    *)       executable_ext=''     ;;
   esac
 
   local configlet_path="${output_dir}/configlet${executable_ext}"


### PR DESCRIPTION
Better communicate to the reader that, on Windows:

- `"${os}"` is exactly `zip`
- `"${ext}"` is exactly `.exe`