### PR TITLE
fetch-configlet: explicitly pass `-s` to `uname`

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -47,7 +47,7 @@ main() {
   fi
 
   local os
-  case "$(uname)" in
+  case "$(uname -s)" in
     Darwin*)   os='macos'   ;;
     Linux*)    os='linux'   ;;
     Windows*)  os='windows' ;;


### PR DESCRIPTION
I believe that a bare `uname` should do the same thing as `uname -s` everywhere. But let's not rely on this, or rely on the reader knowing it. Better communicate that we want the operating system name.

With GNU coreutils 9.3:

```console
$ uname --help
Usage: uname [OPTION]...
Print certain system information.  With no OPTION, same as -s.

  -a, --all                print all information, in the following order,
                             except omit -p and -i if unknown:
  -s, --kernel-name        print the kernel name
[...]
```

And [on OpenBSD][1] (good man pages to check portability of various commands):

> If no options are specified, uname prints the operating system name as if the -s option had been specified.

[1]: https://man.openbsd.org/uname