### PR TITLE
Preserve newly added editor and invalidator keys when using `configlet create`

### DIFF
--- a/src/fmt/exercises.nim
+++ b/src/fmt/exercises.nim
@@ -6,9 +6,9 @@ func filesKeyOrder(val: ConceptExerciseFiles | PracticeExerciseFiles;
   let fkEx = when val is ConceptExerciseFiles: fkExemplar else: fkExample
   if prettyMode == pmFmt or val.originalKeyOrder.len == 0:
     result = @[fkSolution, fkTest, fkEx]
-    if prettyMode == pmFmt and val.editor.len > 0:
+    if val.editor.len > 0:
       result.add fkEditor
-    if prettyMode == pmFmt and val.invalidator.len > 0:
+    if val.invalidator.len > 0:
       result.add fkInvalidator
   else:
     result = val.originalKeyOrder

--- a/src/fmt/exercises.nim
+++ b/src/fmt/exercises.nim
@@ -6,9 +6,9 @@ func filesKeyOrder(val: ConceptExerciseFiles | PracticeExerciseFiles;
   let fkEx = when val is ConceptExerciseFiles: fkExemplar else: fkExample
   if prettyMode == pmFmt or val.originalKeyOrder.len == 0:
     result = @[fkSolution, fkTest, fkEx]
-    if val.editor.len > 0:
+    if prettyMode == pmFmt and val.editor.len > 0:
       result.add fkEditor
-    if val.invalidator.len > 0:
+    if prettyMode == pmFmt and val.invalidator.len > 0:
       result.add fkInvalidator
   else:
     result = val.originalKeyOrder

--- a/tests/test_binary_create.nim
+++ b/tests/test_binary_create.nim
@@ -1,4 +1,4 @@
-import std/[os, osproc, re, strformat, strutils, unittest]
+import std/[json, os, osproc, re, strformat, strutils, unittest]
 import exec
 import "."/[binary_helpers]
 
@@ -204,6 +204,61 @@ proc main =
         A  exercises/practice/foo/test/foo_test.exs
       """.unindent()
       testStatusThenReset(trackDir, expectedStatus)
+
+    suite "create practice exercise with editor and invalidator files":
+      setup:
+        let trackConfigPath = trackDir / "config.json"
+        var trackConfig = json.parseFile(trackConfigPath)
+        let files = trackConfig["files"]
+        files["editor"] = %* ["lib/%{snake_slug}_editor.ex"]
+        files["invalidator"] = %* ["lib/%{snake_slug}_invalidator.ex"]
+        writeFile(trackConfigPath, trackConfig.pretty() & "\n")
+
+      test "creates metadata file entries, and exits with 0":
+        const expectedOutput = fmt"""
+          Updating cached 'problem-specifications' data...
+          Created practice exercise 'foo'.
+        """.unindent()
+        execAndCheck(0, &"{createBase} --practice-exercise=foo", expectedOutput)
+
+        const expectedConfig = """
+        {
+          "authors": [],
+          "files": {
+            "solution": [
+              "lib/foo.ex"
+            ],
+            "test": [
+              "test/foo_test.exs"
+            ],
+            "example": [
+              ".meta/example.ex"
+            ],
+            "editor": [
+              "lib/foo_editor.ex"
+            ],
+            "invalidator": [
+              "lib/foo_invalidator.ex"
+            ]
+          },
+          "blurb": ""
+        }
+        """.dedent(8).replace("\p", "\n")
+        let configPath = trackDir / "exercises" / "practice" / "foo" / ".meta" / "config.json"
+        let config = readFile(configPath)
+        check config == expectedConfig
+
+        const expectedStatus = """
+          M  config.json
+          A  exercises/practice/foo/.docs/instructions.md
+          A  exercises/practice/foo/.meta/config.json
+          A  exercises/practice/foo/.meta/example.ex
+          A  exercises/practice/foo/lib/foo.ex
+          A  exercises/practice/foo/lib/foo_editor.ex
+          A  exercises/practice/foo/lib/foo_invalidator.ex
+          A  exercises/practice/foo/test/foo_test.exs
+        """.unindent()
+        testStatusThenReset(trackDir, expectedStatus)
 
 main()
 {.used.}


### PR DESCRIPTION
Related to https://forum.exercism.org/t/configlet-create-doesnt-add-invalidator-or-editor-to-exercise-config-json/.

Currently, `configlet create --practice-exercise <slug>` does not populate the editor and invalidator file paths in the exercise's config.json when the patterns are set in a track's root-level config file. That invariably requires a follow-up `configlet sync --filepaths -uye <slug>` to add the missing entries.