### PR TITLE
create, README: fix descriptions of new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Options for completion:
 Options for create:
       --approach <slug>           The slug of the approach
       --article <slug>            The slug of the article
-      --practice-exercise <slug>  The slug of the concept exercise
-      --concept-exercise <slug>   The slug of the practice exercise
+      --practice-exercise <slug>  The slug of the practice exercise
+      --concept-exercise <slug>   The slug of the concept exercise
   -e, --exercise <slug>           Only operate on this exercise
   -o, --offline                   Do not update the cached 'problem-specifications' data
 

--- a/src/cli.nim
+++ b/src/cli.nim
@@ -242,8 +242,8 @@ func genHelpText: string =
                   &"{paddingOpt}{allowedValues(Verbosity)} (default: normal)",
     optCreateApproach: "The slug of the approach",
     optCreateArticle: "The slug of the article",
-    optCreateConceptExercise: "The slug of the practice exercise",
-    optCreatePracticeExercise: "The slug of the concept exercise",
+    optCreateConceptExercise: "The slug of the concept exercise",
+    optCreatePracticeExercise: "The slug of the practice exercise",
     optCompletionShell: &"Choose the shell type (required)\n" &
                         &"{paddingOpt}{allowedValues(Shell)}",
     optFmtSyncCreateExercise: "Only operate on this exercise",


### PR DESCRIPTION
The help text for the `--practice-exercise` and `--concept-exercise` options of `configlet create` were inverted:

```text
Options for create:
      --approach <slug>           The slug of the approach
      --article <slug>            The slug of the article
      --practice-exercise <slug>  The slug of the concept exercise
      --concept-exercise <slug>   The slug of the practice exercise
  -e, --exercise <slug>           Only operate on this exercise
  -o, --offline                   Do not update the cached 'problem-specifications' data
```

This PR swaps them around.