### PR TITLE
fetch-configlet: support more platforms

### DIFF
--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -22,13 +22,15 @@ get_download_url() {
   local os="$1"
   local ext="$2"
   local latest='https://api.github.com/repos/exercism/configlet/releases/latest'
+  local unamem
+  unamem="$(uname -m)"
   local arch
-  case "$(uname -m)" in
-    aarch64|arm64) arch='arm64'  ;;
-    x86_64)        arch='x86-64' ;;
-    *686*)         arch='i386'   ;;
-    *386*)         arch='i386'   ;;
-    *)             arch='x86-64' ;;
+  case "${unamem}" in
+    aarch64|arm64) arch='arm64'     ;;
+    x86_64)        arch='x86-64'    ;;
+    *686*)         arch='i386'      ;;
+    *386*)         arch='i386'      ;;
+    *)             arch="${unamem}" ;;
   esac
   local suffix="${os}_${arch}.${ext}"
   curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${latest}" |

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -26,11 +26,14 @@ get_download_url() {
   unamem="$(uname -m)"
   local arch
   case "${unamem}" in
-    aarch64|arm64) arch='arm64'     ;;
-    x86_64)        arch='x86-64'    ;;
-    *686*)         arch='i386'      ;;
-    *386*)         arch='i386'      ;;
-    *)             arch="${unamem}" ;;
+    aarch64|arm64) arch='arm64'       ;;
+    x86_64)        arch='x86-64'      ;;
+    *686*)         arch='i386'        ;;
+    *386*)         arch='i386'        ;;
+    ppc)           arch='powerpc'     ;;
+    ppc64)         arch='powerpc64'   ;;
+    ppc64le)       arch='powerpc64le' ;;
+    *)             arch="${unamem}"   ;;
   esac
   local suffix="${os}_${arch}.${ext}"
   curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${latest}" |

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -50,13 +50,15 @@ main() {
   fi
 
   local os
-  case "$(uname -s)" in
-    Darwin*)   os='macos'   ;;
-    Linux*)    os='linux'   ;;
-    Windows*)  os='windows' ;;
-    MINGW*)    os='windows' ;;
-    MSYS_NT-*) os='windows' ;;
-    *)         os='linux'   ;;
+  local unames
+  unames="$(uname -s)"
+  case "${unames}" in
+    Darwin*)   os='macos'       ;;
+    Linux*)    os='linux'       ;;
+    Windows*)  os='windows'     ;;
+    MINGW*)    os='windows'     ;;
+    MSYS_NT-*) os='windows'     ;;
+    *)         os="${unames,,}" ;; # Convert to lower case.
   esac
 
   local ext

--- a/scripts/fetch-configlet
+++ b/scripts/fetch-configlet
@@ -22,10 +22,10 @@ get_download_url() {
   local os="$1"
   local ext="$2"
   local latest='https://api.github.com/repos/exercism/configlet/releases/latest'
-  local unamem
-  unamem="$(uname -m)"
+  local uname_m
+  uname_m="$(uname -m)"
   local arch
-  case "${unamem}" in
+  case "${uname_m}" in
     aarch64|arm64) arch='arm64'       ;;
     x86_64)        arch='x86-64'      ;;
     *686*)         arch='i386'        ;;
@@ -33,7 +33,7 @@ get_download_url() {
     ppc)           arch='powerpc'     ;;
     ppc64)         arch='powerpc64'   ;;
     ppc64le)       arch='powerpc64le' ;;
-    *)             arch="${unamem}"   ;;
+    *)             arch="${uname_m}"  ;;
   esac
   local suffix="${os}_${arch}.${ext}"
   curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${latest}" |
@@ -53,15 +53,15 @@ main() {
   fi
 
   local os
-  local unames
-  unames="$(uname -s)"
-  case "${unames}" in
-    Darwin*)   os='macos'       ;;
-    Linux*)    os='linux'       ;;
-    Windows*)  os='windows'     ;;
-    MINGW*)    os='windows'     ;;
-    MSYS_NT-*) os='windows'     ;;
-    *)         os="${unames,,}" ;; # Convert to lower case.
+  local uname_s
+  uname_s="$(uname -s)"
+  case "${uname_s}" in
+    Darwin*)   os='macos'        ;;
+    Linux*)    os='linux'        ;;
+    Windows*)  os='windows'      ;;
+    MINGW*)    os='windows'      ;;
+    MSYS_NT-*) os='windows'      ;;
+    *)         os="${uname_s,,}" ;; # Convert to lower case.
   esac
 
   local ext


### PR DESCRIPTION
Allow `fetch-configlet` to:

- download the existing riscv64 Linux asset
- support future assets for e.g. FreeBSD/NetBSD/OpenBSD
- support low-priority, but theoretically possible future assets for powerpc/powerpc64/powerpc64le/sparc64/etc

---

Working towards my suggestion in https://github.com/exercism/configlet/pull/805:

>I think we shouldn't hardcode the available binaries in the fetch scripts. Instead, we should try to download the configlet release for the user's machine, and error if the asset does not exist. Then we can add assets to the configlet releases without updating the fetch scripts on every track. That'll also make the fetch script support riscv64 Linux.