### PR TITLE
.github: bump macos-12 to macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,10 @@ jobs:
             runs-on: macos-13
             arch: x86-64
 
+          - os: macos
+            runs-on: macos-15
+            arch: aarch64
+
           - os: windows
             runs-on: windows-2022
             arch: x86-64
@@ -83,9 +87,6 @@ jobs:
 
           - runs-on: ubuntu-22.04
             zig_target: riscv64-linux-musl
-
-          - runs-on: macos-13
-            zig_target: aarch64-macos-none
 
           - runs-on: ubuntu-22.04
             zig_target: aarch64-windows-gnu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             arch: x86-64
 
           - os: macos
-            runs-on: macos-12
+            runs-on: macos-13
             arch: x86-64
 
           - os: windows
@@ -84,7 +84,7 @@ jobs:
           - runs-on: ubuntu-22.04
             zig_target: riscv64-linux-musl
 
-          - runs-on: macos-12
+          - runs-on: macos-13
             zig_target: aarch64-macos-none
 
           - runs-on: ubuntu-22.04

--- a/.github/workflows/fetch-configlet.yml
+++ b/.github/workflows/fetch-configlet.yml
@@ -19,7 +19,7 @@ jobs:
             runs-on: ubuntu-22.04
 
           - os: macos
-            runs-on: macos-12
+            runs-on: macos-13
 
           - os: windows
             runs-on: windows-2022

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
             arch: x86-64
 
           - os: macos
-            runs-on: macos-12
+            runs-on: macos-13
             arch: x86-64
 
           - os: windows


### PR DESCRIPTION
This is the newer x86_64 macOS image, and is not in beta. See [here](https://github.com/actions/runner-images/blob/1b535372a075188bfce11fbd27d72a254c736b3c/README.md#available-images).

It would now be possible to use `macos-14` somewhere, building a macOS arm64 configlet asset natively rather than cross-compiling via Zig. But let's try to avoid that for now.

---

To-do:

- [ ] Resolve error in the build workflow, in particular the cross-compile job for `aarch64-macos-none`

```text
CC: ../nimdir/lib/std/sysrand.nim
/Users/runner/.cache/nim/configlet_r/@m..@snimdir@slib@sstd@ssysrand.nim.c:9:10: fatal error: 'Security/SecRandom.h' file not found
nimble.nim(304)          buildFromDir
    9 | #include <Security/SecRandom.h>

      |          ^~~~~~~~~~~~~~~~~~~~~~
    Error:  Build failed for the package: configlet
1 error generated.
     Info:  Nimble data file "/Users/runner/.nimble/nimbledata2.json" has been saved.
Error: execution of an external compiler program 'zigcc -c -w -ferror-limit=3 -pthread -target aarch64-macos-none -Os   -I/Users/runner/work/exercism-configlet/exercism-configlet/nimdir/lib -I/Users/runner/work/exercism-configlet/exercism-configlet/src -o /Users/runner/.cache/nim/configlet_r/@m..@snimdir@slib@sstd@ssysrand.nim.c.o /Users/runner/.cache/nim/configlet_r/@m..@snimdir@slib@sstd@ssysrand.nim.c' failed with exit code: 1
```

I think it just needs to pass to the linker:

```text
-framework Security
```