### PR TITLE
lint(track_config): add support for `paradigm/array` tag

### DIFF
--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -226,6 +226,7 @@ proc hasValidKeyFeatures(data: JsonNode; path: Path): bool =
                       errorAnnotation = errorAnnotation)
 
 const tags = [
+  "paradigm/array",
   "paradigm/declarative",
   "paradigm/functional",
   "paradigm/imperative",


### PR DESCRIPTION
CC @eNascimento178 and @jonmcalder Once this is merged and we've released a new version of `configlet`, you can use this tag for your tracks.

Corresponding docs PR opened: https://github.com/exercism/docs/pull/499