### PR TITLE
fix: `macos-13` to `macos-15-intel`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             arch: x86-64
 
           - os: macos
-            runs-on: macos-13
+            runs-on: macos-15-intel
             arch: x86-64
 
           - os: macos

--- a/.github/workflows/fetch-configlet.yml
+++ b/.github/workflows/fetch-configlet.yml
@@ -19,7 +19,7 @@ jobs:
             runs-on: ubuntu-24.04
 
           - os: macos
-            runs-on: macos-13
+            runs-on: macos-15-intel
 
           - os: windows
             runs-on: windows-2022

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
             arch: x86-64
 
           - os: macos
-            runs-on: macos-13
+            runs-on: macos-15-intel
             arch: x86-64
 
           - os: windows

--- a/tests/test_binary_fmt.nim
+++ b/tests/test_binary_fmt.nim
@@ -211,8 +211,7 @@ proc main =
 
   suite "fmt, with --update, without --yes, for an exercise that is not formatted (no diff, and exits with 1)":
     test "-e bob":
-      let exitCode = execCmdEx(&"{fmtUpdateUnformatted} -e bob")[1]
-      check exitCode == 1
+      execAndCheckExitCode(1, &"{fmtUpdateUnformatted} -e bob", inputStr = "n")
       checkNoDiff(unformattedTrackDir)
 
   suite "fmt, with --update, for an exercise that is not formatted (diff, and exits with 0)":


### PR DESCRIPTION
`macos-13` was retired last December so the related GHAs were timing out. This bumps the places we use x84-64 macOS runners.