### PR TITLE
.github(lint-whitespace): print trailing whitespace line numbers

### DIFF
--- a/.github/bin/lint-whitespace
+++ b/.github/bin/lint-whitespace
@@ -8,7 +8,7 @@ cd "${repo_root}" || exit
 exit_status=0
 
 # Check that each git-tracked non-binary file has no trailing whitespace.
-trailing_whitespace="$(git grep --cached -I '[[:blank:]]$')"
+trailing_whitespace="$(git grep --line-number --cached -I '[[:blank:]]$')"
 if [ -n "${trailing_whitespace}" ]; then
   echo "There is trailing whitespace on the below lines:"
   echo "${trailing_whitespace}"


### PR DESCRIPTION
This makes it a lot easier to find the culprit.