### PR TITLE
specification for practice exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Therefore configlet has a `sync` command, which can check that such Practice Exe
 There are three kinds of data that configlet can update from `problem-specifications`: documentation, metadata, and tests.
 There is also one kind of data that configlet can populate from the track-level `config.json` file: filepaths in exercise config files.
 
+By default, configlet looks up the upstream exercise in `problem-specifications` using the Practice Exercise's `slug`.
+If a track needs to use a different `slug` from the upstream exercise name (for example, to avoid a name collision in the track's language), it can set the optional `specification` key on that Practice Exercise in the track-level `config.json` file.
+The `specification` value, like a `slug`, must be a kebab-case string.
+
 Later sections describe the checking and updating of these data kinds, but as a quick summary:
 
 - `configlet sync` only operates on exercises that exist in the track-level `config.json` file.

--- a/src/fmt/track_config.nim
+++ b/src/fmt/track_config.nim
@@ -189,6 +189,8 @@ func addPracticeExercise(result: var string; val: PracticeExercise;
   result.add "{"
   result.addString("slug", $val.slug, indentLevel + 1)
   result.addString("name", val.name, indentLevel + 1)
+  if val.specification.isSome():
+    result.addString("specification", $val.specification.get, indentLevel + 1)
   result.addString("uuid", val.uuid, indentLevel + 1)
   result.addArray("practices", toSeq(val.practices), indentLevel + 1)
   result.addArray("prerequisites", toSeq(val.prerequisites), indentLevel + 1)

--- a/src/lint/track_config.nim
+++ b/src/lint/track_config.nim
@@ -93,6 +93,8 @@ proc isValidPracticeExercise(data: JsonNode; context: string;
     let checks = [
       hasString(data, "slug", path, context, maxLen = 255, checkIsKebab = true),
       hasString(data, "name", path, context, maxLen = 255),
+      hasString(data, "specification", path, context, isRequired = false,
+                maxLen = 255, checkIsKebab = true),
       hasString(data, "uuid", path, context, checkIsUuid = true),
       hasInteger(data, "difficulty", path, context, allowed = 1..10),
       hasArrayOfStrings(data, "practices", path, context,

--- a/src/sync/exercises.nim
+++ b/src/sync/exercises.nim
@@ -82,11 +82,14 @@ proc init(T: typedesc[ExerciseTestCases], testCases: ProbSpecsTestCases): T =
         let uuidOfReimplementation = reimplementations[uuid]
         testCase.reimplements = some(testCasesByUuids[uuidOfReimplementation])
 
-iterator findExercises*(conf: Conf, probSpecsDir: ProbSpecsDir): Exercise {.inline.} =
+iterator findExercises*(conf: Conf, probSpecsDir: ProbSpecsDir;
+                        specBySlug: Table[string, string]): Exercise {.inline.} =
   for practiceExercise in findPracticeExercises(conf):
     # Parse `canonical-data.json` only when necessary
     if skTests in conf.action.scope:
-      let testCases = getCanonicalTests(probSpecsDir, practiceExercise.slug.string)
+      let slug = practiceExercise.slug.string
+      let specSlug = specBySlug.getOrDefault(slug, slug)
+      let testCases = getCanonicalTests(probSpecsDir, specSlug)
       yield Exercise(
         slug: practiceExercise.slug,
         tests: ExerciseTests.init(practiceExercise.tests, testCases),

--- a/src/sync/sync.nim
+++ b/src/sync/sync.nim
@@ -88,6 +88,9 @@ proc syncImpl*(conf: Conf): set[SyncKind] =
   let trackConfigPath = conf.trackDir / "config.json"
   let trackConfig = parseFile(trackConfigPath, TrackConfig)
   let trackExerciseSlugs = getSlugs(trackConfig.exercises, conf, trackConfigPath)
+  # Maps a track slug to its `specification` override (for Practice Exercises
+  # whose problem-specifications name differs from their track slug).
+  let specBySlug = specBySlug(trackConfig.exercises.practice)
   logDetailed(&"Found {trackExerciseSlugs.`concept`.len} Concept Exercises " &
               &"and {trackExerciseSlugs.practice.len} Practice Exercises in " &
                trackConfigPath)
@@ -110,12 +113,12 @@ proc syncImpl*(conf: Conf): set[SyncKind] =
     # Check/update docs
     of skDocs:
       checkOrUpdateDocs(result, conf, trackExerciseSlugs.practice,
-                        trackPracticeExercisesDir, psExercisesDir)
+                        trackPracticeExercisesDir, psExercisesDir, specBySlug)
 
     # Check/update metadata
     of skMetadata:
       checkOrUpdateMetadata(result, conf, trackExerciseSlugs.practice,
-                            trackPracticeExercisesDir, psExercisesDir)
+                            trackPracticeExercisesDir, psExercisesDir, specBySlug)
 
     # Check/update filepaths
     of skFilepaths:
@@ -126,7 +129,7 @@ proc syncImpl*(conf: Conf): set[SyncKind] =
 
     # Check/update tests
     of skTests:
-      let exercises = toSeq findExercises(conf, probSpecsDir)
+      let exercises = toSeq findExercises(conf, probSpecsDir, specBySlug)
       if conf.action.update:
         updateTests(result, conf, exercises)
       else:

--- a/src/sync/sync_common.nim
+++ b/src/sync/sync_common.nim
@@ -1,4 +1,5 @@
-import std/[algorithm, enumutils, json, os, sets, strformat, strutils]
+import std/[algorithm, enumutils, json, options, os, sets, strformat, strutils,
+            tables]
 import ".."/[cli, lint/validators, types_exercise_config, types_track_config]
 
 proc userSaysYes*(syncKind: SyncKind): bool =
@@ -32,6 +33,16 @@ func getSlugs*(e: seq[ConceptExercise] | seq[PracticeExercise],
     if withDeprecated or item.status != sDeprecated:
       result.add item.slug
   sort result
+
+func specBySlug*(practiceExercises: seq[PracticeExercise]): Table[string, string] =
+  ## Maps a track exercise `slug` to its `specification` value, for the (rare)
+  ## Practice Exercises whose problem-specifications exercise name differs from
+  ## their track slug. Exercises without a `specification` are omitted; callers
+  ## should fall back to the slug via `getOrDefault`.
+  result = initTable[string, string]()
+  for e in practiceExercises:
+    if e.specification.isSome():
+      result[$e.slug] = $e.specification.get
 
 func truncateAndAdd*(s: var string, truncateLen: int, slug: Slug) =
   ## Truncates `s` to `truncateLen`, then appends `slug`.

--- a/src/sync/sync_docs.nim
+++ b/src/sync/sync_docs.nim
@@ -1,4 +1,4 @@
-import std/[os, strformat, strutils]
+import std/[os, strformat, strutils, tables]
 import ".."/[cli, logger, types_track_config]
 import "."/sync_common
 
@@ -131,7 +131,8 @@ proc checkOrUpdateDocs*(seenUnsynced: var set[SyncKind];
                         conf: Conf;
                         practiceExerciseSlugs: seq[Slug];
                         trackPracticeExercisesDir: string;
-                        psExercisesDir: string) =
+                        psExercisesDir: string;
+                        specBySlug: Table[string, string]) =
   ## Prints a message for each Practice Exercise on the track with an outdated
   ## `.docs/introduction.md` or `.docs/instructions.md` file, and updates them
   ## if `--update` was passed and the user confirms.
@@ -147,7 +148,8 @@ proc checkOrUpdateDocs*(seenUnsynced: var set[SyncKind];
   let trackDestStartLen = trackDestPath.len
 
   for slug in practiceExerciseSlugs:
-    psSourcePath.truncateAndAdd(psStartLen, slug)
+    let specSlug = Slug(specBySlug.getOrDefault($slug, $slug))
+    psSourcePath.truncateAndAdd(psStartLen, specSlug)
     if dirExists(psSourcePath): # e.g. /foo/problem-specifications/exercises/bob
       trackDestPath.truncateAndAdd(trackDestStartLen, slug)
       trackDestPath.addDocsDir()

--- a/src/sync/sync_metadata.nim
+++ b/src/sync/sync_metadata.nim
@@ -1,4 +1,4 @@
-import std/[options, os, strformat, strutils]
+import std/[options, os, strformat, strutils, tables]
 import pkg/parsetoml
 import ".."/[cli, fmt/exercises, helpers, logger, types_exercise_config, types_track_config]
 import "."/sync_common
@@ -112,7 +112,8 @@ proc checkOrUpdateMetadata*(seenUnsynced: var set[SyncKind];
                             conf: Conf;
                             practiceExerciseSlugs: seq[Slug];
                             trackPracticeExercisesDir: string;
-                            psExercisesDir: string) =
+                            psExercisesDir: string;
+                            specBySlug: Table[string, string]) =
   ## Prints a message for each Practice Exercise on the track with an outdated
   ## `.meta/config.json` file, and updates them if `--update` was passed and the
   ## user confirms.
@@ -131,7 +132,8 @@ proc checkOrUpdateMetadata*(seenUnsynced: var set[SyncKind];
   let startLenTrackPath = trackExerciseConfigPath.len
 
   for slug in practiceExerciseSlugs:
-    psMetadataTomlPath.truncateAndAdd(startLenPsPath, slug)
+    let specSlug = Slug(specBySlug.getOrDefault($slug, $slug))
+    psMetadataTomlPath.truncateAndAdd(startLenPsPath, specSlug)
     if dirExists(psMetadataTomlPath):
       psMetadataTomlPath.addMetadataTomlPath()
       trackExerciseConfigPath.truncateAndAdd(startLenTrackPath, slug)

--- a/src/types_track_config.nim
+++ b/src/types_track_config.nim
@@ -49,6 +49,8 @@ type
   PracticeExercise* = object
     slug*: Slug
     name*: string
+    specification*: Option[Slug] ## If set, sync uses this slug to find the
+      ## exercise in `problem-specifications`, instead of `slug`.
     uuid*: string
     practices*: OrderedSet[string]
     prerequisites*: OrderedSet[string]

--- a/tests/test_fmt.nim
+++ b/tests/test_fmt.nim
@@ -1,8 +1,52 @@
 import std/[importutils, json, os, options, random, strutils, unittest]
 import exec, fmt/exercises, helpers, sync/sync_common, types_exercise_config
+import fmt/track_config, types_track_config
 
 const
   testsDir = currentSourcePath().parentDir()
+
+proc testFmtTrackConfig =
+  suite "fmt: track config `specification` key":
+    const contents = """
+      {
+        "exercises": {
+          "practice": [
+            {
+              "slug": "binary-chop",
+              "name": "Binary Search",
+              "specification": "binary-search",
+              "uuid": "11111111-1111-4111-8111-111111111111",
+              "practices": [],
+              "prerequisites": [],
+              "difficulty": 3
+            },
+            {
+              "slug": "leap",
+              "name": "Leap",
+              "uuid": "22222222-2222-4222-8222-222222222222",
+              "practices": [],
+              "prerequisites": [],
+              "difficulty": 1
+            }
+          ]
+        }
+      }
+    """.dedent(6)
+
+    let trackConfig = TrackConfig.init(contents)
+    let formatted = prettyTrackConfig(trackConfig)
+
+    test "round-trips the `specification` key, after `name` and before `uuid`":
+      check:
+        "\"specification\": \"binary-search\"" in formatted
+        formatted.find("\"name\": \"Binary Search\"") <
+          formatted.find("\"specification\": \"binary-search\"")
+        formatted.find("\"specification\": \"binary-search\"") <
+          formatted.find("\"uuid\": \"11111111-1111-4111-8111-111111111111\"")
+
+    test "omits the `specification` key for an exercise that lacks it":
+      # Only the `binary-chop` exercise has a `specification`.
+      check formatted.count("\"specification\"") == 1
 
 proc testFmt =
   const trackDir = testsDir / ".test_elixir_track_repo"
@@ -374,6 +418,7 @@ proc testFmt =
 
 proc main =
   testFmt()
+  testFmtTrackConfig()
 
 main()
 {.used.}

--- a/tests/test_lint.nim
+++ b/tests/test_lint.nim
@@ -1,6 +1,8 @@
-import std/[strutils, unittest]
+import std/[json, strutils, unittest]
+import helpers
 import lint/validators
 import lint/approaches_and_articles {.all.}
+from lint/track_config {.all.} import isValidPracticeExercise
 
 proc testIsKebabCase =
   suite "isKebabCase":
@@ -345,12 +347,50 @@ proc testCountLinesWithoutCodeFence =
         countLinesWithoutCodeFence(s, dkArticles) == 7
         countLinesWithoutCodeFence(s, dkApproaches) == 9
 
+proc testSpecificationKey =
+  suite "the optional `specification` key in a Practice Exercise":
+    const path = Path("config.json")
+    # `hasString(checkIsUuid = true)` records UUIDs to detect duplicates across
+    # the track, so each exercise here needs its own UUID.
+    proc practiceExercise(uuid, specification: string): JsonNode =
+      result = %*{
+        "slug": "binary-chop",
+        "name": "Binary Search",
+        "uuid": uuid,
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      }
+      if specification.len > 0:
+        result["specification"] = newJString(specification)
+
+    test "is accepted when it is a valid kebab-case slug":
+      check isValidPracticeExercise(
+        practiceExercise("11111111-1111-4111-8111-111111111111", "binary-search"),
+        "practice", path)
+
+    test "is accepted when omitted (it is optional)":
+      check isValidPracticeExercise(
+        practiceExercise("22222222-2222-4222-8222-222222222222", ""),
+        "practice", path)
+
+    test "is rejected when it is not kebab-case":
+      check not isValidPracticeExercise(
+        practiceExercise("33333333-3333-4333-8333-333333333333", "Binary_Search"),
+        "practice", path)
+
+    test "is rejected when it is the wrong type":
+      let data = practiceExercise("44444444-4444-4444-8444-444444444444", "")
+      data["specification"] = newJInt(42)
+      check not isValidPracticeExercise(data, "practice", path)
+
 proc main =
   testIsKebabCase()
   testIsUuidV4()
   testExtractPlaceholders()
   testIsFilesPattern()
   testCountLinesWithoutCodeFence()
+  testSpecificationKey()
 
 main()
 {.used.}

--- a/tests/test_sync.nim
+++ b/tests/test_sync.nim
@@ -1,4 +1,4 @@
-import std/[importutils, json, os, options, strutils, unittest]
+import std/[importutils, json, os, options, strutils, tables, unittest]
 import exec, fmt/exercises, helpers, sync/sync_common,
     types_exercise_config, types_track_config
 from sync/sync_filepaths {.all.} import update
@@ -612,10 +612,29 @@ proc testSyncMetadata =
         p == expected
         metadataAreUpToDate(p, metadata)
 
+proc testSpecBySlug =
+  suite "specBySlug":
+    let practiceExercises = @[
+      PracticeExercise(slug: Slug("binary-chop"),
+                       specification: some(Slug("binary-search"))),
+      PracticeExercise(slug: Slug("leap")),
+    ]
+    let m = specBySlug(practiceExercises)
+
+    test "contains only the exercises that set a `specification`":
+      check m.len == 1
+
+    test "maps a renamed slug to its problem-specifications slug":
+      check m.getOrDefault("binary-chop", "binary-chop") == "binary-search"
+
+    test "falls back to the slug for an exercise without `specification`":
+      check m.getOrDefault("leap", "leap") == "leap"
+
 proc main =
   testSyncCommon()
   testSyncFilepaths()
   testSyncMetadata()
+  testSpecBySlug()
 
 main()
 {.used.}


### PR DESCRIPTION
Tracks may need to assign a practice exercise a different slug than the one used in problem-specifications.

We introduce the optional `specification` key.

https://forum.exercism.org/t/factor-track-feedback/60226/19