### PR TITLE
fetch-configlet.ps1: fix for newer PowerShell versions

### DIFF
--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -33,5 +33,10 @@ Write-Output "Fetching configlet..."
 $downloadUrl = Get-DownloadUrl
 $outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
 Invoke-WebRequest -Uri $downloadUrl -OutFile $outputFile @requestOpts
-Expand-Archive $outputFile -DestinationPath $outputDirectory -Force
+
+$configletPath = Join-Path -Path $outputDirectory -ChildPath "configlet.exe"
+if (Test-Path -Path $configletPath) { Remove-Item -Path $configletPath }
+[System.IO.Compression.ZipFile]::ExtractToDirectory($outputPath, $outputDirectory)
+Remove-Item -Path $outputPath
+
 Remove-Item -Path $outputFile

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -29,6 +29,7 @@ if (!(Test-Path -Path $outputDirectory)) {
     exit 1
 }
 
+Write-Output "Fetching configlet..."
 $downloadUrl = Get-DownloadUrl
 $outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
 Invoke-WebRequest -Uri $downloadUrl -OutFile $outputFile @requestOpts

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -12,8 +12,6 @@ $requestOpts = @{
     RetryIntervalSec  = 1
 }
 
-$fileName = "configlet_.+_windows_$arch.zip"
-
 Function Get-DownloadUrl {
     $arch = If ([Environment]::Is64BitOperatingSystem) { "x86-64" } Else { "i386" }
     $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"
@@ -38,5 +36,7 @@ Invoke-WebRequest -Uri $downloadUrl -OutFile $outputPath @requestOpts
 $configletPath = Join-Path -Path $outputDirectory -ChildPath "configlet.exe"
 if (Test-Path -Path $configletPath) { Remove-Item -Path $configletPath }
 [System.IO.Compression.ZipFile]::ExtractToDirectory($outputPath, $outputDirectory)
-
 Remove-Item -Path $outputPath
+
+$configletVersion = (Select-String -Pattern "/releases/download/(.+?)/" -InputObject $downloadUrl -AllMatches).Matches.Groups[1].Value
+Write-Output "Downloaded configlet ${configletVersion} to ${configletPath}"

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -17,9 +17,9 @@ $fileName = "configlet_.+_windows_$arch.zip"
 
 Function Get-DownloadUrl {
     $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"
-    Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts
-    | Select-Object -ExpandProperty assets
-    | Where-Object { $_.browser_download_url -match $FileName }
+    Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts `
+    | Select-Object -ExpandProperty assets `
+    | Where-Object { $_.browser_download_url -match $FileName } `
     | Select-Object -ExpandProperty browser_download_url -First 1
 }
 

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -12,10 +12,10 @@ $requestOpts = @{
     RetryIntervalSec  = 1
 }
 
-$arch = If ([Environment]::Is64BitOperatingSystem) { "x86-64" } Else { "i386" }
 $fileName = "configlet_.+_windows_$arch.zip"
 
 Function Get-DownloadUrl {
+    $arch = If ([Environment]::Is64BitOperatingSystem) { "x86-64" } Else { "i386" }
     $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"
     Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts `
     | Select-Object -ExpandProperty assets `

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -19,7 +19,7 @@ Function Get-DownloadUrl {
     $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"
     Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts `
     | Select-Object -ExpandProperty assets `
-    | Where-Object { $_.browser_download_url -match $FileName } `
+    | Where-Object { $_.name -match "^configlet_.+_windows_${arch}.zip$" } `
     | Select-Object -ExpandProperty browser_download_url -First 1
 }
 

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -23,8 +23,13 @@ Function Get-DownloadUrl {
     | Select-Object -ExpandProperty browser_download_url -First 1
 }
 
-$downloadUrl = Get-DownloadUrl
 $outputDirectory = "bin"
+if (!(Test-Path -Path $outputDirectory)) {
+    Write-Output "Error: no ./bin directory found. This script should be ran from a repo root."
+    exit 1
+}
+
+$downloadUrl = Get-DownloadUrl
 $outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
 Invoke-WebRequest -Uri $downloadUrl -OutFile $outputFile @requestOpts
 Expand-Archive $outputFile -DestinationPath $outputDirectory -Force

--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -31,12 +31,12 @@ if (!(Test-Path -Path $outputDirectory)) {
 
 Write-Output "Fetching configlet..."
 $downloadUrl = Get-DownloadUrl
-$outputFile = Join-Path -Path $outputDirectory -ChildPath $fileName
-Invoke-WebRequest -Uri $downloadUrl -OutFile $outputFile @requestOpts
+$outputFileName = "configlet.zip"
+$outputPath = Join-Path -Path $outputDirectory -ChildPath $outputFileName
+Invoke-WebRequest -Uri $downloadUrl -OutFile $outputPath @requestOpts
 
 $configletPath = Join-Path -Path $outputDirectory -ChildPath "configlet.exe"
 if (Test-Path -Path $configletPath) { Remove-Item -Path $configletPath }
 [System.IO.Compression.ZipFile]::ExtractToDirectory($outputPath, $outputDirectory)
-Remove-Item -Path $outputPath
 
-Remove-Item -Path $outputFile
+Remove-Item -Path $outputPath


### PR DESCRIPTION
- scripts(ps1): fix command chaining
- scripts(ps1): move  to where it is needed
- scripts(ps1): use name field to exactly match filename
- scripts(ps1): test if script is run from repo root
- scripts(ps1): add message for downloading
- scripts(ps1): replace broken expand-archive with ZipFile
- scripts(ps1): use explicit output filename
- scripts(ps1): output download info

Closes #839