### PR TITLE
all: replace jsony imports with an export

### DIFF
--- a/src/create/approaches.nim
+++ b/src/create/approaches.nim
@@ -1,5 +1,4 @@
 import std/[os, strformat, strutils]
-import pkg/jsony
 import ".."/[fmt/approaches, helpers, sync/sync_common, types_track_config,
              types_approaches_config, uuid/uuid]
 

--- a/src/create/articles.nim
+++ b/src/create/articles.nim
@@ -1,5 +1,4 @@
 import std/[os, strformat, strutils]
-import pkg/jsony
 import ".."/[fmt/articles, helpers, sync/sync_common, types_track_config,
              types_articles_config, uuid/uuid]
 

--- a/src/fmt/exercises.nim
+++ b/src/fmt/exercises.nim
@@ -1,5 +1,4 @@
 import std/[json, options, os, sets, strformat, strutils]
-import pkg/jsony
 import ".."/[helpers, sync/sync_common, types_exercise_config, types_track_config]
 
 func filesKeyOrder(val: ConceptExerciseFiles | PracticeExerciseFiles;

--- a/src/fmt/track_config.nim
+++ b/src/fmt/track_config.nim
@@ -1,5 +1,4 @@
 import std/[algorithm, sequtils, json, options, sets, strformat]
-import pkg/jsony
 import ".."/[helpers, sync/sync_common, types_track_config]
 
 func trackConfigKeyOrderForFmt(e: TrackConfig): seq[TrackConfigKey] =

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -1,7 +1,7 @@
 import std/[algorithm, os, parseutils, strformat, strscans, strutils, terminal]
 import pkg/jsony
 import "."/cli
-export jsony
+export jsony # Ensures `parseHook`s are visible at call sites.
 
 template withDir*(dir: string; body: untyped): untyped =
   ## Changes the current directory to `dir` temporarily.

--- a/src/helpers.nim
+++ b/src/helpers.nim
@@ -1,6 +1,7 @@
 import std/[algorithm, os, parseutils, strformat, strscans, strutils, terminal]
 import pkg/jsony
 import "."/cli
+export jsony
 
 template withDir*(dir: string; body: untyped): untyped =
   ## Changes the current directory to `dir` temporarily.

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -1,5 +1,4 @@
 import std/[os, sequtils, strformat, strutils, terminal]
-import pkg/jsony # This is not always used, but removing it will make tests fail.
 import ".."/[cli, helpers, logger, types_track_config]
 import "."/[exercises, probspecs, sync_common, sync_docs, sync_filepaths,
             sync_metadata, sync_tests]

--- a/src/sync/sync_filepaths.nim
+++ b/src/sync/sync_filepaths.nim
@@ -1,5 +1,4 @@
 import std/[os, strformat, strutils]
-import pkg/jsony # This is not always used, but removing it will make tests fail.
 import ".."/[cli, fmt/exercises, helpers, logger, types_exercise_config, types_track_config]
 import "."/sync_common
 

--- a/src/types_track_config.nim
+++ b/src/types_track_config.nim
@@ -1,5 +1,4 @@
 import std/[hashes, options, sets]
-import pkg/jsony
 import "."/[cli, helpers]
 
 type

--- a/tests/test_fmt.nim
+++ b/tests/test_fmt.nim
@@ -1,5 +1,4 @@
 import std/[importutils, json, os, options, random, strutils, unittest]
-import pkg/jsony
 import exec, fmt/exercises, helpers, sync/sync_common, types_exercise_config
 
 const


### PR DESCRIPTION
Closes: #817

---

I'll create a separate PR for other unused imports, and the remaining `jsony` import in `info.nim`.