### PR TITLE
logger: add `withLevel` template

### DIFF
--- a/src/logger.nim
+++ b/src/logger.nim
@@ -17,6 +17,12 @@ proc setupLogging*(verbosity: Verbosity) =
   addHandler(consoleLogger)
   setLevel(verbosity)
 
+template withLevel*(verbosity: Verbosity, body: untyped): untyped =
+  let currentLevel = consoleLogger.levelThreshold
+  consoleLogger.levelThreshold = toLevel(verbosity)
+  body
+  consoleLogger.levelThreshold = currentLevel
+
 template logNormal*(msgs: varargs[string]) =
   notice(msgs)
 

--- a/src/logger.nim
+++ b/src/logger.nim
@@ -1,16 +1,21 @@
 import std/logging
 import "."/cli
 
+let consoleLogger = newConsoleLogger(levelThreshold = lvlNotice,
+                                     fmtStr = "")
+
 func toLevel(verbosity: Verbosity): Level =
   case verbosity
   of verQuiet: lvlNone
   of verNormal: lvlNotice
   of verDetailed: lvlInfo
 
+proc setLevel(verbosity: Verbosity) =
+  consoleLogger.levelThreshold = toLevel(verbosity)
+
 proc setupLogging*(verbosity: Verbosity) =
-  let consoleLogger = newConsoleLogger(levelThreshold = toLevel(verbosity),
-                                       fmtStr = "")
   addHandler(consoleLogger)
+  setLevel(verbosity)
 
 template logNormal*(msgs: varargs[string]) =
   notice(msgs)


### PR DESCRIPTION
- Add proc to set level of logger
- Allow running code with specific verbosity
