### PR TITLE
.github: set dependabot's commit message prefix to .github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    commit-message:
+      prefix: '.github'


### PR DESCRIPTION
Change the dependabot commit prefix to the prefix that's more commonly used in this repo for updating versions of actions.

The default prefix is `build(deps)`, which can be misunderstood as a change that, for example:

- Only affects the `.github/workflows/build.yml` workflow, or its dependencies.
- Only affects the `.github/bin/build` script, or its dependencies.
- Only affects the build process for the binary, e.g. what happens when `nimble build` is run.

---

We've preferred the `.github` prefix for version bumps:

```console
$ git rev-parse --short HEAD
2828f19
$ git log --format='%s' --grep '^\.github.*bump' | wc -l
36
$ git log --format='%s' --grep '^build(deps).*bump' | wc -l
6
```