### PR TITLE
lint(track_config): allow omitting `concepts` and `exercises.concept`

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -121,7 +121,7 @@ proc hasValidExercises(data: JsonNode; path: Path): bool =
     let exercises = data[k]
     let checks = [
       hasArrayOf(exercises, "concept", path, isValidConceptExercise, k,
-                 allowedLength = 0..int.high),
+                 isRequired = false, allowedLength = 0..int.high),
       hasArrayOf(exercises, "practice", path, isValidPracticeExercise, k,
                  allowedLength = 0..int.high),
       hasArrayOfStrings(exercises, "foregone", path, k, isRequired = false,
@@ -141,7 +141,7 @@ proc isValidConcept(data: JsonNode; context: string; path: Path): bool =
 
 proc hasValidConcepts(data: JsonNode; path: Path): bool =
   result = hasArrayOf(data, "concepts", path, isValidConcept,
-                      allowedLength = 0..int.high)
+                      isRequired = false, allowedLength = 0..int.high)
 
 const keyFeatureIcons = [
   "community",


### PR DESCRIPTION
A recent commit (66914845a323) caused `configlet fmt -uy` to remove these keys from the track-level `config.json` file when the corresponding value was empty. This would cause a subsequent `configlet lint` to indicate an error, in line with the spec. But we'll change the spec so that omitting these keys is allowed, because:

- It's fine for tracks to lack concepts, or to lack concept exercises
- There is little value in keeping empty arrays around
- In practice the keys _are_ optional, because Exercism gracefully   handles them being omitted 

Fixes: #831