### PR TITLE
create, fmt, info: remove unused imports

### DIFF
--- a/src/create/approaches.nim
+++ b/src/create/approaches.nim
@@ -1,6 +1,5 @@
 import std/[os, strformat, strutils]
-import ".."/[fmt/approaches, helpers, sync/sync_common, types_track_config,
-             types_approaches_config, uuid/uuid]
+import ".."/[fmt/approaches, helpers, types_track_config, types_approaches_config, uuid/uuid]
 
 func kebabToTitleCase(slug: Slug): string =
   result = newStringOfCap(slug.len)

--- a/src/create/articles.nim
+++ b/src/create/articles.nim
@@ -1,6 +1,5 @@
 import std/[os, strformat, strutils]
-import ".."/[fmt/articles, helpers, sync/sync_common, types_track_config,
-             types_articles_config, uuid/uuid]
+import ".."/[fmt/articles, helpers, types_track_config, types_articles_config, uuid/uuid]
 
 func kebabToTitleCase(slug: Slug): string =
   result = newStringOfCap(slug.len)

--- a/src/fmt/track_config.nim
+++ b/src/fmt/track_config.nim
@@ -1,4 +1,4 @@
-import std/[algorithm, sequtils, json, options, sets, strformat]
+import std/[algorithm, sequtils, json, options, sets]
 import ".."/[helpers, sync/sync_common, types_track_config]
 
 func trackConfigKeyOrderForFmt(e: TrackConfig): seq[TrackConfigKey] =

--- a/src/info/info.nim
+++ b/src/info/info.nim
@@ -1,5 +1,4 @@
 import std/[algorithm, os, sequtils, sets, strformat, strutils, sugar, terminal]
-import pkg/jsony
 import ".."/[cli, sync/probspecs, types_track_config]
 
 proc header(s: string): string =


### PR DESCRIPTION
With this PR, there is exactly one file (`helpers.nim`) that imports `jsony`, and it also exports `jsony`. Following this rule should make the codebase more robust to the problem of `parseHook`s not being visible.

To-do:

- [x] Add some of these back, if they were actually used.
