### PR TITLE
Fix  update mac os workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           - runs-on: ubuntu-22.04
             zig_target: riscv64-linux-musl
 
-          - runs-on: macos-12
+          - runs-on: macos-14
             zig_target: aarch64-macos-none
 
           - runs-on: ubuntu-22.04

--- a/.github/workflows/fetch-configlet.yml
+++ b/.github/workflows/fetch-configlet.yml
@@ -19,7 +19,7 @@ jobs:
             runs-on: ubuntu-22.04
 
           - os: macos
-            runs-on: macos-12
+            runs-on: macos-14
 
           - os: windows
             runs-on: windows-2022


### PR DESCRIPTION
GitHub dropped macOS-12 support. Workflow needs updating to 14.

See: https://forum.exercism.org/t/github-actions-runner-breaking-changes-announced/12612