### PR TITLE
Add completions for `create` options author and difficulty.

### DIFF
--- a/completions/configlet.bash
+++ b/completions/configlet.bash
@@ -85,7 +85,17 @@ _configlet_complete_create_() {
       _configlet_complete_slugs_ "practice" "concept"
       ;;
     *)
-      _configlet_complete_options_ "--approach --article --concept-exercise -e --exercise --practice-exercise -o --offline $global_opts"
+      local options=(
+           --approach
+           --article
+        -a --author
+           --concept-exercise
+        -d --difficulty
+        -e --exercise
+           --practice-exercise
+        -o --offline
+      )
+      _configlet_complete_options_ "${options[*]} $global_opts"
       ;;
   esac
 }

--- a/completions/configlet.fish
+++ b/completions/configlet.fish
@@ -22,8 +22,9 @@ complete -c configlet -n "__fish_seen_subcommand_from completion" -s s -l shell 
   -xa "bash fish zsh"
 
 # create subcommand
-complete -c configlet -n "__fish_seen_subcommand_from create"     -s e -l exercise  -d "exercise slug" \
-  -xa '(__fish_configlet_find_dirs ./exercises/{concept,practice})'
+complete -c configlet -n "__fish_seen_subcommand_from create"     -s e -l exercise  -d "exercise slug"
+complete -c configlet -n "__fish_seen_subcommand_from create"     -s a -l author    -d "The implementation author"
+complete -c configlet -n "__fish_seen_subcommand_from create"     -s d -l difficulty -d "The exerise difficulty (default 1)"
 complete -c configlet -n "__fish_seen_subcommand_from create"     -s o -l offline   -d "Do not update prob-specs cache"
 complete -c configlet -n "__fish_seen_subcommand_from create"          -l approach  -d "The slug of the approach"
 complete -c configlet -n "__fish_seen_subcommand_from create"          -l article   -d "The slug of the article"

--- a/completions/configlet.zsh
+++ b/completions/configlet.zsh
@@ -82,6 +82,8 @@ _configlet() {
       _arguments "${_arguments_options[@]}" \
           "$_configlet_global_opts[@]" \
           '(-e --exercise)'{-e+,--exercise=}'[exercise slug]:slug:_configlet_complete_any_exercise_slug' \
+          {-a,--author}'[The author of this implementation]' \
+          {-d,--difficulty}'[The exercise difficulty (default 1)]' \
           {-o,--offline}'[Do not update prob-specs cache]' \
           '--approach=[The slug of the approach]' \
           '--article=[The slug of the article]' \


### PR DESCRIPTION
Remove completion for exercise name in fish completion: if creating, slug won't exist to complete.