### PR TITLE
.github: bump Ubuntu from 22.04 to 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   create-empty-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -30,7 +30,7 @@ jobs:
       matrix:
         include:
           - os: linux
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
             arch: x86-64
 
           - os: macos
@@ -82,13 +82,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-22.04
+          - runs-on: ubuntu-24.04
             zig_target: aarch64-linux-musl
 
-          - runs-on: ubuntu-22.04
+          - runs-on: ubuntu-24.04
             zig_target: riscv64-linux-musl
 
-          - runs-on: ubuntu-22.04
+          - runs-on: ubuntu-24.04
             zig_target: aarch64-windows-gnu
 
     name: "${{ matrix.zig_target }}"
@@ -119,7 +119,7 @@ jobs:
 
   checksums:
     needs: [build, cross-compile]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Upload signatures and checksums
     permissions:
       contents: write

--- a/.github/workflows/fetch-configlet.yml
+++ b/.github/workflows/fetch-configlet.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - os: linux
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
 
           - os: macos
             runs-on: macos-13

--- a/.github/workflows/lint-whitespace.yml
+++ b/.github/workflows/lint-whitespace.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   lint_whitespace:
     name: Lint whitespace
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   markdownlint:
     name: Lint markdown files
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   shellcheck:
     name: Run shellcheck on scripts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - os: linux
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
             arch: x86-64
 
           - os: macos


### PR DESCRIPTION
I believe this will bump the versions of GCC and musl used to compile the Linux x86_64 configlet release.

Closes: https://github.com/exercism/configlet/issues/657
Closes: https://github.com/exercism/configlet/issues/658

---

To-do:

- [x] First merge https://github.com/exercism/configlet/pull/908