### PR TITLE
config: remove now-default nimStrictDelete

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -5,7 +5,6 @@ warning("ProveInit", off)
 warning("Uninit", off)
 switch("experimental", "strictDefs")
 switch("experimental", "strictFuncs")
-switch("define", "nimStrictDelete")
 switch("mm", "refc")
 
 # Replace the stdlib JSON modules with our own stricter versions.


### PR DESCRIPTION
The nimStrictDelete behavior is the default since Nim 2.2.0, and with commit https://github.com/exercism/configlet/commit/3e4d5c1a196822b47bdc0fb3cfe50d86a8040a12 we've recently updated to Nim 2.2.4.

The configlet codebase doesn't use `system.delete`, but Nim advertised that its stricter behavior would become the default, so in becfece03e1dca741f09396d31cadc1d2315a2a9 I added `nimStrictDelete` to the config as a precaution.

The [release notes for Nim 2.2.0][2] say:

>    ## Changes affecting backward compatibility
>
>    - `-d:nimStrictDelete` becomes the default. An index error is produced when the index passed to `system.delete` is out of bounds. Use `-d:nimAuditDelete` to mimic the old behavior for backward compatibility.

[2]: https://github.com/nim-lang/Nim/blob/9b527a51b854/changelogs/changelog_2_2_0.md