### PR TITLE
.github, nimble: bump Nim from 2.0.0 to 2.0.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@2546aaf825947f6bf76be75ff78d74176992e99d
         with:
-          version: "binary:2.0.0"
+          version: "binary:2.0.8"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -101,7 +101,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@2546aaf825947f6bf76be75ff78d74176992e99d
         with:
-          version: "binary:2.0.0"
+          version: "binary:2.0.8"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@2546aaf825947f6bf76be75ff78d74176992e99d
         with:
-          version: "binary:2.0.0"
+          version: "binary:2.0.8"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -16,7 +16,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 2.0.0"
+requires "nim >= 2.0.8"
 requires "jsony"
 requires "parsetoml"
 requires "supersnappy"

--- a/src/patched_stdlib/json.nim
+++ b/src/patched_stdlib/json.nim
@@ -645,7 +645,7 @@ proc delete*(obj: JsonNode, key: string) =
   obj.fields.del(key)
 
 proc copy*(p: JsonNode): JsonNode =
-  ## Performs a deep copy of `a`.
+  ## Performs a deep copy of `p`.
   case p.kind
   of JString:
     result = newJString(p.str)


### PR DESCRIPTION
See the release posts:

- https://nim-lang.org/blog/2023/12/19/versions-1618-202-released.html
- https://nim-lang.org/blog/2024/04/16/versions-1620-204-released.html
- https://nim-lang.org/blog/2024/06/17/version-206-released.html
- https://nim-lang.org/blog/2024/07/03/version-208-released.html

and [new commits][5].

This commit reflects the [only change to the upstream `std/json`][6]. The upstream [`std/parsejson` wasn't changed][7].

[5]: https://github.com/nim-lang/Nim/compare/v2.0.0...v2.0.8
[6]: https://github.com/nim-lang/Nim/commits/v2.0.8/lib/pure/json.nim
[7]: https://github.com/nim-lang/Nim/commits/v2.0.8/lib/pure/parsejson.nim

---

Previous Nim bump: https://github.com/exercism/configlet/pull/723