### PR TITLE
fix: more occurrences of macos12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             arch: x86-64
 
           - os: macos
-            runs-on: macos-12
+            runs-on: macos-14
             arch: x86-64
 
           - os: windows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
             arch: x86-64
 
           - os: macos
-            runs-on: macos-12
+            runs-on: macos-14
             arch: x86-64
 
           - os: windows


### PR DESCRIPTION
Missed to files. Thanks @glennj 

> @vaeng Did you miss one? The merge into main is still using v12: https://github.com/exercism/configlet/actions/runs/10903920485/job/30259101645 ![image](https://private-user-images.githubusercontent.com/122470/368182530-ba22ac37-d7c6-489d-b9b3-eae2b354a476.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjY1OTM5NjIsIm5iZiI6MTcyNjU5MzY2MiwicGF0aCI6Ii8xMjI0NzAvMzY4MTgyNTMwLWJhMjJhYzM3LWQ3YzYtNDg5ZC1iOWIzLWVhZTJiMzU0YTQ3Ni5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwOTE3JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDkxN1QxNzIxMDJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1kZjYwNTljZTVlNDJlMWMyNTIxODM2ZmYzMzljZjVkYjc4MTI0OTliZGExNmY1Mzg0MmRhOTM5Yzg2OTQ4YmU5JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.gVnRuNkZB8Z7v3PDCHJUKjll7TdC7ECQeWg-o_jGusY)

