### PR TITLE
completions: add new `create` options

### DIFF
--- a/completions/configlet.bash
+++ b/completions/configlet.bash
@@ -85,7 +85,7 @@ _configlet_complete_create_() {
       _configlet_complete_slugs_ "practice" "concept"
       ;;
     *)
-      _configlet_complete_options_ "--approach --article --concept-exercise -e --exercise --practice-exercise $global_opts"
+      _configlet_complete_options_ "--approach --article --concept-exercise -e --exercise --practice-exercise -o --offline $global_opts"
       ;;
   esac
 }

--- a/completions/configlet.bash
+++ b/completions/configlet.bash
@@ -84,14 +84,8 @@ _configlet_complete_create_() {
     '-e' | '--exercise')
       _configlet_complete_slugs_ "practice" "concept"
       ;;
-    '--concept-exercise')
-      _configlet_complete_slugs_ "concept"
-      ;;
-    '--practice-exercise')
-      _configlet_complete_slugs_ "practice"
-      ;;
     *)
-      _configlet_complete_options_ "--approach --article -e --exercise $global_opts"
+      _configlet_complete_options_ "--approach --article --concept-exercise -e --exercise --practice-exercise $global_opts"
       ;;
   esac
 }

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -26,6 +26,8 @@ complete -c configlet -n "__fish_seen_subcommand_from create"     -s e -l exerci
   -xa '(__fish_configlet_find_dirs ./exercises/{concept,practice})'
 complete -c configlet -n "__fish_seen_subcommand_from create"          -l approach  -d "The slug of the approach"
 complete -c configlet -n "__fish_seen_subcommand_from create"          -l article   -d "The slug of the article"
+complete -c configlet -n "__fish_seen_subcommand_from create"          -l practice-exercise   -d "The slug of the practice exercise"
+complete -c configlet -n "__fish_seen_subcommand_from create"          -l concept-exercise   -d "The slug of the concept exercise"
 
 # fmt subcommand
 complete -c configlet -n "__fish_seen_subcommand_from fmt"        -s e -l exercise  -d "exercise slug" \

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -24,9 +24,10 @@ complete -c configlet -n "__fish_seen_subcommand_from completion" -s s -l shell 
 # create subcommand
 complete -c configlet -n "__fish_seen_subcommand_from create"     -s e -l exercise  -d "exercise slug" \
   -xa '(__fish_configlet_find_dirs ./exercises/{concept,practice})'
+complete -c configlet -n "__fish_seen_subcommand_from create"     -s o -l offline   -d "Do not update prob-specs cache"
 complete -c configlet -n "__fish_seen_subcommand_from create"          -l approach  -d "The slug of the approach"
 complete -c configlet -n "__fish_seen_subcommand_from create"          -l article   -d "The slug of the article"
-complete -c configlet -n "__fish_seen_subcommand_from create"          -l practice-exercise   -d "The slug of the practice exercise"
+complete -c configlet -n "__fish_seen_subcommand_from create"          -l practice-exercise  -d "The slug of the practice exercise"
 complete -c configlet -n "__fish_seen_subcommand_from create"          -l concept-exercise   -d "The slug of the concept exercise"
 
 # fmt subcommand

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -84,6 +84,8 @@ _configlet() {
           '(-e --exercise)'{-e+,--exercise=}'[exercise slug]:slug:_configlet_complete_any_exercise_slug' \
           '--approach=[The slug of the approach]' \
           '--article=[The slug of the article]' \
+          '--concept-exercise=[The slug of the concept exercise]' \
+          '--practice-exercise=[The slug of the practice exercise]' \
       ;;
     (fmt)
       _arguments "${_arguments_options[@]}" \

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -82,6 +82,7 @@ _configlet() {
       _arguments "${_arguments_options[@]}" \
           "$_configlet_global_opts[@]" \
           '(-e --exercise)'{-e+,--exercise=}'[exercise slug]:slug:_configlet_complete_any_exercise_slug' \
+          {-o,--offline}'[Do not update prob-specs cache]' \
           '--approach=[The slug of the approach]' \
           '--article=[The slug of the article]' \
           '--concept-exercise=[The slug of the concept exercise]' \


### PR DESCRIPTION
For bash, we're creating _new_ slugs, so there's no point enabling tab completion for the option's argument.

Closes: https://github.com/exercism/configlet/issues/853
Closes: https://github.com/exercism/configlet/issues/854
Closes: https://github.com/exercism/configlet/issues/855