### PR TITLE
docs(README, releases): improve style

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Global options:
 
 The primary function of configlet is to do _linting_: checking if a track's configuration files are correctly structured - both syntactically and semantically.
 Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience.
-Therefore configlet's guards play an important part in maintaining the integrity of Exercism.
+Configlet's checks are therefore important for maintaining the integrity of Exercism.
 
 The `configlet lint` command is still under development.
 The list of currently implemented checks is [here](https://github.com/exercism/configlet/issues/249).
@@ -326,7 +326,7 @@ To print a list of paths for which there isn't already a formatted exercise `.me
 configlet fmt
 ```
 
-For configlet to prompt to write formatted config files, add the `--update` option (or `-u` for short):
+To make configlet prompt to write formatted config files, add the `--update` option (or `-u` for short):
 
 ```shell
 configlet fmt --update

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ We describe the checking and updating of these data kinds in individual sections
 - Note that `configlet sync` tries to preserve the key order in exercise `.meta/config.json` files when updating.
   To write these files in a canonical form without syncing, please use the `configlet fmt` command.
   However, `configlet sync` _does_ add (possibly empty) required keys (`authors`, `files`, `blurb`) when they're missing.
-  This is less "sync-like", but more ergonomic: when implementing a new exercise, you can use `sync` to create a starter `.meta/config.json` file.
+  This is less like syncing, but more ergonomic: when implementing a new exercise, you can use `sync` to create a starter `.meta/config.json` file.
 - `configlet sync` removes keys that aren't in the spec.
   Custom key/value pairs are still supported, but you must write them inside a JSON object named `custom`.
 - Configlet exits with an exit code of 0 when all the seen data are up to date, and 1 otherwise.

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ If you are adding a Practice Exercise named `foo` that exists in `problem-specif
 1. Manually add an entry to the track-level `config.json` file for the exercise `foo`.
    This makes the exercise visible to `configlet sync`.
 1. Run `configlet sync --docs --filepaths --metadata -uy -e foo` to create the exercise's documentation, and a starter `.meta/config.json` file with populated `files`, `blurb`, and perhaps `source` and `source_url` values.
-1. Edit the exercise `.meta/config.json` file as desired.
+1. Edit the exercise `.meta/config.json` file as needed.
    For example, add yourself to the `authors` array.
 1. Run `configlet sync --tests include -u -e foo` to create a `.meta/tests.toml` file with every test included.
 1. View that `.meta/tests.toml` file, and add `include = false` to any test case that the exercise won't implement.

--- a/README.md
+++ b/README.md
@@ -314,17 +314,13 @@ An Exercism track repository has many JSON files, including:
 
 - For each Concept Exercise or Practice Exercise, a `.meta/config.json` file.
 
-These files are more readable if they have a consistent formatting Exercism-wide,
-and so configlet has a `fmt` command for rewriting a track's JSON files in a canonical form.
+These files are more readable if they have a consistent formatting Exercism-wide, and so configlet has a `fmt` command for rewriting a track's JSON files in a canonical form.
 
-The `fmt` command currently only operates on the exercise `.meta/config.json` files,
-but it's likely to operate on all the track JSON files in the future.
+The `fmt` command currently only operates on the exercise `.meta/config.json` files, but it's likely to operate on all the track JSON files in the future.
 
-A plain `configlet fmt` makes no changes to the track,
-and checks the formatting of the `.meta/config.json` file for every Concept Exercise and Practice Exercise.
+A plain `configlet fmt` makes no changes to the track, and checks the formatting of the `.meta/config.json` file for every Concept Exercise and Practice Exercise.
 
-To print a list of paths for which there isn't already a formatted exercise `.meta/config.json` file
-(exiting with a nonzero exit code if at least one exercise lacks a formatted config file):
+To print a list of paths for which there isn't already a formatted exercise `.meta/config.json` file (exiting with a nonzero exit code if at least one exercise lacks a formatted config file):
 
 ```shell
 configlet fmt
@@ -392,8 +388,7 @@ The canonical key order for an exercise `.meta/config.json` file is:
 where the square brackets indicate that the enclosed key is optional.
 
 Note that `configlet fmt` only operates on exercises that exist in the track-level `config.json` file.
-Therefore if you are implementing a new exercise on a track and want to format its `.meta/config.json` file,
-add the exercise to the track-level `config.json` file first.
+Therefore if you are implementing a new exercise on a track and want to format its `.meta/config.json` file, add the exercise to the track-level `config.json` file first.
 If the exercise isn't yet ready to be user-facing, set its `status` value to `wip`.
 
 The exit code is 0 when every seen exercise has a formatted `.meta/config.json` file when configlet exits, and 1 otherwise.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The list of currently implemented checks is [here](https://github.com/exercism/c
 
 A Practice Exercise on an Exercism track is often implemented from a specification in the [`exercism/problem-specifications`](https://github.com/exercism/problem-specifications) repository.
 
-Exercism intentionally requires that every exercise has its own copy of certain files (like `.docs/instructions.md`), even when that exercise exists in `problem-specifications`.
+Exercism intentionally requires that every exercise has its own copy of certain files (such as `.docs/instructions.md`), even when that exercise exists in `problem-specifications`.
 Therefore configlet has a `sync` command, which can check that such Practice Exercises on a track are in sync with that upstream source, and can update them when updates are available.
 
 There are three kinds of data that configlet can update from `problem-specifications`: documentation, metadata, and tests.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can then use configlet by running `bin/configlet` or `bin/configlet.exe` res
 We sign each configlet release archive with [`minisign`](https://jedisct1.github.io/minisign/).
 
 For now, if you want to verify the signature of a configlet release, you need to do it manually.
-The `fetch-configlet` script may support checking the release signature in the future, but it won't be required: we don't want to require every `fetch-configlet` user to install `minisign`.
+The `fetch-configlet` script may support checking the release signature in the future, but it won't require checking it: we don't want to require every `fetch-configlet` user to install `minisign`.
 
 To verify a release archive, first download (from the assets section of a [release](https://github.com/exercism/configlet/releases)) the archive and its corresponding `.minisig` file.
 Write them to the same directory.
@@ -47,7 +47,7 @@ You may delete the archive and the `.minisig` file.
 
 ## Usage
 
-The application is a single binary and can be used as follows:
+The application is a single binary, and you can use it as follows:
 
 ```text
 Usage:
@@ -110,7 +110,7 @@ The primary function of configlet is to do _linting_: checking if a track's conf
 Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism.
 
 The `configlet lint` command is still under development.
-The list of currently implemented checks can be found [here](https://github.com/exercism/configlet/issues/249).
+The list of currently implemented checks is [here](https://github.com/exercism/configlet/issues/249).
 
 ## `configlet sync`
 
@@ -119,8 +119,8 @@ A Practice Exercise on an Exercism track is often implemented from a specificati
 Exercism deliberately requires that every exercise has its own copy of certain files (like `.docs/instructions.md`), even when that exercise exists in `problem-specifications`.
 Therefore configlet has a `sync` command, which can check that such Practice Exercises on a track are in sync with that upstream source, and can update them when updates are available.
 
-There are three kinds of data that can be updated from `problem-specifications`: documentation, metadata, and tests.
-There is also one kind of data that can be populated from the track-level `config.json` file: filepaths in exercise config files.
+There are three kinds of data that configlet can update from `problem-specifications`: documentation, metadata, and tests.
+There is also one kind of data that configlet can populate from the track-level `config.json` file: filepaths in exercise config files.
 
 We describe the checking and updating of these data kinds in individual sections below, but as a quick summary:
 
@@ -138,14 +138,14 @@ We describe the checking and updating of these data kinds in individual sections
   However, `configlet sync` _does_ add (possibly empty) required keys (`authors`, `files`, `blurb`) when they are missing.
   This is less "sync-like", but more ergonomic: when implementing a new exercise, you can use `sync` to create a starter `.meta/config.json` file.
 - `configlet sync` removes keys that are not in the spec.
-  Custom key/value pairs are still supported: they must be written inside a JSON object named `custom`.
-- The exit code is 0 when all the seen data are synced when configlet exits, and 1 otherwise.
+  Custom key/value pairs are still supported, but you must write them inside a JSON object named `custom`.
+- Configlet exits with an exit code of 0 when all the seen data are up to date, and 1 otherwise.
 
 Note that in `configlet` releases `4.0.0-alpha.34` and earlier, the `sync` command operated only on tests.
 
 ### Docs
 
-A Practice Exercise that is derived from the `problem-specifications` repo must have a `.docs/instructions.md` file (and possibly a `.docs/introduction.md` file too) containing the exercise documentation from `problem-specifications`.
+A Practice Exercise that originates from the `problem-specifications` repo must have a `.docs/instructions.md` file (and possibly a `.docs/introduction.md` file too) containing the exercise documentation from `problem-specifications`.
 
 To check every Practice Exercise on the track for available documentation updates (exiting with a non-zero exit code if at least one update is available):
 
@@ -175,7 +175,7 @@ configlet sync --docs -uy -e prime-factors
 ### Metadata
 
 Every exercise on a track must have a `.meta/config.json` file.
-For a Practice Exercise that is derived from the `problem-specifications` repo, this file should contain the `blurb`, `source` and `source_url` key/value pairs that exist in the corresponding upstream `metadata.toml` file.
+For a Practice Exercise that originates from the `problem-specifications` repo, this file should contain the `blurb`, `source` and `source_url` key/value pairs that exist in the corresponding upstream `metadata.toml` file.
 
 To check every Practice Exercise for available metadata updates (exiting with a non-zero exit code if at least one update is available):
 
@@ -205,8 +205,8 @@ configlet sync --metadata -uy -e prime-factors
 ### Tests
 
 If a track implements an exercise for which test data exists in the [problem-specifications repo](https://github.com/exercism/problem-specifications), the exercise _must_ contain a `.meta/tests.toml` file.
-The goal of the `tests.toml` file is to keep track of which tests are implemented by the exercise.
-Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
+The goal of the `tests.toml` file is to track which tests the exercise implements.
+Each test in this file has a UUID to identify it, and may have an `include` key to specify whether the test is implemented.
 
 A `tests.toml` file has this format:
 
@@ -268,7 +268,7 @@ Finally, the `sync` command also handles "syncing" from a source that isn't `pro
 Every Concept Exercise and Practice Exercise must have a `.meta/config.json` file with a `files` object that specifies the (relative) locations of the files that the exercise uses.
 Such filepaths usually follow a simple pattern, and so configlet can populate the exercise-level values from patterns in the `files` key of the track-level `config.json` file.
 
-To check that every Concept Exercise and Practice Exercise on the track has a fully populated `files` key (or at least one that cannot be populated from the track-level `files` key):
+To check that every Concept Exercise and Practice Exercise on the track has a fully populated `files` key (or at least one that we can populate from the track-level `files` key):
 
 ```shell
 configlet sync --filepaths
@@ -329,7 +329,7 @@ To print a list of paths for which there is not already a formatted exercise `.m
 configlet fmt
 ```
 
-To be prompted to write formatted config files, add the `--update` option (or `-u` for short):
+For configlet to prompt to write formatted config files, add the `--update` option (or `-u` for short):
 
 ```shell
 configlet fmt --update
@@ -357,7 +357,7 @@ When writing JSON files, `configlet fmt` will:
 - Use a separate line for each item in a JSON array, and each key in a JSON object.
 
 - Remove key/value pairs for keys that are optional and have empty values.
-  For example, `"source": ""` is removed.
+  For example, it will remove `"source": ""`.
 
 - Remove `"test_runner": true` from Practice Exercise config files.
   This is an optional key - the spec says that an omitted `test_runner` key implies the value `true`.
@@ -437,7 +437,7 @@ For example, if the track has a concept named `floating-point-numbers` then an `
 ```
 
 You can run `configlet generate` to generate the exercise's `introduction.md` for any exercise that has an `introduction.md.tpl` file.
-The generated `introduction.md` is identical to the `introduction.md.tpl`, except that concept placeholders are replaced with the contents of the concept's `introduction.md` file (minus its top-level heading).
+The generated `introduction.md` is identical to the `introduction.md.tpl`, except that configlet replaces concept placeholders with the contents of the concept's `introduction.md` file (minus its top-level heading).
 In the future, `configlet generate` will also increment the level of other headings by 1 (e.g. from `## My Heading` to `### My Heading`), but this is not yet implemented.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Then run a `minisign` command in that directory:
 minisign -Vm configlet_4.0.0-beta.13_linux_x86-64.tar.gz -P RWQGj6DTXgYLhKvWJMGtbDUrZerawUcyWnti9MGuWMx7VDW9DqZn2tMZ
 ```
 
-where the above argument to `-P` is the [configlet public key](https://github.com/exercism/configlet/blob/009dc9df9d947e71ff039ac2af0f82315dbf9073/configlet-minisign.pub).
+where the argument to `-P` is the [configlet public key](https://github.com/exercism/configlet/blob/009dc9df9d947e71ff039ac2af0f82315dbf9073/configlet-minisign.pub).
 
-The above command has verified the release archive if (and only if) the command's output begins with `Signature and comment signature verified`.
+The preceding command has verified the release archive if (and only if) the command's output begins with `Signature and comment signature verified`.
 For example:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Global options:
 ## `configlet lint`
 
 The primary function of configlet is to do _linting_: checking if a track's configuration files are correctly structured - both syntactically and semantically.
-Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism.
+Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience.
+Therefore configlet's guards play an important part in maintaining the integrity of Exercism.
 
 The `configlet lint` command is still under development.
 The list of currently implemented checks is [here](https://github.com/exercism/configlet/issues/249).

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ You can then use configlet by running `bin/configlet` or `bin/configlet.exe` res
 
 ### Verifying
 
-We sign each configlet release archive with [`minisign`](https://jedisct1.github.io/minisign/).
+Exercism signs each configlet release archive with [`minisign`](https://jedisct1.github.io/minisign/).
 
 For now, if you want to verify the signature of a configlet release, you need to do it manually.
-The `fetch-configlet` script may support checking the release signature in the future, but it won't require checking it: we don't want to require every `fetch-configlet` user to install `minisign`.
+The `fetch-configlet` script may support checking the release signature in the future, but it won't require checking it: Exercism doesn't want to require every `fetch-configlet` user to install `minisign`.
 
 To verify a release archive, first download (from the assets section of a [release](https://github.com/exercism/configlet/releases)) the archive and its corresponding `.minisig` file.
 Write them to the same directory.
@@ -268,7 +268,7 @@ Finally, the `sync` command also handles "syncing" from a source that isn't `pro
 Every Concept Exercise and Practice Exercise must have a `.meta/config.json` file with a `files` object that specifies the (relative) locations of the files that the exercise uses.
 Such filepaths usually follow a simple pattern, and so configlet can populate the exercise-level values from patterns in the `files` key of the track-level `config.json` file.
 
-To check that every Concept Exercise and Practice Exercise on the track has a fully populated `files` key (or at least one that we can populate from the track-level `files` key):
+To check that every Concept Exercise and Practice Exercise on the track has a fully populated `files` key (or at least one that configlet can populate from the track-level `files` key):
 
 ```shell
 configlet sync --filepaths

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ To check that every Concept Exercise and Practice Exercise on the track has a fu
 configlet sync --filepaths
 ```
 
-(Note that `configlet lint` will also produce an error when an exercise has a missing/empty `files` key.)
+(Note that `configlet lint` also produces an error when an exercise has a missing/empty `files` key.)
 
 To populate empty/missing values of the exercise-level `files` key for every Concept Exercise and Practice Exercise from the patterns in the track-level `files` key:
 
@@ -358,7 +358,7 @@ When writing JSON files, `configlet fmt` will:
 - Use a separate line for each item in a JSON array, and each key in a JSON object.
 
 - Remove key/value pairs for keys that are optional and have empty values.
-  For example, it will remove `"source": ""`.
+  For example, it removes `"source": ""`.
 
 - Remove `"test_runner": true` from Practice Exercise config files.
   This is an optional key - the spec says that an omitted `test_runner` key implies the value `true`.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ We describe the checking and updating of these data kinds in individual sections
 - To operate on a subset of data kinds, use some combination of the `--docs`, `--filepaths`, `--metadata`, and `--tests` options.
 - To interactively update data on the track, use the `--update` option.
 - To non-interactively update docs, filepaths, and metadata on the track, use `--update --yes`.
-- To non-interactively include every unseen test for a given exercise, use e.g. `--update --tests include --exercise prime-factors`.
+- To non-interactively include every unseen test for a given exercise, use (for example) `--update --tests include --exercise prime-factors`.
 - To skip downloading the `problem-specifications` repo, add `--offline --prob-specs-dir /path/to/local/problem-specifications`
 - Note that `configlet sync` tries to maintain the key order in exercise `.meta/config.json` files when updating.
   To write these files in a canonical form without syncing, please use the `configlet fmt` command.
@@ -438,7 +438,7 @@ For example, if the track has a concept named `floating-point-numbers` then an `
 
 You can run `configlet generate` to generate the exercise's `introduction.md` for any exercise that has an `introduction.md.tpl` file.
 The generated `introduction.md` is identical to the `introduction.md.tpl`, except that configlet replaces concept placeholders with the contents of the concept's `introduction.md` file (minus its top-level heading).
-In the future, `configlet generate` will also increment the level of other headings by 1 (e.g. from `## My Heading` to `### My Heading`), but this isn't yet implemented.
+In the future, `configlet generate` will also increment the level of other headings by 1 (for example from `## My Heading` to `### My Heading`), but this isn't yet implemented.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The list of currently implemented checks is [here](https://github.com/exercism/c
 
 ## `configlet sync`
 
-A Practice Exercise on an Exercism track is often implemented from a specification in the [`exercism/problem-specifications`](https://github.com/exercism/problem-specifications) repo.
+A Practice Exercise on an Exercism track is often implemented from a specification in the [`exercism/problem-specifications`](https://github.com/exercism/problem-specifications) repository.
 
 Exercism deliberately requires that every exercise has its own copy of certain files (like `.docs/instructions.md`), even when that exercise exists in `problem-specifications`.
 Therefore configlet has a `sync` command, which can check that such Practice Exercises on a track are in sync with that upstream source, and can update them when updates are available.
@@ -132,7 +132,7 @@ We describe the checking and updating of these data kinds in individual sections
 - To interactively update data on the track, use the `--update` option.
 - To non-interactively update docs, filepaths, and metadata on the track, use `--update --yes`.
 - To non-interactively include every unseen test for a given exercise, use (for example) `--update --tests include --exercise prime-factors`.
-- To skip downloading the `problem-specifications` repo, add `--offline --prob-specs-dir /path/to/local/problem-specifications`
+- To skip downloading the `problem-specifications` repository, add `--offline --prob-specs-dir /path/to/local/problem-specifications`
 - Note that `configlet sync` tries to maintain the key order in exercise `.meta/config.json` files when updating.
   To write these files in a canonical form without syncing, please use the `configlet fmt` command.
   However, `configlet sync` _does_ add (possibly empty) required keys (`authors`, `files`, `blurb`) when they're missing.
@@ -145,7 +145,7 @@ Note that in `configlet` releases `4.0.0-alpha.34` and earlier, the `sync` comma
 
 ### Docs
 
-A Practice Exercise that originates from the `problem-specifications` repo must have a `.docs/instructions.md` file (and possibly a `.docs/introduction.md` file too) containing the exercise documentation from `problem-specifications`.
+A Practice Exercise that originates from the `problem-specifications` repository must have a `.docs/instructions.md` file (and possibly a `.docs/introduction.md` file too) containing the exercise documentation from `problem-specifications`.
 
 To check every Practice Exercise on the track for available documentation updates (exiting with a non-zero exit code if at least one update is available):
 
@@ -175,7 +175,7 @@ configlet sync --docs -uy -e prime-factors
 ### Metadata
 
 Every exercise on a track must have a `.meta/config.json` file.
-For a Practice Exercise that originates from the `problem-specifications` repo, this file should contain the `blurb`, `source` and `source_url` key/value pairs that exist in the corresponding upstream `metadata.toml` file.
+For a Practice Exercise that originates from the `problem-specifications` repository, this file should contain the `blurb`, `source` and `source_url` key/value pairs that exist in the corresponding upstream `metadata.toml` file.
 
 To check every Practice Exercise for available metadata updates (exiting with a non-zero exit code if at least one update is available):
 
@@ -204,7 +204,7 @@ configlet sync --metadata -uy -e prime-factors
 
 ### Tests
 
-If a track implements an exercise for which test data exists in the [problem-specifications repo](https://github.com/exercism/problem-specifications), the exercise _must_ contain a `.meta/tests.toml` file.
+If a track implements an exercise for which test data exists in the [problem-specifications repository](https://github.com/exercism/problem-specifications), the exercise _must_ contain a `.meta/tests.toml` file.
 The goal of the `tests.toml` file is to track which tests the exercise implements.
 Each test in this file has a UUID to identify it, and may have an `include` key to specify whether the test is implemented.
 
@@ -305,7 +305,7 @@ If you are adding a Practice Exercise named `foo` that exists in `problem-specif
 
 ## `configlet fmt`
 
-An Exercism track repo has many JSON files, including:
+An Exercism track repository has many JSON files, including:
 
 - The track `config.json` file.
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ configlet sync --tests --update
 
 For each missing test, this prompts the user to choose whether to include/exclude/skip it, and updates the corresponding `tests.toml` file accordingly.
 Configlet writes an exercise's `tests.toml` file when the user has finished making choices for that exercise.
-This means that you can terminate configlet at a prompt (for example, by pressing Ctrl-C in the terminal) and only lose the syncing decisions for at most one exercise.
+This means that you can exit configlet at a prompt (for example, by pressing Ctrl-C in the terminal) and only lose the syncing decisions for at most one exercise.
 
 To non-interactively include every unseen test case, use `--tests include`.
 For example, to do so for an exercise named `prime-factors`:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Each track should have a `bin/fetch-configlet` script, and might have a `bin/fet
 The first is a bash script, and the second is a PowerShell script.
 
 Running one of these scripts downloads the latest version of configlet to the `bin` directory.
-You can then use configlet by running `bin/configlet` or `bin/configlet.exe` respectively.
+You can then use configlet by running `bin/configlet`, or `bin/configlet.exe` on Windows.
 
 ### Verifying
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Global options:
 
 ## `configlet lint`
 
-The primary function of configlet is to do _linting_: checking if a track's configuration files are properly structured - both syntactically and semantically.
+The primary function of configlet is to do _linting_: checking if a track's configuration files are correctly structured - both syntactically and semantically.
 Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism.
 
 The `configlet lint` command is still under development.
@@ -116,7 +116,7 @@ The list of currently implemented checks is [here](https://github.com/exercism/c
 
 A Practice Exercise on an Exercism track is often implemented from a specification in the [`exercism/problem-specifications`](https://github.com/exercism/problem-specifications) repository.
 
-Exercism deliberately requires that every exercise has its own copy of certain files (like `.docs/instructions.md`), even when that exercise exists in `problem-specifications`.
+Exercism intentionally requires that every exercise has its own copy of certain files (like `.docs/instructions.md`), even when that exercise exists in `problem-specifications`.
 Therefore configlet has a `sync` command, which can check that such Practice Exercises on a track are in sync with that upstream source, and can update them when updates are available.
 
 There are three kinds of data that configlet can update from `problem-specifications`: documentation, metadata, and tests.
@@ -133,7 +133,7 @@ We describe the checking and updating of these data kinds in individual sections
 - To non-interactively update docs, filepaths, and metadata on the track, use `--update --yes`.
 - To non-interactively include every unseen test for a given exercise, use (for example) `--update --tests include --exercise prime-factors`.
 - To skip downloading the `problem-specifications` repository, add `--offline --prob-specs-dir /path/to/local/problem-specifications`
-- Note that `configlet sync` tries to maintain the key order in exercise `.meta/config.json` files when updating.
+- Note that `configlet sync` tries to preserve the key order in exercise `.meta/config.json` files when updating.
   To write these files in a canonical form without syncing, please use the `configlet fmt` command.
   However, `configlet sync` _does_ add (possibly empty) required keys (`authors`, `files`, `blurb`) when they're missing.
   This is less "sync-like", but more ergonomic: when implementing a new exercise, you can use `sync` to create a starter `.meta/config.json` file.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Therefore configlet has a `sync` command, which can check that such Practice Exe
 There are three kinds of data that configlet can update from `problem-specifications`: documentation, metadata, and tests.
 There is also one kind of data that configlet can populate from the track-level `config.json` file: filepaths in exercise config files.
 
-We describe the checking and updating of these data kinds in individual sections below, but as a quick summary:
+We describe the checking and updating of these data kinds in individual sections later, but as a quick summary:
 
 - `configlet sync` only operates on exercises that exist in the track-level `config.json` file.
   Therefore if you are implementing a new exercise on a track and want to add the initial files with `configlet sync`, please add the exercise to the track-level `config.json` file first.
@@ -401,7 +401,7 @@ The exit code is 0 when every seen exercise has a formatted `.meta/config.json` 
 ## `configlet uuid`
 
 Each exercise and concept has a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier), which must only appear once across all of Exercism.
-It must be a valid version 4 UUID (compliant with RFC 4122) in the canonical textual representation, which means that it must match the below regular expression:
+It must be a valid version 4 UUID (compliant with RFC 4122) in the canonical textual representation, which means that it must match this regular expression:
 
 ```text
 ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ There is also one kind of data that configlet can populate from the track-level 
 We describe the checking and updating of these data kinds in individual sections later, but as a quick summary:
 
 - `configlet sync` only operates on exercises that exist in the track-level `config.json` file.
-  Therefore if you are implementing a new exercise on a track and want to add the initial files with `configlet sync`, please add the exercise to the track-level `config.json` file first.
-  If the exercise isn't yet ready to be user-facing, please set its `status` value to `wip`.
+  Therefore if you are implementing a new exercise on a track and want to add the initial files with `configlet sync`, add the exercise to the track-level `config.json` file first.
+  If the exercise isn't yet ready to be user-facing, set its `status` value to `wip`.
 - A plain `configlet sync` makes no changes to the track, and checks every data kind for every exercise.
 - To operate on a subset of data kinds, use some combination of the `--docs`, `--filepaths`, `--metadata`, and `--tests` options.
 - To interactively update data on the track, use the `--update` option.
@@ -135,7 +135,7 @@ We describe the checking and updating of these data kinds in individual sections
 - To non-interactively include every unseen test for a given exercise, use (for example) `--update --tests include --exercise prime-factors`.
 - To skip downloading the `problem-specifications` repository, add `--offline --prob-specs-dir /path/to/local/problem-specifications`
 - Note that `configlet sync` tries to preserve the key order in exercise `.meta/config.json` files when updating.
-  To write these files in a canonical form without syncing, please use the `configlet fmt` command.
+  To write these files in a canonical form without syncing, use the `configlet fmt` command.
   However, `configlet sync` _does_ add (possibly empty) required keys (`authors`, `files`, `blurb`) when they're missing.
   This is less like syncing, but more ergonomic: when implementing a new exercise, you can use `sync` to create a starter `.meta/config.json` file.
 - `configlet sync` removes keys that aren't in the spec.
@@ -393,8 +393,8 @@ where the square brackets indicate that the enclosed key is optional.
 
 Note that `configlet fmt` only operates on exercises that exist in the track-level `config.json` file.
 Therefore if you are implementing a new exercise on a track and want to format its `.meta/config.json` file,
-please add the exercise to the track-level `config.json` file first.
-If the exercise isn't yet ready to be user-facing, please set its `status` value to `wip`.
+add the exercise to the track-level `config.json` file first.
+If the exercise isn't yet ready to be user-facing, set its `status` value to `wip`.
 
 The exit code is 0 when every seen exercise has a formatted `.meta/config.json` file when configlet exits, and 1 otherwise.
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ To interactively update the `tests.toml` file for every Practice Exercise, add t
 configlet sync --tests --update
 ```
 
-For each missing test, this prompts the user to choose whether to include/exclude/skip it, and updates the corresponding `tests.toml` file accordingly.
+For each missing test, this prompts the user to choose whether to include/exclude/skip it, and updates the corresponding `tests.toml` file as appropriate.
 Configlet writes an exercise's `tests.toml` file when the user has finished making choices for that exercise.
 This means that you can exit configlet at a prompt (for example, by pressing Ctrl-C in the terminal) and only lose the syncing decisions for at most one exercise.
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Therefore configlet has a `sync` command, which can check that such Practice Exe
 There are three kinds of data that configlet can update from `problem-specifications`: documentation, metadata, and tests.
 There is also one kind of data that configlet can populate from the track-level `config.json` file: filepaths in exercise config files.
 
-We describe the checking and updating of these data kinds in individual sections later, but as a quick summary:
+Later sections describe the checking and updating of these data kinds, but as a quick summary:
 
 - `configlet sync` only operates on exercises that exist in the track-level `config.json` file.
   Therefore if you are implementing a new exercise on a track and want to add the initial files with `configlet sync`, add the exercise to the track-level `config.json` file first.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Note that in `configlet` releases `4.0.0-alpha.34` and earlier, the `sync` comma
 
 A Practice Exercise that originates from the `problem-specifications` repository must have a `.docs/instructions.md` file (and possibly a `.docs/introduction.md` file too) containing the exercise documentation from `problem-specifications`.
 
-To check every Practice Exercise on the track for available documentation updates (exiting with a non-zero exit code if at least one update is available):
+To check every Practice Exercise on the track for available documentation updates (exiting with a nonzero exit code if at least one update is available):
 
 ```shell
 configlet sync --docs
@@ -178,7 +178,7 @@ configlet sync --docs -uy -e prime-factors
 Every exercise on a track must have a `.meta/config.json` file.
 For a Practice Exercise that originates from the `problem-specifications` repository, this file should contain the `blurb`, `source` and `source_url` key/value pairs that exist in the corresponding upstream `metadata.toml` file.
 
-To check every Practice Exercise for available metadata updates (exiting with a non-zero exit code if at least one update is available):
+To check every Practice Exercise for available metadata updates (exiting with a nonzero exit code if at least one update is available):
 
 ```shell
 configlet sync --metadata
@@ -238,7 +238,7 @@ comment = "excluded because we don't want to add error handling to the exercise"
 In this case, the track has chosen to implement two of the three available tests.
 If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
 
-To check every Practice Exercise `tests.toml` file for available tests updates (exiting with a non-zero exit code if there is at least one test case that appears in the exercise's canonical data, but not in the `tests.toml`):
+To check every Practice Exercise `tests.toml` file for available tests updates (exiting with a nonzero exit code if there is at least one test case that appears in the exercise's canonical data, but not in the `tests.toml`):
 
 ```shell
 configlet sync --tests
@@ -324,7 +324,7 @@ A plain `configlet fmt` makes no changes to the track,
 and checks the formatting of the `.meta/config.json` file for every Concept Exercise and Practice Exercise.
 
 To print a list of paths for which there isn't already a formatted exercise `.meta/config.json` file
-(exiting with a non-zero exit code if at least one exercise lacks a formatted config file):
+(exiting with a nonzero exit code if at least one exercise lacks a formatted config file):
 
 ```shell
 configlet fmt

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The `fetch-configlet` script may support checking the release signature in the f
 
 To verify a release archive, first download (from the assets section of a [release](https://github.com/exercism/configlet/releases)) the archive and its corresponding `.minisig` file.
 Write them to the same directory.
-For example, to verify the configlet 4.0.0-beta.13 Linux x86-64 release, download these files to the same directory:
+For example, to verify the configlet `4.0.0-beta.13` Linux x86-64 release, download these files to the same directory:
 
 ```text
 configlet_4.0.0-beta.13_linux_x86-64.tar.gz

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ We describe the checking and updating of these data kinds in individual sections
 
 - `configlet sync` only operates on exercises that exist in the track-level `config.json` file.
   Therefore if you are implementing a new exercise on a track and want to add the initial files with `configlet sync`, please add the exercise to the track-level `config.json` file first.
-  If the exercise is not yet ready to be user-facing, please set its `status` value to `wip`.
+  If the exercise isn't yet ready to be user-facing, please set its `status` value to `wip`.
 - A plain `configlet sync` makes no changes to the track, and checks every data kind for every exercise.
 - To operate on a subset of data kinds, use some combination of the `--docs`, `--filepaths`, `--metadata`, and `--tests` options.
 - To interactively update data on the track, use the `--update` option.
@@ -135,9 +135,9 @@ We describe the checking and updating of these data kinds in individual sections
 - To skip downloading the `problem-specifications` repo, add `--offline --prob-specs-dir /path/to/local/problem-specifications`
 - Note that `configlet sync` tries to maintain the key order in exercise `.meta/config.json` files when updating.
   To write these files in a canonical form without syncing, please use the `configlet fmt` command.
-  However, `configlet sync` _does_ add (possibly empty) required keys (`authors`, `files`, `blurb`) when they are missing.
+  However, `configlet sync` _does_ add (possibly empty) required keys (`authors`, `files`, `blurb`) when they're missing.
   This is less "sync-like", but more ergonomic: when implementing a new exercise, you can use `sync` to create a starter `.meta/config.json` file.
-- `configlet sync` removes keys that are not in the spec.
+- `configlet sync` removes keys that aren't in the spec.
   Custom key/value pairs are still supported, but you must write them inside a JSON object named `custom`.
 - Configlet exits with an exit code of 0 when all the seen data are up to date, and 1 otherwise.
 
@@ -299,7 +299,7 @@ If you are adding a Practice Exercise named `foo` that exists in `problem-specif
 1. Edit the exercise `.meta/config.json` file as desired.
    For example, add yourself to the `authors` array.
 1. Run `configlet sync --tests include -u -e foo` to create a `.meta/tests.toml` file with every test included.
-1. View that `.meta/tests.toml` file, and add `include = false` to any test case that the exercise will not implement.
+1. View that `.meta/tests.toml` file, and add `include = false` to any test case that the exercise won't implement.
 1. Implement the tests for the exercise to match those included in `.meta/tests.toml`.
 1. Add the other required files.
 
@@ -317,12 +317,12 @@ These files are more readable if they have a consistent formatting Exercism-wide
 and so configlet has a `fmt` command for rewriting a track's JSON files in a canonical form.
 
 The `fmt` command currently only operates on the exercise `.meta/config.json` files,
-but it is likely to operate on all the track JSON files in the future.
+but it's likely to operate on all the track JSON files in the future.
 
 A plain `configlet fmt` makes no changes to the track,
 and checks the formatting of the `.meta/config.json` file for every Concept Exercise and Practice Exercise.
 
-To print a list of paths for which there is not already a formatted exercise `.meta/config.json` file
+To print a list of paths for which there isn't already a formatted exercise `.meta/config.json` file
 (exiting with a non-zero exit code if at least one exercise lacks a formatted config file):
 
 ```shell
@@ -393,7 +393,7 @@ where the square brackets indicate that the enclosed key is optional.
 Note that `configlet fmt` only operates on exercises that exist in the track-level `config.json` file.
 Therefore if you are implementing a new exercise on a track and want to format its `.meta/config.json` file,
 please add the exercise to the track-level `config.json` file first.
-If the exercise is not yet ready to be user-facing, please set its `status` value to `wip`.
+If the exercise isn't yet ready to be user-facing, please set its `status` value to `wip`.
 
 The exit code is 0 when every seen exercise has a formatted `.meta/config.json` file when configlet exits, and 1 otherwise.
 
@@ -422,7 +422,7 @@ e42b94bb-9c90-47f2-aebb-03cdbc27bf3b
 
 Each concept exercise and concept have an `introduction.md` file.
 If you want the exercise's introduction to include the concept's introduction verbatim, you can create a `introduction.md.tpl` file to achieve this.
-This file may use a placeholder to refer to the concept's introduction, so that the information is not duplicated.
+This file may use a placeholder to refer to the concept's introduction, so that the information isn't duplicated.
 
 Concept placeholders must use the following format:
 
@@ -438,7 +438,7 @@ For example, if the track has a concept named `floating-point-numbers` then an `
 
 You can run `configlet generate` to generate the exercise's `introduction.md` for any exercise that has an `introduction.md.tpl` file.
 The generated `introduction.md` is identical to the `introduction.md.tpl`, except that configlet replaces concept placeholders with the contents of the concept's `introduction.md` file (minus its top-level heading).
-In the future, `configlet generate` will also increment the level of other headings by 1 (e.g. from `## My Heading` to `### My Heading`), but this is not yet implemented.
+In the future, `configlet generate` will also increment the level of other headings by 1 (e.g. from `## My Heading` to `### My Heading`), but this isn't yet implemented.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -275,9 +275,9 @@ To check that every Concept Exercise and Practice Exercise on the track has a fu
 configlet sync --filepaths
 ```
 
-(Note that `configlet lint` also produces an error when an exercise has a missing/empty `files` key.)
+(Note that `configlet lint` also produces an error when an exercise has a missing or empty `files` key.)
 
-To populate empty/missing values of the exercise-level `files` key for every Concept Exercise and Practice Exercise from the patterns in the track-level `files` key:
+To populate empty or missing values of the exercise-level `files` key for every Concept Exercise and Practice Exercise from the patterns in the track-level `files` key:
 
 ```shell
 configlet sync --filepaths --update

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ For example, to do so for an exercise named `prime-factors`:
 configlet sync --tests include -u -e prime-factors
 ```
 
-Remember to actually implement these tests on the track!
+Remember to actually implement these tests on the track.
 
 ### Filepaths
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -75,7 +75,7 @@ We should:
 1. State in the new release notes that the reader shouldn't use the previous **tag**.
 
 This process means that we don't tag a different commit with a previously pushed tag.
-Please read the [git documentation on re-tagging][git-re-tag].
+See the [git documentation on re-tagging][git-re-tag].
 
 ### Investigate problems in a release
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -9,7 +9,7 @@
 1. Ideally, check that `configlet lint` and `configlet sync` don't produce unexpected output on any track - diffing the output from the previous release.
 
 1. Double-check that the repository is in a state such that a release makes sense.
-   Remember that we don't support force-pushing to `main`, so any release commit (and tag) will remain permanently.
+   Remember that we don't support force-pushing to `main`, so any release commit (and tag) remains permanently.
 
 1. If we merged a commit since creating the release PR, rebase the release PR on `main`.
    This ensures that CI tests the merge immediately before the release.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -82,7 +82,7 @@ See the [Git documentation on re-tagging][git-re-tag].
 If we've already published a release, and want to investigate a problem in it, we should mark the release as a prerelease.
 Similar to a draft release, a release marked as a prerelease won't be downloaded by a configlet CI job, or `fetch-configlet`.
 Note that you can't set a published release as a draft again.
-If it turns out that we want the release to be available again, simply undo the marking of the release as prerelease.
+If it turns out that we want the release to be available again, just undo the marking of the release as prerelease.
 If it turns out that we want to remove the release, follow the steps in the earlier section to create a new release.
 
 [bump_version]: https://github.com/exercism/configlet/blob/main/bin/bump_version.nim

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -83,7 +83,7 @@ If we've already published a release, and want to investigate a problem in it, w
 Similar to a draft release, a release marked as a prerelease won't be downloaded by a configlet CI job, or `fetch-configlet`.
 Note that you can't set a published release as a draft again.
 If it turns out that we want the release to be available again, simply undo the marking of the release as prerelease.
-If it turns out that we want to remove the release, follow the steps in the section above to create a new release.
+If it turns out that we want to remove the release, follow the steps in the earlier section to create a new release.
 
 [bump_version]: https://github.com/exercism/configlet/blob/main/bin/bump_version.nim
 [gh]: https://github.com/cli/cli

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,13 +2,13 @@
 
 ## How to create a configlet release
 
-1. Check that the repo state is such that creating a release PR makes sense.
+1. Check that the repository state is such that creating a release PR makes sense.
 
 1. Run [`bin/bump_version.nim`][bump_version], which also prompts to create a release PR if you have [`gh`][gh] installed on your machine.
 
 1. Ideally, check that `configlet lint` and `configlet sync` do not produce unexpected output on any track - diffing the output from the previous release.
 
-1. Double-check that the repo is in a state such that a release makes sense.
+1. Double-check that the repository is in a state such that a release makes sense.
    Remember that we do not support force-pushing to `main`, so any release commit (and tag) will remain permanently.
 
 1. If any commit has been merged since the release PR was created, rebase the release PR on `main`.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,10 +6,10 @@
 
 1. Run [`bin/bump_version.nim`][bump_version], which also prompts to create a release PR if you have [`gh`][gh] installed on your machine.
 
-1. Ideally, check that `configlet lint` and `configlet sync` do not produce unexpected output on any track - diffing the output from the previous release.
+1. Ideally, check that `configlet lint` and `configlet sync` don't produce unexpected output on any track - diffing the output from the previous release.
 
 1. Double-check that the repository is in a state such that a release makes sense.
-   Remember that we do not support force-pushing to `main`, so any release commit (and tag) will remain permanently.
+   Remember that we don't support force-pushing to `main`, so any release commit (and tag) will remain permanently.
 
 1. If any commit has been merged since the release PR was created, rebase the release PR on `main`.
    This ensures that CI tests the merge immediately before the release.
@@ -28,7 +28,7 @@
 > 3. Check that CI is green.
 > 4. Un-draft the release.
 
-where un-drafting the release means that, from that moment on, it is used in any newly triggered track CI configlet job (and downloaded by a user who runs `fetch-configlet`).
+where un-drafting the release means that, from that moment on, it's used in any newly triggered track CI configlet job (and downloaded by a user who runs `fetch-configlet`).
 
 If you edit the draft release notes in the GitHub web interface, be careful to not prematurely press the green "Publish release" button when you mean to press the "Save draft" button.
 You can also edit the release notes using the [GitHub CLI][gh] - for example, for a version `1.2.3`:
@@ -48,7 +48,7 @@ gh -R exercism/configlet release edit 1.2.3 --draft=false
 ### Intermittent failures
 
 If any build job fails due to intermittent failures, we should restart only the failing job.
-If we restart a build job that was successful, it will fail when it cannot upload an asset that already exists.
+If we restart a build job that was successful, it will fail when it can't upload an asset that already exists.
 In that case, we should manually delete the corresponding asset from the release and then restart the job.
 
 ### Abort or remove a release
@@ -59,12 +59,12 @@ If any of these are true:
 
 - We no longer want to create a release at this time.
 
-- We have already published a release, but we want to make track CI use the previous configlet version.
+- We've already published a release, but we want to make track CI use the previous configlet version.
 
 We should:
 
 1. Delete the problematic release, preferably without un-drafting it.
-   Do not delete the problematic tag.
+   Don't delete the problematic tag.
 
 1. Create PRs to fix the problem.
 
@@ -72,16 +72,16 @@ We should:
 
 1. When appropriate, begin the release process again.
 
-1. State in the new release notes that the previous **tag** should not be used.
+1. State in the new release notes that the previous **tag** shouldn't be used.
 
-This process means that we do not tag a different commit with a previously pushed tag.
+This process means that we don't tag a different commit with a previously pushed tag.
 Please read the [git documentation on re-tagging][git-re-tag].
 
 ### Investigate problems in a release
 
-If we have already published a release, and want to investigate a problem in it, we should mark the release as a prerelease.
-Similar to a draft release, a release marked as a prerelease will not be downloaded by a configlet CI job, or `fetch-configlet`.
-Note that a published release cannot be set as draft again.
+If we've already published a release, and want to investigate a problem in it, we should mark the release as a prerelease.
+Similar to a draft release, a release marked as a prerelease won't be downloaded by a configlet CI job, or `fetch-configlet`.
+Note that a published release can't be set as draft again.
 If it turns out that we want the release to be available again, simply undo the marking of the release as prerelease.
 If it turns out that we want to remove the release, follow the steps in the section above to create a new release.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -51,7 +51,7 @@ If any build job fails due to intermittent failures, we should restart only the 
 If we restart a build job that was successful, it will fail when it can't upload an asset that already exists.
 In that case, we should manually delete the corresponding asset from the release and then restart the job.
 
-### Abort or remove a release
+### Cancel or remove a release
 
 If any of these are true:
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -11,7 +11,7 @@
 1. Double-check that the repository is in a state such that a release makes sense.
    Remember that we don't support force-pushing to `main`, so any release commit (and tag) will remain permanently.
 
-1. If any commit has been merged since the release PR was created, rebase the release PR on `main`.
+1. If we merged a commit since creating the release PR, rebase the release PR on `main`.
    This ensures that CI tests the merge immediately before the release.
 
 1. Merge the release PR (using "Squash and merge" with the pre-filled commit title and a blank commit body).
@@ -72,7 +72,7 @@ We should:
 
 1. When appropriate, begin the release process again.
 
-1. State in the new release notes that the previous **tag** shouldn't be used.
+1. State in the new release notes that the reader shouldn't use the previous **tag**.
 
 This process means that we don't tag a different commit with a previously pushed tag.
 Please read the [git documentation on re-tagging][git-re-tag].
@@ -81,7 +81,7 @@ Please read the [git documentation on re-tagging][git-re-tag].
 
 If we've already published a release, and want to investigate a problem in it, we should mark the release as a prerelease.
 Similar to a draft release, a release marked as a prerelease won't be downloaded by a configlet CI job, or `fetch-configlet`.
-Note that a published release can't be set as draft again.
+Note that you can't set a published release as a draft again.
 If it turns out that we want the release to be available again, simply undo the marking of the release as prerelease.
 If it turns out that we want to remove the release, follow the steps in the section above to create a new release.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -75,7 +75,7 @@ We should:
 1. State in the new release notes that the reader shouldn't use the previous **tag**.
 
 This process means that we don't tag a different commit with a previously pushed tag.
-See the [git documentation on re-tagging][git-re-tag].
+See the [Git documentation on re-tagging][git-re-tag].
 
 ### Investigate problems in a release
 


### PR DESCRIPTION
Resolve some linter complaints that mostly hail from the Microsoft/Google/RedHat style guides. See the individual commits.

I don't feel strongly about most of this - feel free to suggest changes.