### PR TITLE
.github(install-zig): bump Zig from 0.11.0 to 0.13.0

### DIFF
--- a/.github/bin/install-zig
+++ b/.github/bin/install-zig
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-version='0.11.0' # 2023-08-04
+version='0.13.0' # 2024-06-07
 
 case "$(uname)" in
   Darwin*)   os='macos'   ;;
@@ -37,15 +37,15 @@ curl "${curlopts[@]}" --output "${archive}" "${url}"
 echo "Verifying archive..." >&2
 case "${os}" in
   linux)
-    archive_sha256='2d00e789fec4f71790a6e7bf83ff91d564943c5ee843c5fd966efc474b423047'
+    archive_sha256='d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea'
     echo "${archive_sha256} ${archive}" | sha256sum -c -
     ;;
   macos)
-    archive_sha256='1c1c6b9a906b42baae73656e24e108fd8444bb50b6e8fd03e9e7a3f8b5f05686'
+    archive_sha256='8b06ed1091b2269b700b3b07f8e3be3b833000841bae5aa6a09b1a8b4773effd'
     shasum -a 256 -c <<< "${archive_sha256} *${archive}"
     ;;
   windows)
-    archive_sha256='142caa3b804d86b4752556c9b6b039b7517a08afa3af842645c7e2dcd125f652'
+    archive_sha256='d859994725ef9402381e557c60bb57497215682e355204d754ee3df75ee3c158'
     # TODO: check windows archive checksum
     ;;
 esac


### PR DESCRIPTION
See the release notes for [0.12.0][1] and [0.13.0][2].

[1]: https://ziglang.org/download/0.12.0/release-notes.html
[2]: https://ziglang.org/download/0.13.0/release-notes.html