### PR TITLE
.github: attest build provenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,9 @@ jobs:
     runs-on: ubuntu-24.04
     name: Upload signatures and checksums
     permissions:
+      attestations: write
       contents: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -140,3 +142,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIGLET_MINISIGN_SECRET_KEY: ${{ secrets.CONFIGLET_MINISIGN_SECRET_KEY }}
+
+      - name: Generate signed build provenance attestations
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
+        with:
+          subject-checksums: 'releases/*/configlet_*_checksums_sha256.txt'
+
+      - name: Verify artifact attestation
+        run: gh attestation verify releases/*/*linux_x86-64.tar.gz -R exercism/configlet


### PR DESCRIPTION
See:

- https://github.blog/news-insights/product-news/introducing-artifact-attestations-now-in-public-beta/
- https://github.blog/changelog/2024-06-25-artifact-attestations-is-generally-available/
- https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations
- https://github.com/actions/attest-build-provenance
- https://cli.github.com/manual/gh_attestation_verify
- https://github.com/exercism/configlet/attestations
- [github/roadmap/issues#1138](https://www.github.com/github/roadmap/issues/1138)