### PR TITLE
.github, nimble: build aarch64 macOS natively; bump Nim from 2.0.8 to 2.2.24; bump `macos-12` to `macos-13`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         run: ./.github/bin/linux-install-musl
 
       - name: Install Nim
-        uses: iffy/install-nim@25e9ede26d630a40bb8ecb9ce75479e281e717bf
+        uses: iffy/install-nim@0f3350b4052f0906164f934a2e638257341fdff7
         with:
           version: "binary:2.0.8"
         env:
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
 
       - name: Install Nim
-        uses: iffy/install-nim@25e9ede26d630a40bb8ecb9ce75479e281e717bf
+        uses: iffy/install-nim@0f3350b4052f0906164f934a2e638257341fdff7
         with:
           version: "binary:2.0.8"
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@0f3350b4052f0906164f934a2e638257341fdff7
         with:
-          version: "binary:2.0.8"
+          version: "binary:2.2.4"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -101,7 +101,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@0f3350b4052f0906164f934a2e638257341fdff7
         with:
-          version: "binary:2.0.8"
+          version: "binary:2.2.4"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             arch: x86-64
 
           - os: macos
-            runs-on: macos-12
+            runs-on: macos-13
             arch: x86-64
 
           - os: macos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,10 @@ jobs:
             runs-on: macos-12
             arch: x86-64
 
+          - os: macos
+            runs-on: macos-15
+            arch: arm64
+
           - os: windows
             runs-on: windows-2022
             arch: x86-64
@@ -83,9 +87,6 @@ jobs:
 
           - runs-on: ubuntu-22.04
             zig_target: riscv64-linux-musl
-
-          - runs-on: macos-12
-            zig_target: aarch64-macos-none
 
           - runs-on: ubuntu-22.04
             zig_target: aarch64-windows-gnu

--- a/.github/workflows/fetch-configlet.yml
+++ b/.github/workflows/fetch-configlet.yml
@@ -19,7 +19,7 @@ jobs:
             runs-on: ubuntu-22.04
 
           - os: macos
-            runs-on: macos-12
+            runs-on: macos-13
 
           - os: windows
             runs-on: windows-2022

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Nim
         uses: iffy/install-nim@0f3350b4052f0906164f934a2e638257341fdff7
         with:
-          version: "binary:2.0.8"
+          version: "binary:2.2.4"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
             arch: x86-64
 
           - os: macos
-            runs-on: macos-12
+            runs-on: macos-13
             arch: x86-64
 
           - os: windows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         run: ./.github/bin/linux-install-musl
 
       - name: Install Nim
-        uses: iffy/install-nim@25e9ede26d630a40bb8ecb9ce75479e281e717bf
+        uses: iffy/install-nim@0f3350b4052f0906164f934a2e638257341fdff7
         with:
           version: "binary:2.0.8"
         env:

--- a/configlet.nimble
+++ b/configlet.nimble
@@ -16,7 +16,7 @@ srcDir        = "src"
 bin           = @["configlet"]
 
 # Dependencies
-requires "nim >= 2.0.8"
+requires "nim >= 2.2.4"
 requires "jsony"
 requires "parsetoml"
 requires "supersnappy"

--- a/src/patched_stdlib/parsejson.nim
+++ b/src/patched_stdlib/parsejson.nim
@@ -1,5 +1,5 @@
 # This file is minimally adapted from this version in the Nim standard library:
-# https://github.com/nim-lang/Nim/blob/a488067a4130/lib/pure/parsejson.nim
+# https://github.com/nim-lang/Nim/blob/f7145dd26efe/lib/pure/parsejson.nim
 # The standard library version is lenient: it silently allows line comments
 # with `//`, and long comments with `/* */`.
 # The below version is stricter: it raises a `JsonParsingError` for such
@@ -29,7 +29,7 @@
 ## and exported by the `json` standard library
 ## module, but can also be used in its own right.
 
-import strutils, lexbase, streams, unicode
+import std/[strutils, lexbase, streams, unicode]
 import std/private/decode_helpers
 
 when defined(nimPreviewSlimSystem):


### PR DESCRIPTION
The `macos-12` runner no longer exists. Update those labels to `macos-13` for the x86_64 jobs, and replace the previous cross-compilation job for aarch64 macOS with a native build on `macos-15` (which is aarch64).

That change also requires us to bump Nim (and therefore `iffy/install-nim` to support that), because Nim only began releasing binaries for aarch64 macOS relatively recently.

To-do:
 
- [x] Amend the Nim-bumping commit to update the patched `json.nim` and `parsejson.nim` accordingly. The changes are only cosmetic, but it's good to be thorough.
- [x] Then once again push a dev tag to this repo in order to test the build job. Edit: it worked with [this test release](https://github.com/exercism/configlet/releases/tag/untagged-10ec2874fc4dfc428ee8) for the tag `4.0.0-dev.ee7.3` (which used https://github.com/exercism/configlet/commit/306b3459e5d816b3ee8e6b15fc7c80651ad387ee).

---

In the root directory of the Nim compiler repo, looking at the changes to the `json` module due to the Nim update from 2.0.8 to 2.2.4:

```console
$ git diff v2.0.8 v2.2.4 -U1 -- lib/pure/json.nim
```

```diff
@@ -43,3 +43,3 @@
 ##
-## .. code-block:: Nim
+##   ```Nim
 ##   import std/json
@@ -50,2 +50,3 @@
 ##   doAssert jsonNode["key"].kind == JFloat
+##   ```
 ##
@@ -64,3 +65,3 @@
 ##
-## .. code-block:: Nim
+##   ```Nim
 ##   import std/json
@@ -70,2 +71,3 @@
 ##   doAssert jsonNode["key"].getFloat() == 3.14
+##   ```
 ##
@@ -81,3 +83,3 @@
 ##
-## .. code-block:: Nim
+##   ```Nim
 ##   import std/json
@@ -90,2 +92,3 @@
 ##   doAssert jsonNode{"nope"}.getBool() == false
+##   ```
 ##
@@ -97,3 +100,3 @@
 ##
-## .. code-block:: Nim
+##   ```Nim
 ##   import std/json
@@ -105,2 +108,3 @@
 ##   doAssert jsonNode{"nope"}.getFloat(3.14) == 3.14 # note the {}
+##   ```
 ##
@@ -115,3 +119,3 @@
 ##
-## .. code-block:: Nim
+##   ```Nim
 ##   import std/json
@@ -129,2 +133,3 @@
 ##     assert user.`type`.get() != "robot"
+##   ```
 ##
@@ -136,3 +141,3 @@
 ##
-## .. code-block:: nim
+##   ```nim
 ##   import std/json
@@ -150,2 +155,3 @@
 ##   echo j2
+##   ```
 ##
@@ -161,5 +167,5 @@ runnableExamples:
 
-import hashes, tables, strutils, lexbase, streams, macros, parsejson
+import std/[hashes, tables, strutils, lexbase, streams, macros, parsejson]
 
-import options # xxx remove this dependency using same approach as https://github.com/nim-lang/Nim/pull/14563
+import std/options # xxx remove this dependency using same approach as https://github.com/nim-lang/Nim/pull/14563
 import std/private/since
@@ -497,2 +503,3 @@ proc hash*(n: JsonNode): Hash {.noSideEffect.} =
 proc hash*(n: OrderedTable[string, JsonNode]): Hash =
+  result = default(Hash)
   for key, val in n:
@@ -508,3 +515,3 @@ proc len*(n: JsonNode): int =
   of JObject: result = n.fields.len
-  else: discard
+  else: result = 0
 
@@ -545,3 +552,3 @@ proc `[]`*[U, V](a: JsonNode, x: HSlice[U, V]): JsonNode =
   runnableExamples:
-    import json
+    import std/json
     let arr = %[0,1,2,3,4,5]
@@ -606,2 +613,4 @@ proc getOrDefault*(node: JsonNode, key: string): JsonNode =
     result = node.fields.getOrDefault(key)
+  else:
+    result = nil
 
@@ -933,3 +942,3 @@ iterator parseJsonFragments*(s: Stream, filename: string = ""; rawIntegers = fal
   ## field but kept as raw numbers via `JString`.
-  var p: JsonParser
+  var p: JsonParser = default(JsonParser)
   p.open(s, filename)
@@ -951,3 +960,3 @@ proc parseJson*(s: Stream, filename: string = ""; rawIntegers = false, rawFloats
   ## field but kept as raw numbers via `JString`.
-  var p: JsonParser
+  var p: JsonParser = default(JsonParser)
   p.open(s, filename)
@@ -961,3 +970,3 @@ proc parseJson*(s: Stream, filename: string = ""; rawIntegers = false, rawFloats
 when defined(js):
-  from math import `mod`
+  from std/math import `mod`
   from std/jsffi import JsObject, `[]`, to
@@ -987,5 +996,5 @@ when defined(js):
   proc len(x: JsObject): int =
-    asm """
+    {.emit: """
       `result` = `x`.length;
-    """
+    """.}
 
@@ -1000,10 +1009,11 @@ when defined(js):
       result = newJObject()
-      asm """for (var property in `x`) {
+      {.emit: """for (var property in `x`) {
         if (`x`.hasOwnProperty(property)) {
-      """
+      """.}
+
       var nimProperty: cstring
       var nimValue: JsObject
-      asm "`nimProperty` = property; `nimValue` = `x`[property];"
+      {.emit: "`nimProperty` = property; `nimValue` = `x`[property];".}
       result[$nimProperty] = nimValue.convertObject()
-      asm "}}"
+      {.emit: "}}".}
     of JInt:
@@ -1362,3 +1372,3 @@ proc to*[T](node: JsonNode, t: typedesc[T]): T =
 when false:
-  import os
+  import std/os
   var s = newFileStream(paramStr(1), fmRead)
```

And changes to the `parsejson` module:

```console
$ git diff v2.0.8 v2.2.4 -U1 -- lib/pure/parsejson.nim
```

```diff
@@ -13,3 +13,3 @@
 
-import strutils, lexbase, streams, unicode
+import std/[strutils, lexbase, streams, unicode]
 import std/private/decode_helpers
```

---

And double-checking that the diff from the upstream version to our patched version in this PR is still as expected, running in the root directory of the Nim compiler repo:

```console
$ git checkout v2.2.4
$ git diff -U0 lib/pure/json.nim /path/to/exercism/configlet/src/patched_stdlib/json.nim
```

outputs:

```diff
@@ -1,8 +1,25 @@
-#
-#
-#            Nim's Runtime Library
-#        (c) Copyright 2015 Andreas Rumpf, Dominik Picheta
-#
-#    See the file "copying.txt", included in this
-#    distribution, for details about the copyright.
-#
+# This file is minimally adapted from this version in the Nim standard library:
+# https://github.com/nim-lang/Nim/blob/f7145dd26efe/lib/pure/json.nim
+# The standard library version is lenient: it silently allows a trailing comma.
+# The below version is stricter: it raises a `JsonParsingError` for a trailing
+# comma.
+
+# Copyright (c) 2015 Andreas Rumpf, Dominik Picheta
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
@@ -917,0 +935,3 @@ proc parseJson(p: var JsonParser; rawIntegers, rawFloats: bool, depth = 0): Json
+      # Raise `JsonParsingError` for a trailing comma, unlike `std/json`
+      if p.tok == tkCurlyRi:
+        raiseParseErr(p, "found trailing comma. } or key/value pair")
@@ -927,0 +948,3 @@ proc parseJson(p: var JsonParser; rawIntegers, rawFloats: bool, depth = 0): Json
+      # Raise `JsonParsingError` for a trailing comma, unlike `std/json`
+      if p.tok == tkBracketRi:
+        raiseParseErr(p, "found trailing comma. ] or array item")
```

and

```console
$ git diff -U0 lib/pure/parsejson.nim /path/to/exercism/configlet/src/patched_stdlib/parsejson.nim
```

outputs:

```diff
@@ -1,8 +1,26 @@
-#
-#
-#            Nim's Runtime Library
-#        (c) Copyright 2018 Nim contributors
-#
-#    See the file "copying.txt", included in this
-#    distribution, for details about the copyright.
-#
+# This file is minimally adapted from this version in the Nim standard library:
+# https://github.com/nim-lang/Nim/blob/f7145dd26efe/lib/pure/parsejson.nim
+# The standard library version is lenient: it silently allows line comments
+# with `//`, and long comments with `/* */`.
+# The below version is stricter: it raises a `JsonParsingError` for such
+# comments.
+
+# Copyright (c) 2018 Nim contributors
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
@@ -60 +77,0 @@ type
-    errEOC_Expected,      ## `*/` expected
@@ -91 +107,0 @@ const
-    "'*/' expected",
@@ -269,37 +285,2 @@ proc skip(my: var JsonParser) =
-    of '/':
-      if my.buf[pos+1] == '/':
-        # skip line comment:
-        inc(pos, 2)
-        while true:
-          case my.buf[pos]
-          of '\0':
-            break
-          of '\c':
-            pos = lexbase.handleCR(my, pos)
-            break
-          of '\L':
-            pos = lexbase.handleLF(my, pos)
-            break
-          else:
-            inc(pos)
-      elif my.buf[pos+1] == '*':
-        # skip long comment:
-        inc(pos, 2)
-        while true:
-          case my.buf[pos]
-          of '\0':
-            my.err = errEOC_Expected
-            break
-          of '\c':
-            pos = lexbase.handleCR(my, pos)
-          of '\L':
-            pos = lexbase.handleLF(my, pos)
-          of '*':
-            inc(pos)
-            if my.buf[pos] == '/':
-              inc(pos)
-              break
-          else:
-            inc(pos)
-      else:
-        break
+    # Raise `JsonParsingError` for comments with `//` or `/* */`,
+    # unlike `std/parsejson`
@@ -356 +337 @@ proc getTok*(my: var JsonParser): TokKind =
-  skip(my) # skip whitespace, comments
+  skip(my) # skip whitespace
```

Closes: https://github.com/exercism/configlet/issues/800