### PR TITLE
build: build arm64 macOS binary natively

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,10 @@ jobs:
             arch: x86-64
 
           - os: macos
+            runs-on: macos-13-xlarge
+            arch: arm64
+
+          - os: macos
             runs-on: macos-12
             arch: x86-64
 
@@ -83,9 +87,6 @@ jobs:
 
           - runs-on: ubuntu-22.04
             zig_target: riscv64-linux-musl
-
-          - runs-on: macos-12
-            zig_target: aarch64-macos-none
 
           - runs-on: ubuntu-22.04
             zig_target: aarch64-windows-gnu


### PR DESCRIPTION
Apple silicon (M1) macOS runners are [now available in public beta][1].

Closes: #801

[1]: https://github.blog/changelog/2023-10-02-github-actions-apple-silicon-m1-macos-runners-are-now-available-in-public-beta/

---

@ErikSchierboom it looks the new job currently won't run. GitHub [says](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners):

>  GitHub offers customers on GitHub Team and GitHub Enterprise Cloud plans a range of managed virtual machines with more RAM, CPU, and disk space

and

> can now be used by any developer, team, or enterprise! 

I thought that "GitHub Team" was what open-source orgs were. Do you know whether this runner is available for Exercism, or whether there perhaps a setting somewhere that Exercism needs to change to allow using it in this repo?