### PR TITLE
fix: make compatible with v5 and v7

### DIFF
--- a/scripts/fetch-configlet.ps1
+++ b/scripts/fetch-configlet.ps1
@@ -6,16 +6,32 @@
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
-$requestOpts = @{
-    Headers           = If ($env:GITHUB_TOKEN) { @{ Authorization = "Bearer ${env:GITHUB_TOKEN}" } } Else { @{ } }
-    MaximumRetryCount = 3
-    RetryIntervalSec  = 1
+$headers = If ($env:GITHUB_TOKEN) { @{ Authorization = "Bearer ${env:GITHUB_TOKEN}" } } Else { @{ } }
+
+$irmOpts = @{ Headers = $headers }
+$iwrOpts = @{ Headers = $headers }
+
+if ((Get-Command Invoke-RestMethod).Parameters.ContainsKey("MaximumRetryCount")) {
+    $irmOpts.MaximumRetryCount = 3
+}
+if ((Get-Command Invoke-RestMethod).Parameters.ContainsKey("RetryIntervalSec")) {
+    $irmOpts.RetryIntervalSec = 1
+}
+if ((Get-Command Invoke-RestMethod).Parameters.ContainsKey("PreserveAuthorizationOnRedirect")) {
+    $irmOpts.PreserveAuthorizationOnRedirect = $true
+}
+
+if ((Get-Command Invoke-WebRequest).Parameters.ContainsKey("MaximumRetryCount")) {
+    $iwrOpts.MaximumRetryCount = 3
+}
+if ((Get-Command Invoke-WebRequest).Parameters.ContainsKey("RetryIntervalSec")) {
+    $iwrOpts.RetryIntervalSec = 1
 }
 
 Function Get-DownloadUrl {
     $arch = If ([Environment]::Is64BitOperatingSystem) { "x86-64" } Else { "i386" }
     $latestUrl = "https://api.github.com/repos/exercism/configlet/releases/latest"
-    Invoke-RestMethod -Uri $latestUrl -PreserveAuthorizationOnRedirect @requestOpts `
+    Invoke-RestMethod -Uri $latestUrl @irmOpts `
     | Select-Object -ExpandProperty assets `
     | Where-Object { $_.name -match "^configlet_.+_windows_${arch}.zip$" } `
     | Select-Object -ExpandProperty browser_download_url -First 1
@@ -31,11 +47,16 @@ Write-Output "Fetching configlet..."
 $downloadUrl = Get-DownloadUrl
 $outputFileName = "configlet.zip"
 $outputPath = Join-Path -Path $outputDirectory -ChildPath $outputFileName
-Invoke-WebRequest -Uri $downloadUrl -OutFile $outputPath @requestOpts
+Invoke-WebRequest -Uri $downloadUrl -OutFile $outputPath @iwrOpts
 
 $configletPath = Join-Path -Path $outputDirectory -ChildPath "configlet.exe"
 if (Test-Path -Path $configletPath) { Remove-Item -Path $configletPath }
-[System.IO.Compression.ZipFile]::ExtractToDirectory($outputPath, $outputDirectory)
+if (Get-Command Expand-Archive -ErrorAction SilentlyContinue) {
+    Expand-Archive -Path $outputPath -DestinationPath $outputDirectory -Force
+} else {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($outputPath, $outputDirectory)
+}
 Remove-Item -Path $outputPath
 
 $configletVersion = (Select-String -Pattern "/releases/download/(.+?)/" -InputObject $downloadUrl -AllMatches).Matches.Groups[1].Value


### PR DESCRIPTION
I had problems using the existing script with windows 11 and powershell 5. I updated my ps version to 7.6 and still had errors.

As I don't know powershell, I used AI to finda  solution and this seems to work. I am worried about backwards comatibility and general AI use for things I don't understand.


Probably best to let knowledgeable people judge this.